### PR TITLE
feat: contribute and contact pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Check out the [Next.js and Supabase Starter Kit](https://github.com/supabase/sup
 
 ## Acknowledgments
 
+Check out our [Colophon](https://www.peels.app/colophon) page for the full list. Here are just a few:
+
 - Built with [Next.js](https://nextjs.org)
 - Authentication and database by [Supabase](https://supabase.com)
 - Maps powered by [MapTiler](https://www.maptiler.com) and [Protomaps](https://protomaps.com)

--- a/messages/en.json
+++ b/messages/en.json
@@ -114,6 +114,22 @@
   },
   "Contact": {
     "title": "Contact",
-    "subtitle": "Here’s how to reach the Peels team."
+    "subtitle": "Here’s how to reach the Peels team.",
+    "via": {
+      "therot": "Hello, reader of The Rot! Thanks for stopping by. Here’s a direct line to Danny.",
+      "general": "Hello there! Here are some email addresses you can contact us at."
+    },
+    "contactLabel": "If you want to",
+    "contactOptions": {
+      "general": "Make a general enquiry",
+      "support": "Get help with something",
+      "dw": "Talk to Danny",
+      "newsletter": "Talk about the newsletter"
+    },
+    "emailLabel": "You’re best off emailing",
+    "copyButton": {
+      "copied": "Copied!",
+      "copyAddress": "Copy address"
+    }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -68,7 +68,7 @@
   },
   "Support": {
     "title": "Support",
-    "subtitle": "We periodically update this page with answers to common questions. Feel free to <email>email us</email> for help with anything else.",
+    "subtitle": "We periodically update this page with answers to common questions. Feel free to <link>contact us</link> for anything else.",
     "peelsFaq": {
       "title": "About Peels",
       "whosBehind": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,5 +111,9 @@
         "answer": "<p>We only send emails that are necessary to keep Peels working. That includes one or two account-related emails, and emails to notify you whenever a fellow Peels member has sent you message.</p><p>Email notifications are required for listing hosts, as it means a prospective donor has enquired about dropping off scraps (or picking something up). Hosts who longer wish to receive emails can either hide their listing from the map (making it impossible for new donors to reach out) or delete their listing entirely (meaning previous donors can no longer message, either).</p><p>People without listings cannot be messaged (and thus emailed) unless they initiate contact with a host first.</p><p>Anyone can report or block individual Peels members via our messaging system. Blocking someone means they can no longer message or email you.</p>"
       }
     }
+  },
+  "Contact": {
+    "title": "Contact",
+    "subtitle": "Here’s how to reach the Peels team."
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
-import createNextIntlPlugin from 'next-intl/plugin';
+import createNextIntlPlugin from "next-intl/plugin";
 import { withPigment, extendTheme } from "@pigment-css/nextjs-plugin";
 import createMDX from "@next/mdx";
 
@@ -283,7 +283,7 @@ export default withPigment(withNextIntl(withMDX(nextConfig)), {
         maxWidth: {
           media: "720px", // Homepage content, newsletter issues
           text: "640px", // Markdown, Profile
-          aside: "512px" // NewsletterCallout
+          aside: "512px", // NewsletterCallout
         },
         textOpticalWidth: "36ch",
       },
@@ -322,9 +322,9 @@ export default withPigment(withNextIntl(withMDX(nextConfig)), {
       size: {
         p: {
           sm: "0.875rem", // 14px
-          md: "1rem", // 16px 
+          md: "1rem", // 16px
           lg: "1.125rem", // 18px
-        }
+        },
       },
       lineHeight: {
         h: "115%",
@@ -332,8 +332,8 @@ export default withPigment(withNextIntl(withMDX(nextConfig)), {
           sm: "145%",
           md: "155%",
           lg: "160%",
-        }
-      }
-    }
+        },
+      },
+    },
   }),
 });

--- a/src/app/(core)/(interact)/(centered)/profile/page.js
+++ b/src/app/(core)/(interact)/(centered)/profile/page.js
@@ -62,8 +62,6 @@ export default async function ProfilePage({ searchParams }) {
   );
 }
 
-
-
 const NakedSection = styled("section")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",

--- a/src/app/(core)/(interact)/(stretched)/map/page.js
+++ b/src/app/(core)/(interact)/(stretched)/map/page.js
@@ -15,10 +15,10 @@ async function getInitialData(listingSlug) {
   // Then get listing data if slug exists
   const listingResponse = listingSlug
     ? await supabase
-      .from(user ? "listings_private_data" : "listings_public_data")
-      .select()
-      .eq("slug", listingSlug)
-      .single()
+        .from(user ? "listings_private_data" : "listings_public_data")
+        .select()
+        .eq("slug", listingSlug)
+        .single()
     : null;
 
   return {
@@ -36,7 +36,7 @@ export async function generateMetadata({ searchParams }) {
       title: "Map",
       openGraph: {
         title: `Map · ${siteConfig.name}`,
-      }
+      },
     };
   }
 

--- a/src/app/(core)/(static)/(index)/page.js
+++ b/src/app/(core)/(static)/(index)/page.js
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { useTranslations } from 'next-intl';
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { siteConfig } from "@/config/site";
 import IntroHeader from "@/components/IntroHeader";
@@ -19,9 +19,8 @@ export const metadata = {
   },
 };
 
-
 export default function Index() {
-  const t = useTranslations('Index');
+  const t = useTranslations("Index");
 
   return (
     <StyledMain>
@@ -32,39 +31,47 @@ export default function Index() {
 
       <Intro>
         <IntroHeader />
-        <h1>{t('title')}</h1>
-        <p>{t('subtitle')}</p>
+        <h1>{t("title")}</h1>
+        <p>{t("subtitle")}</p>
 
         <HeroButtons />
       </Intro>
 
       <StaticPageSection padding="lg">
         <HeaderBlock>
-          <h2>{t('howItWorks.title')}</h2>
-          <p>{t('howItWorks.subtitle')}</p>
+          <h2>{t("howItWorks.title")}</h2>
+          <p>{t("howItWorks.subtitle")}</p>
         </HeaderBlock>
         <PeelsHowItWorks />
       </StaticPageSection>
 
       <StaticPageSection padding="lg" id="newsletter-section">
         <HeaderBlock>
-          <h2>{t('newsletter.title')}</h2>
-          <p>{t('newsletter.subtitle')}</p>
+          <h2>{t("newsletter.title")}</h2>
+          <p>{t("newsletter.subtitle")}</p>
         </HeaderBlock>
         <NewsletterIssuesList />
         <FooterBlock>
-          <p>{t.rich('newsletter.footer', { page: (chunks) => <Link href="/newsletter">{chunks}</Link> })}</p>
+          <p>
+            {t.rich("newsletter.footer", {
+              page: (chunks) => <Link href="/newsletter">{chunks}</Link>,
+            })}
+          </p>
         </FooterBlock>
       </StaticPageSection>
 
       <StaticPageSection padding="lg" id="faq-section">
         <HeaderBlock>
-          <h2>{t('faq.title')}</h2>
-          <p>{t('faq.subtitle')}</p>
+          <h2>{t("faq.title")}</h2>
+          <p>{t("faq.subtitle")}</p>
         </HeaderBlock>
         <PeelsFaq />
         <FooterBlock>
-          <p>{t.rich('faq.footer', { page: (chunks) => <Link href="/support">{chunks}</Link> })}</p>
+          <p>
+            {t.rich("faq.footer", {
+              page: (chunks) => <Link href="/support">{chunks}</Link>,
+            })}
+          </p>
         </FooterBlock>
       </StaticPageSection>
     </StyledMain>
@@ -121,6 +128,3 @@ const Intro = styled("div")(({ theme }) => ({
     },
   },
 }));
-
-
-

--- a/src/app/(core)/(static)/(legal)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/(legal)/[slug]/page.tsx
@@ -65,7 +65,7 @@ export default async function LegalPage({ params }: LegalPageProps) {
   return (
     // // Largely matches newsletter/(issues) page.tsx
     <StaticPageMain>
-      {/* Wrap header and main content in plain section so they visually hug */}
+      {/* Nest header and main content together so they visually hug */}
       <section>
         <StaticPageHeader title={pageTitle} subtitle={pageDescription} />
         <LongformTextContainer>

--- a/src/app/(core)/(static)/contact/page.js
+++ b/src/app/(core)/(static)/contact/page.js
@@ -1,0 +1,30 @@
+import { useTranslations } from "next-intl";
+import { siteConfig } from "@/config/site";
+import StaticPageMain from "@/components/StaticPageMain";
+import StaticPageHeader from "@/components/StaticPageHeader";
+import StaticPageSection from "@/components/StaticPageSection";
+
+import EmailSelector from "@/components/EmailSelector/EmailSelector";
+
+export const metadata = {
+  title: "Contact",
+  description: "Here’s how to reach the Peels team.",
+  openGraph: {
+    title: `Contact · ${siteConfig.name}`,
+    description: "Here’s how to reach the Peels team.",
+  },
+};
+
+export default function Contact() {
+  const t = useTranslations("Contact");
+
+  return (
+    <StaticPageMain>
+      <StaticPageHeader title={t("title")} subtitle={t("subtitle")} />
+
+      <StaticPageSection padding={null}>
+        <EmailSelector />
+      </StaticPageSection>
+    </StaticPageMain>
+  );
+}

--- a/src/app/(core)/(static)/contact/page.js
+++ b/src/app/(core)/(static)/contact/page.js
@@ -3,8 +3,8 @@ import { siteConfig } from "@/config/site";
 import StaticPageMain from "@/components/StaticPageMain";
 import StaticPageHeader from "@/components/StaticPageHeader";
 import StaticPageSection from "@/components/StaticPageSection";
-
 import EmailSelector from "@/components/EmailSelector/EmailSelector";
+import { styled } from "@pigment-css/react";
 
 export const metadata = {
   title: "Contact",
@@ -20,11 +20,20 @@ export default function Contact() {
 
   return (
     <StaticPageMain>
-      <StaticPageHeader title={t("title")} subtitle={t("subtitle")} />
-
-      <StaticPageSection padding={null}>
+      {/* Nest header and main content together so they visually hug */}
+      <HuggingContent>
+        <StaticPageHeader title={t("title")} subtitle={t("subtitle")} />
         <EmailSelector />
-      </StaticPageSection>
+      </HuggingContent>
     </StaticPageMain>
   );
 }
+
+const HuggingContent = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: theme.spacing.gap.section.md,
+  width: "100%",
+  maxWidth: theme.spacing.container.maxWidth.media,
+}));

--- a/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
@@ -67,7 +67,7 @@ export default async function NewsletterIssuePage({
   return (
     // Largely matches (legal) page.tsx, with some additions below the textual content
     <StaticPageMain>
-      {/* Wrap header and main content in plain section so they visually hug */}
+      {/* Nest header and main content together so they visually hug */}
       <section>
         <StaticPageHeader
           title={title}

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -6,43 +6,38 @@ import { siteConfig } from "@/config/site";
 export const dynamic = "force-static"; // Force as prerendered static content on build, not dynamic (otherwise issues don't populate)
 
 const feed = new Feed({
-    title: `${siteConfig.name}: Newsletter`, // Peels: Newsletter (matches layout.tsx)
-    description: siteConfig.newsletter.description,
-    id: `${siteConfig.url}/newsletter`,
-    link: `${siteConfig.url}/newsletter/feed.xml`,
-    favicon: `${siteConfig.url}/favicon.ico`,
-    language: "en",
-    copyright: `All rights reserved ${
-        new Date().getFullYear()
-    }, ${siteConfig.name}`,
+  title: `${siteConfig.name}: Newsletter`, // Peels: Newsletter (matches layout.tsx)
+  description: siteConfig.newsletter.description,
+  id: `${siteConfig.url}/newsletter`,
+  link: `${siteConfig.url}/newsletter/feed.xml`,
+  favicon: `${siteConfig.url}/favicon.ico`,
+  language: "en",
+  copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.name}`,
 });
 
 export async function GET() {
-    const newsletterIssues = await getAllNewsletterIssues();
+  const newsletterIssues = await getAllNewsletterIssues();
 
-    newsletterIssues.forEach((issue) => {
-        const issueLink = `${siteConfig.url}/newsletter/${issue.slug}`;
-        feed.addItem({
-            title: issue.metadata.title,
-            link: `${siteConfig.url}/newsletter/${issue.slug}`,
-            description: issue.metadata.description,
-            author: issue.metadata.authors.map((author) => ({
-                name: author,
-            })),
-            image:
-                `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/static/newsletter/${issue.customMetadata.issueNumber}/${issue.customMetadata.ogImage}`,
-            content: `${
-                issue.metadata.description
-                    ? `<p>${issue.metadata.description}</p>`
-                    : ""
-            }<p><a href="${issueLink}">Read this full issue on Peels</a></p>`,
-            date: new Date(issue.customMetadata.publishDate),
-        });
+  newsletterIssues.forEach((issue) => {
+    const issueLink = `${siteConfig.url}/newsletter/${issue.slug}`;
+    feed.addItem({
+      title: issue.metadata.title,
+      link: `${siteConfig.url}/newsletter/${issue.slug}`,
+      description: issue.metadata.description,
+      author: issue.metadata.authors.map((author) => ({
+        name: author,
+      })),
+      image: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/static/newsletter/${issue.customMetadata.issueNumber}/${issue.customMetadata.ogImage}`,
+      content: `${
+        issue.metadata.description ? `<p>${issue.metadata.description}</p>` : ""
+      }<p><a href="${issueLink}">Read this full issue on Peels</a></p>`,
+      date: new Date(issue.customMetadata.publishDate),
     });
+  });
 
-    return new Response(feed.rss2(), {
-        headers: {
-            "Content-Type": "application/rss+xml",
-        },
-    });
+  return new Response(feed.rss2(), {
+    headers: {
+      "Content-Type": "application/rss+xml",
+    },
+  });
 }

--- a/src/app/(core)/(static)/support/page.js
+++ b/src/app/(core)/(static)/support/page.js
@@ -1,9 +1,9 @@
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { siteConfig } from "@/config/site";
 import StaticPageMain from "@/components/StaticPageMain";
 import StaticPageHeader from "@/components/StaticPageHeader";
 import StaticPageSection from "@/components/StaticPageSection";
-import EncodedEmailLink from "@/components/EncodedEmailLink";
 import SupportFaq from "@/components/SupportFaq";
 import PeelsFaq from "@/components/PeelsFaq";
 import HeaderBlock from "@/components/HeaderBlock";
@@ -26,13 +26,10 @@ export default function Support() {
         subtitle={
           <>
             {t.rich("subtitle", {
-              email: (chunks) => (
-                <EncodedEmailLink
-                  as="plain"
-                  address={siteConfig.encodedEmail.support}
-                >
+              link: (chunks) => (
+                <Link href={`${siteConfig.links.contact}?address=support`}>
                   {chunks}
-                </EncodedEmailLink>
+                </Link>
               ),
             })}
           </>

--- a/src/app/(core)/(static)/support/page.js
+++ b/src/app/(core)/(static)/support/page.js
@@ -27,7 +27,10 @@ export default function Support() {
           <>
             {t.rich("subtitle", {
               email: (chunks) => (
-                <EncodedEmailLink as="plain" address={siteConfig.email.support}>
+                <EncodedEmailLink
+                  as="plain"
+                  address={siteConfig.encodedEmail.support}
+                >
                   {chunks}
                 </EncodedEmailLink>
               ),

--- a/src/app/(forms)/sign-up/page.tsx
+++ b/src/app/(forms)/sign-up/page.tsx
@@ -50,7 +50,7 @@ export default async function SignUp(props: {
             {t("SignUp.footer.neverGotEmail")}{" "}
             {/* TODO: Allow for verification email to be resent to {searchParams.email} after a countdown,
                 before this 'reach out'becomes an option. */}
-            <EncodedEmailLink address={siteConfig.email.support}>
+            <EncodedEmailLink address={siteConfig.encodedEmail.support}>
               {t("SignUp.footer.reachOut")}
             </EncodedEmailLink>{" "}
             {t("SignUp.footer.stillNeedHelp")}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -54,7 +54,7 @@ export const signUpAction = async (formData: FormData, request: Request) => {
   if (!email || !password || !first_name) {
     redirectUrl.searchParams.append(
       "error",
-      "A first name, email, and password are required.",
+      "A first name, email, and password are required."
     );
     return redirect(redirectUrl.toString());
   }
@@ -64,14 +64,14 @@ export const signUpAction = async (formData: FormData, request: Request) => {
     "check_if_email_exists",
     {
       email_to_check: email,
-    },
+    }
   );
 
   if (authError) {
     console.error("Error checking email:", authError);
     redirectUrl.searchParams.append(
       "error",
-      "Sorry, we couldn’t process your request.",
+      "Sorry, we couldn’t process your request."
     );
     return redirect(redirectUrl.toString());
   }
@@ -79,7 +79,7 @@ export const signUpAction = async (formData: FormData, request: Request) => {
   if (existingAuthUser) {
     redirectUrl.searchParams.append(
       "error",
-      "An account with this email already exists. Please sign in instead.",
+      "An account with this email already exists. Please sign in instead."
     );
     return redirect(redirectUrl.toString());
   }
@@ -116,17 +116,17 @@ export const signUpAction = async (formData: FormData, request: Request) => {
     if (isHookTimeout) {
       redirectUrl.searchParams.append(
         "error",
-        "Hmm, something’s not right. Mind trying again?",
+        "Hmm, something’s not right. Mind trying again?"
       );
       return redirect(redirectUrl.toString());
     }
     // Back to general error catching
     console.error(
-      error?.code + " " + error?.message || "No user returned from sign up",
+      error?.code + " " + error?.message || "No user returned from sign up"
     );
     redirectUrl.searchParams.append(
       "error",
-      error?.message || "Sign up failed",
+      error?.message || "Sign up failed"
     );
     return redirect(redirectUrl.toString());
   }
@@ -176,7 +176,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
     return encodedRedirect(
       "error",
       "/forgot-password",
-      "Hmm, something’s not right. Mind trying again?",
+      "Hmm, something’s not right. Mind trying again?"
     );
   }
 
@@ -187,7 +187,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
   return encodedRedirect(
     "success",
     "/forgot-password",
-    "Check your inbox (and spam) for a password reset link, assuming that email address is linked to a Peels account.",
+    "Check your inbox (and spam) for a password reset link, assuming that email address is linked to a Peels account."
   );
 };
 
@@ -300,7 +300,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/profile/reset-password",
-      "Both those fields are required.",
+      "Both those fields are required."
     );
   }
 
@@ -308,7 +308,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/profile/reset-password",
-      "Those passwords don’t match.",
+      "Those passwords don’t match."
     );
   }
 
@@ -320,14 +320,14 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/profile/reset-password",
-      "Hmm, something’s not right. You might not have permission to reset this password, or you tried reusing a recent password.",
+      "Hmm, something’s not right. You might not have permission to reset this password, or you tried reusing a recent password."
     );
   }
 
   encodedRedirect(
     "success",
     "/profile/reset-password",
-    "Your password has been updated. Let’s get back to composting!",
+    "Your password has been updated. Let’s get back to composting!"
   );
 };
 
@@ -358,7 +358,7 @@ export const deleteListingAction = async (slug: string) => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ slug }), // Send the slug in the request body
-      },
+      }
     );
 
     console.log("Response status:", response.status);
@@ -404,7 +404,7 @@ export const deleteAccountAction = async () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ user_id: user.id }),
-      },
+      }
     );
 
     console.log("Response status:", response.status);
@@ -413,8 +413,7 @@ export const deleteAccountAction = async () => {
     // const data = await response.json();
     // console.log("Response data:", data);
 
-    redirectPath =
-      `/sign-in?success=Your account has been deleted. Sorry to see you go.`;
+    redirectPath = `/sign-in?success=Your account has been deleted. Sorry to see you go.`;
 
     // if (!response.ok) {
     //   console.error("Delete account failed:", data);
@@ -438,7 +437,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 async function withRetry<T>(
   fn: () => Promise<T>,
   retries = 3,
-  backoff = 300,
+  backoff = 300
 ): Promise<T> {
   try {
     return await fn();
@@ -453,7 +452,7 @@ export async function fetchListingsInView(
   south: number,
   west: number,
   north: number,
-  east: number,
+  east: number
 ) {
   const supabase = await createClient();
 

--- a/src/app/contribute/page.js
+++ b/src/app/contribute/page.js
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+export default function Contribute() {
+  // No contribute page yet, but "www.peels.app/contribute" is used in a few places as a shorthand for the below
+  redirect(
+    "https://github.com/dnywh/peels?tab=readme-ov-file#contributing-to-peels"
+  );
+  // Could be a catch-all page for technical contributions, language support, and so on.
+  // See also the related FAQ
+}

--- a/src/components/ChatHeader/ChatHeader.jsx
+++ b/src/components/ChatHeader/ChatHeader.jsx
@@ -202,7 +202,7 @@ function ChatHeader({ thread, listing, user, isDrawer, isDemo }) {
               >
                 Sorry to hear you’re having trouble with {otherPersonName}.
                 Please{" "}
-                <EncodedEmailLink address={siteConfig.email.support}>
+                <EncodedEmailLink address={siteConfig.encodedEmail.support}>
                   contact us
                 </EncodedEmailLink>{" "}
                 to report the issue or to block them from contacting you any

--- a/src/components/DecodedSpan/DecodedSpan.jsx
+++ b/src/components/DecodedSpan/DecodedSpan.jsx
@@ -1,14 +1,7 @@
 "use client";
-import { useState, useEffect } from "react";
 
 function DecodedSpan({ children }) {
-  const [decodedEmail, setDecodedEmail] = useState("");
-
-  useEffect(() => {
-    const decoded = atob(children);
-    setDecodedEmail(decoded);
-  }, []);
-
+  const decodedEmail = atob(children);
   return <span>{decodedEmail}</span>;
 }
 

--- a/src/components/DecodedSpan/DecodedSpan.jsx
+++ b/src/components/DecodedSpan/DecodedSpan.jsx
@@ -1,0 +1,15 @@
+"use client";
+import { useState, useEffect } from "react";
+
+function DecodedSpan({ children }) {
+  const [decodedEmail, setDecodedEmail] = useState("");
+
+  useEffect(() => {
+    const decoded = atob(children);
+    setDecodedEmail(decoded);
+  }, []);
+
+  return <span>{decodedEmail}</span>;
+}
+
+export default DecodedSpan;

--- a/src/components/DecodedSpan/index.js
+++ b/src/components/DecodedSpan/index.js
@@ -1,0 +1,2 @@
+export * from "./DecodedSpan";
+export { default } from "./DecodedSpan";

--- a/src/components/EmailSelector/EmailSelector.jsx
+++ b/src/components/EmailSelector/EmailSelector.jsx
@@ -5,18 +5,17 @@ import { siteConfig } from "@/config/site";
 import EncodedEmailLink from "@/components/EncodedEmailLink";
 import DecodedSpan from "@/components/DecodedSpan";
 import Button from "@/components/Button";
-import HeaderBlock from "@/components/HeaderBlock";
 import Form from "@/components/Form";
 import Field from "@/components/Field";
 import Label from "@/components/Label";
-import Input from "@/components/Input";
 import Select from "@/components/Select";
-import InputHint from "@/components/InputHint";
 import PostageStamp from "@/components/PostageStamp";
 import { styled } from "@pigment-css/react";
+import { useTranslations } from "next-intl";
 
 export default function EmailSelector() {
   const searchParams = useSearchParams();
+  const t = useTranslations("Contact");
   // Via search param possible values
   // therot
   const via = searchParams.get("via");
@@ -65,31 +64,25 @@ export default function EmailSelector() {
     <FormSection>
       <PostageStamp />
       <SubSectionTop>
-        {via && (
-          <p>
-            {via === "therot"
-              ? "Hello, reader of The Rot! Thanks for stopping by. Here’s a direct line to Danny."
-              : "Hello there! Here are some email addresses you can contact us at."}
-          </p>
-        )}
+        {via && <p>{via === "therot" ? t("via.therot") : t("via.general")}</p>}
         <Field>
-          <Label htmlFor="contact">If you want to</Label>
+          <Label htmlFor="contact">{t("contactLabel")}</Label>
           <Select
             id="contact"
             value={selectedEmailType}
             onChange={(event) => setSelectedEmailType(event.target.value)}
             required={true}
           >
-            <option value="general">Make a general enquiry</option>
-            <option value="support">Get help with something</option>
-            <option value="dw">Talk to Danny</option>
-            <option value="newsletter">Talk about the newsletter</option>
+            <option value="general">{t("contactOptions.general")}</option>
+            <option value="support">{t("contactOptions.support")}</option>
+            <option value="dw">{t("contactOptions.dw")}</option>
+            <option value="newsletter">{t("contactOptions.newsletter")}</option>
           </Select>
         </Field>
       </SubSectionTop>
       <SubSectionBottom>
         <Field>
-          <Label>You’re best off emailing</Label>
+          <Label>{t("emailLabel")}</Label>
           <EncodedEmailLink
             address={siteConfig.encodedEmail[selectedEmailType]}
           >
@@ -99,7 +92,7 @@ export default function EmailSelector() {
           </EncodedEmailLink>
         </Field>
         <Button onClick={handleCopy}>
-          {isCopied ? "Copied!" : "Copy address"}
+          {isCopied ? t("copyButton.copied") : t("copyButton.copyAddress")}
         </Button>
       </SubSectionBottom>
     </FormSection>

--- a/src/components/EmailSelector/EmailSelector.jsx
+++ b/src/components/EmailSelector/EmailSelector.jsx
@@ -1,0 +1,114 @@
+"use client";
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { siteConfig } from "@/config/site";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+import DecodedSpan from "@/components/DecodedSpan";
+import Button from "@/components/Button";
+import HeaderBlock from "@/components/HeaderBlock";
+import Form from "@/components/Form";
+import Field from "@/components/Field";
+import Label from "@/components/Label";
+import Input from "@/components/Input";
+import Select from "@/components/Select";
+import InputHint from "@/components/InputHint";
+import PostageStamp from "@/components/PostageStamp";
+import { styled } from "@pigment-css/react";
+
+function EmailSelector() {
+  const searchParams = useSearchParams();
+  const [isContact, setIsContact] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(atob(siteConfig.encodedEmail.dw));
+    setIsCopied(true);
+  };
+  // Via search param possible values
+  // therot
+  const via = searchParams.get("via");
+
+  // Address search param possible values
+  // support
+  // dw
+  // general
+  // newsletter
+  const address = searchParams.get("address");
+
+  return (
+    <FormSection>
+      <PostageStamp />
+      <SubSectionTop>
+        {via && (
+          <p>
+            {via === "therot"
+              ? "Hello reader of The Rot! Thanks for stopping by. Here’s a direct line for Danny."
+              : "Hello there! Here are some email addresses you can contact us on."}
+          </p>
+        )}
+        <Field>
+          <Label htmlFor="contact">If you want to</Label>
+          <Select
+            id="contact"
+            value={isContact}
+            onChange={(event) => setIsContact(event.target.value === "true")}
+            required={true}
+          >
+            <option value="general">Make a general enquiry</option>
+            <option value="support">Get help with something</option>
+            <option value="dw">Talk to Danny</option>
+          </Select>
+        </Field>
+      </SubSectionTop>
+      <SubSectionBottom>
+        <Field>
+          <Label>You’re best off emailing</Label>
+          <EncodedEmailLink address={siteConfig.encodedEmail.dw}>
+            <DecodedSpan>{siteConfig.encodedEmail.dw}</DecodedSpan>
+          </EncodedEmailLink>
+        </Field>
+        <Button onClick={handleCopy}>
+          {isCopied ? "Copied!" : "Copy address"}
+        </Button>
+      </SubSectionBottom>
+    </FormSection>
+  );
+}
+
+export default EmailSelector;
+
+const FormSection = styled(Form)(({ theme }) => ({
+  width: "100%",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5rem",
+  backgroundColor: theme.colors.background.top,
+  border: `1px solid ${theme.colors.border.base}`,
+  borderRadius: theme.corners.base,
+  padding: `calc(${theme.spacing.unit} * 3) calc(${theme.spacing.unit} * 1.5) calc(${theme.spacing.unit} * 1.5)`, // + 1.5 units internally, for consistency with other sections that may or may not have hover padding internally
+  // For PostageStamp
+  overflow: "hidden",
+  position: "relative",
+}));
+
+const SubSectionTop = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5rem",
+  maxWidth: "300px",
+}));
+
+const SubSectionBottom = styled("div")(({ theme }) => ({
+  borderTop: `1px solid ${theme.colors.border.base}`,
+  paddingTop: "1.5rem",
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "flex-end",
+  justifyContent: "space-between",
+  gap: "1.5rem",
+
+  "& a": {
+    fontSize: "2rem",
+    fontWeight: "600",
+  },
+}));

--- a/src/components/EmailSelector/EmailSelector.jsx
+++ b/src/components/EmailSelector/EmailSelector.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { siteConfig } from "@/config/site";
 import EncodedEmailLink from "@/components/EncodedEmailLink";
@@ -15,25 +15,51 @@ import InputHint from "@/components/InputHint";
 import PostageStamp from "@/components/PostageStamp";
 import { styled } from "@pigment-css/react";
 
-function EmailSelector() {
+export default function EmailSelector() {
   const searchParams = useSearchParams();
-  const [isContact, setIsContact] = useState(false);
-  const [isCopied, setIsCopied] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(atob(siteConfig.encodedEmail.dw));
-    setIsCopied(true);
-  };
   // Via search param possible values
   // therot
   const via = searchParams.get("via");
 
   // Address search param possible values
-  // support
-  // dw
-  // general
-  // newsletter
   const address = searchParams.get("address");
+
+  // Map via parameters to their corresponding addresses
+  const viaToAddressMap = {
+    therot: "dw",
+    // Add more mappings as needed:
+    // podcast: "general",
+    // conference: "dw",
+  };
+
+  // Determine the address: via mapping takes precedence, then address param, then default
+  let finalAddress = "general";
+  if (via && viaToAddressMap[via]) {
+    finalAddress = viaToAddressMap[via];
+  } else if (address) {
+    finalAddress = address;
+  }
+
+  // Validate the final address against valid options
+  const validAddresses = ["support", "dw", "general", "newsletter"];
+  const validatedAddress = validAddresses.includes(finalAddress)
+    ? finalAddress
+    : "general";
+
+  const [selectedEmailType, setSelectedEmailType] = useState(validatedAddress);
+  const [isCopied, setIsCopied] = useState(false);
+
+  // Reset isCopied when selectedEmailType changes
+  useEffect(() => {
+    setIsCopied(false);
+  }, [selectedEmailType]);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(
+      atob(siteConfig.encodedEmail[selectedEmailType])
+    );
+    setIsCopied(true);
+  };
 
   return (
     <FormSection>
@@ -42,29 +68,34 @@ function EmailSelector() {
         {via && (
           <p>
             {via === "therot"
-              ? "Hello reader of The Rot! Thanks for stopping by. Here’s a direct line for Danny."
-              : "Hello there! Here are some email addresses you can contact us on."}
+              ? "Hello, reader of The Rot! Thanks for stopping by. Here’s a direct line to Danny."
+              : "Hello there! Here are some email addresses you can contact us at."}
           </p>
         )}
         <Field>
           <Label htmlFor="contact">If you want to</Label>
           <Select
             id="contact"
-            value={isContact}
-            onChange={(event) => setIsContact(event.target.value === "true")}
+            value={selectedEmailType}
+            onChange={(event) => setSelectedEmailType(event.target.value)}
             required={true}
           >
             <option value="general">Make a general enquiry</option>
             <option value="support">Get help with something</option>
             <option value="dw">Talk to Danny</option>
+            <option value="newsletter">Talk about the newsletter</option>
           </Select>
         </Field>
       </SubSectionTop>
       <SubSectionBottom>
         <Field>
           <Label>You’re best off emailing</Label>
-          <EncodedEmailLink address={siteConfig.encodedEmail.dw}>
-            <DecodedSpan>{siteConfig.encodedEmail.dw}</DecodedSpan>
+          <EncodedEmailLink
+            address={siteConfig.encodedEmail[selectedEmailType]}
+          >
+            <DecodedSpan>
+              {siteConfig.encodedEmail[selectedEmailType]}
+            </DecodedSpan>
           </EncodedEmailLink>
         </Field>
         <Button onClick={handleCopy}>
@@ -75,17 +106,14 @@ function EmailSelector() {
   );
 }
 
-export default EmailSelector;
-
 const FormSection = styled(Form)(({ theme }) => ({
-  width: "100%",
   display: "flex",
   flexDirection: "column",
-  gap: "1.5rem",
-  backgroundColor: theme.colors.background.top,
-  border: `1px solid ${theme.colors.border.base}`,
+  gap: "2.5rem",
+  padding: "2rem",
   borderRadius: theme.corners.base,
-  padding: `calc(${theme.spacing.unit} * 3) calc(${theme.spacing.unit} * 1.5) calc(${theme.spacing.unit} * 1.5)`, // + 1.5 units internally, for consistency with other sections that may or may not have hover padding internally
+  background: theme.colors.background.top,
+  border: `1px solid ${theme.colors.border.base}`,
   // For PostageStamp
   overflow: "hidden",
   position: "relative",
@@ -95,20 +123,34 @@ const SubSectionTop = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   gap: "1.5rem",
-  maxWidth: "300px",
+  // For PostageStamp
+  "& > p": {
+    marginRight: "8.5rem",
+    textWrap: "balance",
+  },
 }));
 
 const SubSectionBottom = styled("div")(({ theme }) => ({
-  borderTop: `1px solid ${theme.colors.border.base}`,
-  paddingTop: "1.5rem",
+  // borderTop: `1px solid ${theme.colors.border.base}`,
+  // paddingTop: "2.5rem", // Match gap on parent
   display: "flex",
-  flexDirection: "row",
-  alignItems: "flex-end",
-  justifyContent: "space-between",
-  gap: "1.5rem",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "1rem",
 
   "& a": {
-    fontSize: "2rem",
     fontWeight: "600",
+    fontSize: "1.5rem",
+  },
+
+  "@media (min-width: 768px)": {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    gap: "1.5rem",
+
+    "& a": {
+      fontSize: "1.75rem",
+    },
   },
 }));

--- a/src/components/EmailSelector/index.js
+++ b/src/components/EmailSelector/index.js
@@ -1,0 +1,2 @@
+export * from "./EmailSelector";
+export { default } from "./EmailSelector";

--- a/src/components/LegalFooter/LegalFooter.jsx
+++ b/src/components/LegalFooter/LegalFooter.jsx
@@ -5,6 +5,27 @@ import { styled } from "@pigment-css/react";
 
 const currentYear = new Date().getFullYear();
 
+export default function LegalFooter() {
+  return (
+    <StyledFooter>
+      <PeelsLogo color="quaternary" />
+      <p>
+        © {currentYear} {siteConfig.name}
+      </p>
+
+      <StyledNav>
+        <Link href={siteConfig.links.about}>About</Link>
+        <Link href={siteConfig.links.support}>Support</Link>
+        <Link href={siteConfig.links.newsletter}>Newsletter</Link>
+        {/* <Link href={siteConfig.links.colophon}>Colophon</Link> */}
+        <Link href={siteConfig.links.terms}>Terms</Link>
+        <Link href={siteConfig.links.privacy}>Privacy</Link>
+        <Link href={siteConfig.links.contact}>Contact</Link>
+      </StyledNav>
+    </StyledFooter>
+  );
+}
+
 const StyledFooter = styled("footer")(({ theme }) => ({
   marginTop: "5rem", // Fallback if prior sibling has no marginBottom defined
   display: "flex",
@@ -22,7 +43,7 @@ const StyledFooter = styled("footer")(({ theme }) => ({
 const StyledNav = styled("nav")(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
-  gap: "0.5rem 0.75rem",
+  gap: "0.75rem 1.25rem",
   alignItems: "center",
   justifyContent: "center",
   textAlign: "center",
@@ -42,27 +63,6 @@ const StyledNav = styled("nav")(({ theme }) => ({
 
   "@media (min-width: 768px)": {
     gap: "1.25rem",
+    padding: "0 3.5rem",
   },
 }));
-
-function LegalFooter() {
-  return (
-    <StyledFooter>
-      <PeelsLogo color="quaternary" />
-      <p>
-        © {currentYear} {siteConfig.name}
-      </p>
-
-      <StyledNav>
-        <Link href={siteConfig.links.about}>About</Link>
-        <Link href={siteConfig.links.support}>Support</Link>
-        <Link href={siteConfig.links.newsletter}>Newsletter</Link>
-        <Link href={siteConfig.links.colophon}>Colophon</Link>
-        <Link href={siteConfig.links.terms}>Terms</Link>
-        <Link href={siteConfig.links.privacy}>Privacy</Link>
-      </StyledNav>
-    </StyledFooter>
-  );
-}
-
-export default LegalFooter;

--- a/src/components/ListingCta/ListingCta.jsx
+++ b/src/components/ListingCta/ListingCta.jsx
@@ -64,7 +64,7 @@ function ListingCta({ viewer, slug, visibility = true, isStub = false }) {
           </p>
           <p>
             Are you the owner?{" "}
-            <EncodedEmailLink address={siteConfig.email.support}>
+            <EncodedEmailLink address={siteConfig.encodedEmail.support}>
               Reach out
             </EncodedEmailLink>{" "}
             to claim this listing or to request changes.

--- a/src/components/NewsletterCallout/NewsletterCallout.jsx
+++ b/src/components/NewsletterCallout/NewsletterCallout.jsx
@@ -92,6 +92,7 @@ const Callout = styled("div")(({ theme }) => ({
   borderRadius: theme.corners.base,
   background: theme.colors.background.top,
   border: `1px solid ${theme.colors.border.base}`,
+  // For PostageStamp
   overflow: "hidden",
   position: "relative",
 }));

--- a/src/components/PeelsFaq/PeelsFaq.jsx
+++ b/src/components/PeelsFaq/PeelsFaq.jsx
@@ -21,7 +21,7 @@ function PeelsFaq() {
           ),
           opensource: (chunks) => (
             <StrongLink
-              href={`${siteConfig.repoUrl}?tab=readme-ov-file#forking-peels`}
+              href={`${siteConfig.repoUrl}?tab=readme-ov-file`}
               target="_blank"
             >
               {chunks}
@@ -55,14 +55,14 @@ function PeelsFaq() {
           p: (chunks) => <p>{chunks}</p>,
           repo: (chunks) => (
             <StrongLink
-              href={`${siteConfig.repoUrl}?tab=readme-ov-file#forking-peels`}
+              href={`${siteConfig.repoUrl}?tab=readme-ov-file`}
               target="_blank"
             >
               {chunks}
             </StrongLink>
           ),
           email: (chunks) => (
-            <EncodedEmailLink address={siteConfig.email.support}>
+            <EncodedEmailLink address={siteConfig.encodedEmail.support}>
               {chunks}
             </EncodedEmailLink>
           ),
@@ -80,7 +80,7 @@ function PeelsFaq() {
             </StrongLink>
           ),
           email: (chunks) => (
-            <EncodedEmailLink address={siteConfig.email.support}>
+            <EncodedEmailLink address={siteConfig.encodedEmail.support}>
               {chunks}
             </EncodedEmailLink>
           ),
@@ -91,7 +91,7 @@ function PeelsFaq() {
         {t.rich("government.answer", {
           p: (chunks) => <p>{chunks}</p>,
           email: (chunks) => (
-            <EncodedEmailLink address={siteConfig.email.support}>
+            <EncodedEmailLink address={siteConfig.encodedEmail.support}>
               {chunks}
             </EncodedEmailLink>
           ),

--- a/src/components/PostageStamp/PostageStamp.jsx
+++ b/src/components/PostageStamp/PostageStamp.jsx
@@ -21,6 +21,6 @@ const StyledImage = styled(Image)(({ theme }) => ({
   position: "absolute",
   top: 0,
   right: 0,
-  opacity: 0.32,
+  opacity: 0.28,
   transform: "rotate(-16deg) translate(90px, -8px) scale(0.95)",
 }));

--- a/src/components/ProfileActions/ProfileActions.jsx
+++ b/src/components/ProfileActions/ProfileActions.jsx
@@ -58,7 +58,7 @@ export default function ProfileActions({ listings }) {
           cancelButtonText="Done"
         >
           We’re still working on this feature. In the meantime,{" "}
-          <EncodedEmailLink address={siteConfig.email.support}>
+          <EncodedEmailLink address={siteConfig.encodedEmail.support}>
             reach out
           </EncodedEmailLink>{" "}
           and ask us to export your data manually.

--- a/src/components/SignUpForm/SignUpForm.jsx
+++ b/src/components/SignUpForm/SignUpForm.jsx
@@ -107,7 +107,7 @@ export default function SignUpForm({ defaultValues = {}, error }) {
               <>
                 {error?.endsWith(".") ? error : `${error}.`} If you think this
                 might be wrong, please{" "}
-                <EncodedEmailLink address={siteConfig.email.support}>
+                <EncodedEmailLink address={siteConfig.encodedEmail.support}>
                   email us
                 </EncodedEmailLink>
                 .

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -12,7 +12,7 @@ export const siteConfig = {
     colophon: "/colophon",
     join: "/sign-up",
   },
-  email: {
+  encodedEmail: {
     support: "c3VwcG9ydEBwZWVscy5hcHA=",
     dw: "ZGFubnlAcGVlbHMuYXBw",
     general: "dGVhbUBwZWVscy5hcHA=",

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -9,6 +9,7 @@ export const siteConfig = {
     terms: "/terms",
     privacy: "/privacy",
     support: "/support",
+    contact: "/contact",
     colophon: "/colophon",
     join: "/sign-up",
   },

--- a/src/content/legal/colophon.mdx
+++ b/src/content/legal/colophon.mdx
@@ -9,13 +9,25 @@ export const metadata = {
 
 ## Technologies
 
-Peels is made possible thanks to the free and open source software described below. Check out our <StrongLink href={`${siteConfig.repoUrl}/blob/main/package.json`} target="_blank">GitHub repository</StrongLink> for a full list of open source technologies used.
+Peels is made possible thanks to the free and open source software described below. Check out our <StrongLink href={`${siteConfig.repoUrl}/blob/main/package.json`} target="\_blank">GitHub repository</StrongLink> for a full list of open source technologies used.
 
-We’ve made Peels similarly <StrongLink href={`${siteConfig.repoUrl}?tab=readme-ov-file#forking-peels`} target="_blank">open source</StrongLink> to pay it forward and perhaps inspire other circular economy projects.
+We’ve made Peels similarly <StrongLink href={`${siteConfig.repoUrl}?tab=readme-ov-file#forking-peels`} target="\_blank">open source</StrongLink> to pay it forward and perhaps inspire other circular economy projects.
 
 ### Maps
 
-<StrongLink href="http://protomaps.com" target="_blank">Protomaps</StrongLink> generously provides both the map tiles for Peels and a hosted API. We’re rendering those map tiles using <StrongLink href="https://visgl.github.io/react-map-gl/" target="_blank">React Map GL</StrongLink> and <StrongLink href="https://github.com/maplibre/maplibre-gl-js" target="_blank">Maplibre GL JS</StrongLink>.
+<StrongLink href="http://protomaps.com" target="_blank">
+  Protomaps
+</StrongLink>
+generously provides both the map tiles for Peels and a hosted API. We’re
+rendering those map tiles using
+<StrongLink href="https://visgl.github.io/react-map-gl/" target="_blank">
+  React Map GL
+</StrongLink>
+and
+<StrongLink href="https://github.com/maplibre/maplibre-gl-js" target="_blank">
+  Maplibre GL JS
+</StrongLink>
+.
 
 ### Front-end
 
@@ -23,11 +35,14 @@ Peels is built on the open source React framework <StrongLink href="http://proto
 
 ### Back-end
 
-<StrongLink href="http://supabase.com" target="_blank">Supabase</StrongLink> powers all things authentication, database, and storage for Peels.
+<StrongLink href="http://supabase.com" target="_blank">
+  Supabase
+</StrongLink>
+powers all things authentication, database, and storage for Peels.
 
 ### Components
 
-Peels relies on a few ‘headless’ React components under the hood, namely <StrongLink href="https://headlessui.com/" target="_blank">HeadlessUI</StrongLink> and <StrongLink href="https://www.radix-ui.com/primitives" target="_blank">Radix UI</StrongLink>. They provide a solid foundation for accessibility (and helped get us off the ground quickly). 
+Peels relies on a few ‘headless’ React components under the hood, namely <StrongLink href="https://headlessui.com/" target="_blank">HeadlessUI</StrongLink> and <StrongLink href="https://www.radix-ui.com/primitives" target="_blank">Radix UI</StrongLink>. They provide a solid foundation for accessibility (and helped get us off the ground quickly).
 
 We don’t really use any custom components beyond the aforementioned primitive, headless, ones. The one major exception is the map drawer, based on the <StrongLink href="https://vaul.emilkowal.ski/" target="_blank">Vaul</StrongLink> drawer component.
 
@@ -39,7 +54,7 @@ Some icons are derived from the <StrongLink href="https://lucide.dev/" target="_
 
 ## Concepts
 
-It’d be remiss of us not to mention prior work done by folks to pave the way for something like Peels to not only exist, but be instantly understood by regular people using it for the first time. 
+It’d be remiss of us not to mention prior work done by folks to pave the way for something like Peels to not only exist, but be instantly understood by regular people using it for the first time.
 
 ### ShareWaste
 
@@ -51,4 +66,8 @@ We take for granted how central mapping is to our everyday lives. Smart people d
 
 Peels is a beneficiary of this work. We all know what pins on a map means. We know what will likely happen when we tap one, and how to jump between pins or pan around the world.
 
-<StrongLink href="https://maphappenings.com" target="_blank">Map Happenings</StrongLink> does a great job describing the history of mapping platforms, in case you’d like to learn more.
+<StrongLink href="https://maphappenings.com" target="_blank">
+  Map Happenings
+</StrongLink>
+does a great job describing the history of mapping platforms, in case you’d like
+to learn more.

--- a/src/content/legal/privacy.mdx
+++ b/src/content/legal/privacy.mdx
@@ -85,7 +85,7 @@ You have the following rights regarding your personal data:
 5. **Portability**: Request your data in a portable format.
 6. **Objection**: Object to how we process your personal data in specific situations.
 
-Most of these rights can be exercised directly through your profile settings, where you can download a complete copy of your personal data, update your information, or delete your account. Please <EncodedEmailLink address={siteConfig.email.support}>contact us</EncodedEmailLink> for other requests or assistance. Identity verification may be required for certain requests.
+Most of these rights can be exercised directly through your profile settings, where you can download a complete copy of your personal data, update your information, or delete your account. Please <EncodedEmailLink address={siteConfig.encodedEmail.support}>contact us</EncodedEmailLink> for other requests or assistance. Identity verification may be required for certain requests.
 
 ## 5. How long we keep your data
 
@@ -106,4 +106,4 @@ We may update this privacy policy from time to time to reflect changes to our se
 
 ## 8. Contact
 
-Please <EncodedEmailLink address={siteConfig.email.support}>contact us</EncodedEmailLink> if you have questions or concerns about this privacy policy, or wish to exercise your rights.
+Please <EncodedEmailLink address={siteConfig.encodedEmail.support}>contact us</EncodedEmailLink> if you have questions or concerns about this privacy policy, or wish to exercise your rights.

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -83,7 +83,7 @@ You have the following rights regarding your personal data:
 5. **Right to data portability**: You can request that we provide your data in a portable format.
 6. **Right to object**: You can object to our use of your personal data in certain situations, including for direct marketing purposes.
 
-Most of these rights can be exercised directly through your profile settings, where you can download a complete copy of your personal data, update your information, or delete your account. Please <EncodedEmailLink address={siteConfig.email.support}>contact us</EncodedEmailLink> for other requests or assistance. Identity verification may be required for certain requests.
+Most of these rights can be exercised directly through your profile settings, where you can download a complete copy of your personal data, update your information, or delete your account. Please <EncodedEmailLink address={siteConfig.encodedEmail.support}>contact us</EncodedEmailLink> for other requests or assistance. Identity verification may be required for certain requests.
 
 Data may be transferred to or processed in countries outside your location (e.g., the United States) due to the services we use (e.g., Vercel). We ensure such transfers comply with applicable data protection laws.
 
@@ -99,7 +99,7 @@ We may update these Terms from time to time to reflect changes in our services, 
 
 ## 9. Complaints and reporting issues
 
-If you encounter a problem or need to report a violation of these Terms, please <EncodedEmailLink address={siteConfig.email.support}>contact us</EncodedEmailLink>. We will investigate and address issues in a timely manner but are not obligated to mediate disputes between users.
+If you encounter a problem or need to report a violation of these Terms, please <EncodedEmailLink address={siteConfig.encodedEmail.support}>contact us</EncodedEmailLink>. We will investigate and address issues in a timely manner but are not obligated to mediate disputes between users.
 
 ## 10. Account suspension and termination
 
@@ -115,4 +115,4 @@ These Terms are governed by the laws of Australia. By using Peels, you agree to 
 
 ## 12. Contact
 
-Please <EncodedEmailLink address={siteConfig.email.support}>contact us</EncodedEmailLink> if you have any questions about these Terms.
+Please <EncodedEmailLink address={siteConfig.encodedEmail.support}>contact us</EncodedEmailLink> if you have any questions about these Terms.

--- a/src/content/newsletter/celebrating-the-first-few-months.mdx
+++ b/src/content/newsletter/celebrating-the-first-few-months.mdx
@@ -146,7 +146,7 @@ Peels is growing but we can’t do it alone. We’re looking for fellow voluntee
 
 Many would-be compost donors and hosts simply haven’t heard about Peels. As a team of one (sometimes two), our outreach is limited.
 
-**Please <EncodedEmailLink address={siteConfig.email.dw}>reach out</EncodedEmailLink> if you or someone you know can help promote Peels in your local area**. Whether it’s to councils, waste educators, or local networks, any help is appreciated. Our <StrongLink href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/static/promo-kit.zip`}>promo kit</StrongLink> is also a good place to start.
+**Please <EncodedEmailLink address={siteConfig.encodedEmail.dw}>reach out</EncodedEmailLink> if you or someone you know can help promote Peels in your local area**. Whether it’s to councils, waste educators, or local networks, any help is appreciated. Our <StrongLink href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/static/promo-kit.zip`}>promo kit</StrongLink> is also a good place to start.
 
 ### Technical contributions
 

--- a/src/hooks/useNewsletterStatus.js
+++ b/src/hooks/useNewsletterStatus.js
@@ -1,80 +1,78 @@
-
 "use client";
 
 import { useEffect, useState } from "react";
 import { createClient } from "@/utils/supabase/client";
 
 export function useNewsletterStatus() {
-    const [status, setStatus] = useState({
-        isAuthenticated: false,
-        isNewsletterSubscribed: false,
-        error: null,
-        isLoading: true,
-    });
-    const supabase = createClient();
+  const [status, setStatus] = useState({
+    isAuthenticated: false,
+    isNewsletterSubscribed: false,
+    error: null,
+    isLoading: true,
+  });
+  const supabase = createClient();
 
-    useEffect(() => {
-        async function checkNewsletterStatus() {
-            try {
-                const {
-                    data: { user },
-                    error: userError,
-                } = await supabase.auth.getUser();
-
-                if (!user) {
-                    setStatus({
-                        isAuthenticated: false,
-                        isNewsletterSubscribed: false,
-                        error: null,
-                        isLoading: false,
-                    });
-                    return;
-                }
-
-                const { data: profile, error: profileError } = await supabase
-                    .from("profiles")
-                    .select()
-                    .eq("id", user.id)
-                    .single();
-
-                if (profileError) {
-                    console.error("Profile error:", profileError);
-                    setStatus({
-                        isAuthenticated: true,
-                        isNewsletterSubscribed: false,
-                        error: profileError,
-                        isLoading: false,
-                    });
-                    return;
-                }
-                setStatus({
-                    isAuthenticated: true,
-                    isNewsletterSubscribed: profile?.is_newsletter_subscribed || false,
-                    error: null,
-                    isLoading: false,
-                });
-            } catch (error) {
-                console.error("Unexpected error in NewsletterCallout:", error);
-                setStatus({
-                    isAuthenticated: false,
-                    isNewsletterSubscribed: false,
-                    error,
-                    isLoading: false,
-                });
-            }
-        }
-        checkNewsletterStatus();
-
-
-        // Optional: Subscribe to auth changes
+  useEffect(() => {
+    async function checkNewsletterStatus() {
+      try {
         const {
-            data: { subscription },
-        } = supabase.auth.onAuthStateChange(() => {
-            checkNewsletterStatus();
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          setStatus({
+            isAuthenticated: false,
+            isNewsletterSubscribed: false,
+            error: null,
+            isLoading: false,
+          });
+          return;
+        }
+
+        const { data: profile, error: profileError } = await supabase
+          .from("profiles")
+          .select()
+          .eq("id", user.id)
+          .single();
+
+        if (profileError) {
+          console.error("Profile error:", profileError);
+          setStatus({
+            isAuthenticated: true,
+            isNewsletterSubscribed: false,
+            error: profileError,
+            isLoading: false,
+          });
+          return;
+        }
+        setStatus({
+          isAuthenticated: true,
+          isNewsletterSubscribed: profile?.is_newsletter_subscribed || false,
+          error: null,
+          isLoading: false,
         });
+      } catch (error) {
+        console.error("Unexpected error in NewsletterCallout:", error);
+        setStatus({
+          isAuthenticated: false,
+          isNewsletterSubscribed: false,
+          error,
+          isLoading: false,
+        });
+      }
+    }
+    checkNewsletterStatus();
 
-        return () => subscription?.unsubscribe();
-    }, []);
+    // Optional: Subscribe to auth changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      checkNewsletterStatus();
+    });
 
-    return status;
+    return () => subscription?.unsubscribe();
+  }, []);
+
+  return status;
 }

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -3,20 +3,19 @@ import { getUserLocale } from "./services/locale";
 import deepmerge from "deepmerge";
 
 export default getRequestConfig(async () => {
-    // Provide a static locale, fetch a user setting,
-    // read from `cookies()`, `headers()`, etc.
-    // Handled in locale.ts
-    const locale = await getUserLocale();
-    // console.log({ locale });
+  // Provide a static locale, fetch a user setting,
+  // read from `cookies()`, `headers()`, etc.
+  // Handled in locale.ts
+  const locale = await getUserLocale();
+  // console.log({ locale });
 
-    // Fallback to English if another language is missing translations
-    const userMessages =
-        (await import(`../../messages/${locale}.json`)).default;
-    const defaultMessages = (await import(`../../messages/en.json`)).default;
-    const messages = deepmerge(defaultMessages, userMessages);
+  // Fallback to English if another language is missing translations
+  const userMessages = (await import(`../../messages/${locale}.json`)).default;
+  const defaultMessages = (await import(`../../messages/en.json`)).default;
+  const messages = deepmerge(defaultMessages, userMessages);
 
-    return {
-        locale,
-        messages,
-    };
+  return {
+    locale,
+    messages,
+  };
 });

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -8,38 +8,36 @@ import { defaultLocale, type Locale, locales } from "@/i18n/config";
 const COOKIE_NAME = "NEXT_LOCALE";
 
 export async function getUserLocale() {
-    const headersList = await headers();
-    const acceptLanguage = headersList.get("accept-language");
-    // console.log("[locale.ts] preferred-locale:", { acceptLanguage });
+  const headersList = await headers();
+  const acceptLanguage = headersList.get("accept-language");
+  // console.log("[locale.ts] preferred-locale:", { acceptLanguage });
 
-    // Try to get locale from cookie first
-    const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
-    if (cookieLocale) {
-        return cookieLocale;
+  // Try to get locale from cookie first
+  const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
+  if (cookieLocale) {
+    return cookieLocale;
+  }
+
+  // If no cookie, try to use browser preference
+  if (acceptLanguage) {
+    // Parse value. E.g. from:
+    // en-AU,en;q=0.9
+    // To:
+    // en
+    const firstLanguage = acceptLanguage.split(",")[0].split("-")[0] as Locale;
+    if (locales.includes(firstLanguage)) {
+      return firstLanguage;
     }
+    // crowdin.yml reflects this two_letters_code preference
+  }
 
-    // If no cookie, try to use browser preference
-    if (acceptLanguage) {
-        // Parse value. E.g. from:
-        // en-AU,en;q=0.9
-        // To:
-        // en
-        const firstLanguage = acceptLanguage.split(",")[0].split(
-            "-",
-        )[0] as Locale;
-        if (locales.includes(firstLanguage)) {
-            return firstLanguage;
-        }
-        // crowdin.yml reflects this two_letters_code preference
-    }
-
-    // Always return defaultLocale if no other locale is found
-    return defaultLocale;
+  // Always return defaultLocale if no other locale is found
+  return defaultLocale;
 }
 
 // Used in an explicit component, like a language picker:
 // https://next-intl.dev/examples#app-router-without-i18n-routing
 export async function setUserLocale(locale: Locale) {
-    console.log("Setting locale cookie:", locale);
-    (await cookies()).set(COOKIE_NAME, locale);
+  console.log("Setting locale cookie:", locale);
+  (await cookies()).set(COOKIE_NAME, locale);
 }

--- a/src/lib/content/handlers/legal.ts
+++ b/src/lib/content/handlers/legal.ts
@@ -1,41 +1,39 @@
 import { notFound } from "next/navigation";
 import type { LegalPageData } from "../types";
 import {
-    formatContentData,
-    validateBaseCustomMetadata,
-    validateBaseMetadata,
+  formatContentData,
+  validateBaseCustomMetadata,
+  validateBaseMetadata,
 } from "../utils";
 
 export async function getLegalPageMetadata(
-    slug: string,
+  slug: string
 ): Promise<LegalPageData> {
-    try {
-        const file = await import(`@/content/legal/${slug}.mdx`);
+  try {
+    const file = await import(`@/content/legal/${slug}.mdx`);
 
-        if (file?.metadata) {
-            validateBaseMetadata(file.metadata, slug);
+    if (file?.metadata) {
+      validateBaseMetadata(file.metadata, slug);
 
-            // Only validate customMetadata if it exists
-            if (file.customMetadata) {
-                validateBaseCustomMetadata(file.customMetadata, slug, [
-                    "updatedDate",
-                ]);
-            }
+      // Only validate customMetadata if it exists
+      if (file.customMetadata) {
+        validateBaseCustomMetadata(file.customMetadata, slug, ["updatedDate"]);
+      }
 
-            return formatContentData(
-                {
-                    slug,
-                    metadata: file.metadata,
-                    customMetadata: file.customMetadata,
-                },
-                "updatedDate",
-                false, // updatedDate is optional for legal pages
-            );
-        }
-
-        throw new Error(`Unable to find metadata for ${slug}.mdx`);
-    } catch (error: any) {
-        console.error(error?.message);
-        return notFound();
+      return formatContentData(
+        {
+          slug,
+          metadata: file.metadata,
+          customMetadata: file.customMetadata,
+        },
+        "updatedDate",
+        false // updatedDate is optional for legal pages
+      );
     }
+
+    throw new Error(`Unable to find metadata for ${slug}.mdx`);
+  } catch (error: any) {
+    console.error(error?.message);
+    return notFound();
+  }
 }

--- a/src/lib/content/handlers/newsletter.ts
+++ b/src/lib/content/handlers/newsletter.ts
@@ -1,49 +1,49 @@
 import { notFound } from "next/navigation";
 import type { NewsletterIssueData } from "../types";
 import {
-    formatContentData,
-    getAllContentSlugs,
-    validateNewsletterCustomMetadata,
-    validateNewsletterMetadata,
+  formatContentData,
+  getAllContentSlugs,
+  validateNewsletterCustomMetadata,
+  validateNewsletterMetadata,
 } from "../utils";
 
 export async function getNewsletterIssueMetadata(
-    slug: string,
+  slug: string
 ): Promise<NewsletterIssueData> {
-    try {
-        const file = await import(`@/content/newsletter/${slug}.mdx`);
+  try {
+    const file = await import(`@/content/newsletter/${slug}.mdx`);
 
-        if (file?.metadata && file?.customMetadata) {
-            validateNewsletterMetadata(file.metadata, slug);
-            validateNewsletterCustomMetadata(file.customMetadata, slug);
+    if (file?.metadata && file?.customMetadata) {
+      validateNewsletterMetadata(file.metadata, slug);
+      validateNewsletterCustomMetadata(file.customMetadata, slug);
 
-            return formatContentData(
-                {
-                    slug,
-                    metadata: file.metadata,
-                    customMetadata: file.customMetadata,
-                },
-                "publishDate",
-                true, // publishDate is required for legal pages
-            );
-        }
-
-        throw new Error(`Unable to find metadata for ${slug}.mdx`);
-    } catch (error: any) {
-        console.error(error?.message);
-        return notFound();
+      return formatContentData(
+        {
+          slug,
+          metadata: file.metadata,
+          customMetadata: file.customMetadata,
+        },
+        "publishDate",
+        true // publishDate is required for legal pages
+      );
     }
+
+    throw new Error(`Unable to find metadata for ${slug}.mdx`);
+  } catch (error: any) {
+    console.error(error?.message);
+    return notFound();
+  }
 }
 
 export async function getAllNewsletterIssues(): Promise<NewsletterIssueData[]> {
-    const slugs = await getAllContentSlugs("newsletter");
-    const issues = await Promise.all(
-        slugs.map((slug) => getNewsletterIssueMetadata(slug)),
-    );
+  const slugs = await getAllContentSlugs("newsletter");
+  const issues = await Promise.all(
+    slugs.map((slug) => getNewsletterIssueMetadata(slug))
+  );
 
-    return issues.sort(
-        (a, b) =>
-            +new Date(b.customMetadata.publishDate) -
-            +new Date(a.customMetadata.publishDate),
-    );
+  return issues.sort(
+    (a, b) =>
+      +new Date(b.customMetadata.publishDate) -
+      +new Date(a.customMetadata.publishDate)
+  );
 }

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -5,13 +5,13 @@ import type { Metadata } from "next/types";
 
 // Base metadata that all content types share
 export type BaseMetadata = Metadata & {
-    title: string;
-    description: string;
+  title: string;
+  description: string;
 };
 
 // Newsletter-specific metadata
 export type NewsletterMetadata = BaseMetadata & {
-    authors: Array<string>;
+  authors: Array<string>;
 };
 
 // Base custom metadata that all content types share
@@ -19,29 +19,29 @@ export type BaseCustomMetadata = Record<string, never>;
 
 // Newsletter-specific types
 export type NewsletterCustomMetadata = BaseCustomMetadata & {
-    issueNumber: number;
-    verboseTitle: string;
-    ogImage: string;
-    previewImages: Array<string>;
-    publishDate: string;
+  issueNumber: number;
+  verboseTitle: string;
+  ogImage: string;
+  previewImages: Array<string>;
+  publishDate: string;
 };
 
 export type NewsletterIssueData = {
-    slug: string;
-    metadata: NewsletterMetadata;
-    customMetadata: NewsletterCustomMetadata;
-    formattedDate: string;
+  slug: string;
+  metadata: NewsletterMetadata;
+  customMetadata: NewsletterCustomMetadata;
+  formattedDate: string;
 };
 
 // Legal-specific types
 export type LegalCustomMetadata = BaseCustomMetadata & {
-    verboseTitle?: string;
-    updatedDate?: string;
+  verboseTitle?: string;
+  updatedDate?: string;
 };
 
 export type LegalPageData = {
-    slug: string;
-    metadata: BaseMetadata;
-    customMetadata?: LegalCustomMetadata;
-    formattedDate?: string;
+  slug: string;
+  metadata: BaseMetadata;
+  customMetadata?: LegalCustomMetadata;
+  formattedDate?: string;
 };

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -9,106 +9,107 @@ import { formatPublishDate } from "@/utils/dateUtils";
 
 // Common file utilities
 export const isMDXFile = (dirent: Dirent) =>
-    !dirent.isDirectory() && dirent.name.endsWith(".mdx");
+  !dirent.isDirectory() && dirent.name.endsWith(".mdx");
 
 export const getSlugFromFilename = (dirent: Dirent) =>
-    dirent.name.substring(0, dirent.name.lastIndexOf("."));
+  dirent.name.substring(0, dirent.name.lastIndexOf("."));
 
 // Common content loading utilities
 export async function getAllContentSlugs(
-    contentType: "newsletter" | "legal",
+  contentType: "newsletter" | "legal"
 ): Promise<string[]> {
-    try {
-        // Get the absolute path to the project root to avoid potential problems with build processes across deployments
-        const contentPath = join(process.cwd(), "src", "content", contentType);
-        const dirents = await readdir(contentPath, {
-            withFileTypes: true,
-        });
+  try {
+    // Get the absolute path to the project root to avoid potential problems with build processes across deployments
+    const contentPath = join(process.cwd(), "src", "content", contentType);
+    const dirents = await readdir(contentPath, {
+      withFileTypes: true,
+    });
 
-        return dirents.filter(isMDXFile).map(getSlugFromFilename);
-    } catch (error) {
-        console.error(`Error reading ${contentType} content:`, error);
-        return [];
-    }
+    return dirents.filter(isMDXFile).map(getSlugFromFilename);
+  } catch (error) {
+    console.error(`Error reading ${contentType} content:`, error);
+    return [];
+  }
 }
 
 // Common metadata validation
 export function validateBaseMetadata(metadata: any, slug: string) {
-    if (!metadata?.title || !metadata?.description) {
-        throw new Error(`Missing some required metadata fields in: ${slug}`);
-    }
+  if (!metadata?.title || !metadata?.description) {
+    throw new Error(`Missing some required metadata fields in: ${slug}`);
+  }
 }
 
 export function validateNewsletterMetadata(metadata: any, slug: string) {
-    validateBaseMetadata(metadata, slug);
-    if (!metadata?.authors || !Array.isArray(metadata.authors)) {
-        throw new Error(`Missing or invalid authors field in: ${slug}`);
-    }
+  validateBaseMetadata(metadata, slug);
+  if (!metadata?.authors || !Array.isArray(metadata.authors)) {
+    throw new Error(`Missing or invalid authors field in: ${slug}`);
+  }
 }
 
 export function validateNewsletterCustomMetadata(
-    customMetadata: any,
-    slug: string,
+  customMetadata: any,
+  slug: string
 ) {
-    if (
-        !customMetadata?.issueNumber ||
-        !customMetadata?.publishDate ||
-        (customMetadata.previewImages &&
-            !Array.isArray(customMetadata.previewImages))
-    ) {
-        throw new Error(
-            `Missing required newsletter custom metadata fields in: ${slug}`,
-        );
-    }
+  if (
+    !customMetadata?.issueNumber ||
+    !customMetadata?.publishDate ||
+    (customMetadata.previewImages &&
+      !Array.isArray(customMetadata.previewImages))
+  ) {
+    throw new Error(
+      `Missing required newsletter custom metadata fields in: ${slug}`
+    );
+  }
 }
 
 export function validateBaseCustomMetadata(
-    customMetadata: any,
-    slug: string,
-    requiredFields: string[] = [],
+  customMetadata: any,
+  slug: string,
+  requiredFields: string[] = []
 ) {
-    if (!customMetadata) return; // Allow for no custom metadata
+  if (!customMetadata) return; // Allow for no custom metadata
 
-    for (const field of requiredFields) {
-        if (!customMetadata[field]) {
-            throw new Error(
-                `Missing required custom metadata field, ${field}, in: ${slug}`,
-            );
-        }
+  for (const field of requiredFields) {
+    if (!customMetadata[field]) {
+      throw new Error(
+        `Missing required custom metadata field, ${field}, in: ${slug}`
+      );
     }
+  }
 }
 
 // Common data formatting
 export function formatContentData<
-    T extends {
-        metadata: { title: string; description: string };
-        customMetadata?: { [key: string]: string };
-    },
+  T extends {
+    metadata: { title: string; description: string };
+    customMetadata?: { [key: string]: string };
+  },
 >(
-    data: T,
-    dateField: string = "publishDate",
-    isDateRequired: boolean = true,
-): T & { formattedDate: string } { // Always return string for formattedDate
-    if (!data.customMetadata?.[dateField]) {
-        if (isDateRequired) {
-            throw new Error(`Missing required date field: ${dateField}`);
-        }
-        return {
-            ...data,
-            formattedDate: "", // Return empty string instead of undefined
-        };
+  data: T,
+  dateField: string = "publishDate",
+  isDateRequired: boolean = true
+): T & { formattedDate: string } {
+  // Always return string for formattedDate
+  if (!data.customMetadata?.[dateField]) {
+    if (isDateRequired) {
+      throw new Error(`Missing required date field: ${dateField}`);
     }
-
-    // Add OpenGraph metadata
-    const metadata = {
-        ...data,
-        formattedDate: formatPublishDate(data.customMetadata[dateField]),
-        openGraph: {
-            title: data.metadata.title,
-            description: data.metadata.description,
-            type: "article", // Assuming 'article' since these are all longform text pages
-        },
+    return {
+      ...data,
+      formattedDate: "", // Return empty string instead of undefined
     };
+  }
 
-    return metadata;
+  // Add OpenGraph metadata
+  const metadata = {
+    ...data,
+    formattedDate: formatPublishDate(data.customMetadata[dateField]),
+    openGraph: {
+      title: data.metadata.title,
+      description: data.metadata.description,
+      type: "article", // Assuming 'article' since these are all longform text pages
+    },
+  };
+
+  return metadata;
 }

--- a/src/styles/commonStyles.js
+++ b/src/styles/commonStyles.js
@@ -3,25 +3,24 @@
 
 // Common text block styling on static pages like the index, newsletter
 export const sharedSectionTextBlockStyles = ({ theme }) => ({
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: theme.spacing.gap.sectionInner,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: theme.spacing.gap.sectionInner,
 
-    "& > *": {
-        textAlign: "center",
-        textWrap: "balance",
-    },
+  "& > *": {
+    textAlign: "center",
+    textWrap: "balance",
+  },
 });
 
-
-// For use when anchor tags simply inherit the styling of the parent container 
+// For use when anchor tags simply inherit the styling of the parent container
 // I.e. don't stand out until hovered
 export const sharedAnchorTagStyles = ({ theme }) => ({
-    color: "inherit",
-    transition: theme.transitions.textColor,
-    "&:hover": {
-        color: theme.colors.text.primary,
-    },
-})
+  color: "inherit",
+  transition: theme.transitions.textColor,
+  "&:hover": {
+    color: theme.colors.text.primary,
+  },
+});

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,35 +1,28 @@
 // Utils to help format dates in chat threads/messages and static pages (legal pages, newsletters)
 
 // const locale = "en-AU"
-const locale = navigator.language // vary formatting according to local customs (TODO: does Next do this as it (pre)renders on the server, thus locking it in to en-US? Perhaps make client-side)
+const locale = navigator.language; // vary formatting according to local customs (TODO: does Next do this as it (pre)renders on the server, thus locking it in to en-US? Perhaps make client-side)
 
 // Static page date utils
 export function formatPublishDate(dateString) {
   // Formal dates, with no awarness of proximity
   // I.e. no 'yesterday' or 'today' like in chat messages
   // E.g. June 3, 2025
-  return new Date(
-    dateString,
-  ).toLocaleDateString(
-    locale,
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
-  );
+  return new Date(dateString).toLocaleDateString(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }
 
 // Chat message utils
 // Return just the time
 export function formatTimestamp(dateString) {
-  return new Intl.DateTimeFormat(
-    locale,
-    {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: true,
-    }).format(new Date(dateString));
+  return new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(new Date(dateString));
 }
 
 // Return a conditional string based on the date:

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -24,6 +24,6 @@ export const createClient = async () => {
           }
         },
       },
-    },
+    }
   );
 };

--- a/supabase/functions/send-email-for-auth-action/index.ts
+++ b/supabase/functions/send-email-for-auth-action/index.ts
@@ -84,7 +84,7 @@ Deno.serve(async (req) => {
           token_hash,
           redirect_to,
           email_action_type,
-        }),
+        })
       );
       text = await renderAsync(
         React.createElement(ResetPasswordEmail, {
@@ -93,7 +93,7 @@ Deno.serve(async (req) => {
           redirect_to,
           email_action_type,
         }),
-        { plainText: true },
+        { plainText: true }
       );
     } else if (email_action_type === "signup") {
       // Sent to new users after sign up, before they can do anything else
@@ -114,13 +114,13 @@ Deno.serve(async (req) => {
           token_hash,
           redirect_to,
           email_action_type,
-        }),
+        })
       );
       // Timeout debugging
       console.log(
         "[signup] After renderAsync HTML",
         Date.now() - timingStart,
-        "ms",
+        "ms"
       );
 
       text = await renderAsync(
@@ -132,13 +132,13 @@ Deno.serve(async (req) => {
           redirect_to,
           email_action_type,
         }),
-        { plainText: true },
+        { plainText: true }
       );
       // Timeout debugging
       console.log(
         "[signup] After renderAsync TEXT",
         Date.now() - timingStart,
-        "ms",
+        "ms"
       );
 
       // Timeout debugging
@@ -146,7 +146,7 @@ Deno.serve(async (req) => {
       console.log(
         "[signup] Before Resend send",
         resendStart - timingStart,
-        "ms since start",
+        "ms since start"
       );
     } else if (email_action_type === "email_change") {
       // Sent to existing users who change their email address
@@ -162,7 +162,7 @@ Deno.serve(async (req) => {
           token_hash,
           redirect_to,
           email_action_type,
-        }),
+        })
       );
       text = await renderAsync(
         React.createElement(EmailChangeEmail, {
@@ -172,7 +172,7 @@ Deno.serve(async (req) => {
           redirect_to,
           email_action_type,
         }),
-        { plainText: true },
+        { plainText: true }
       );
     } else if (email_action_type === "magiclink") {
       // Passwordless login via email for the user
@@ -187,7 +187,7 @@ Deno.serve(async (req) => {
           token_hash,
           redirect_to,
           email_action_type,
-        }),
+        })
       );
       text = await renderAsync(
         React.createElement(MagicLinkEmail, {
@@ -196,7 +196,7 @@ Deno.serve(async (req) => {
           redirect_to,
           email_action_type,
         }),
-        { plainText: true },
+        { plainText: true }
       );
     } else if (email_action_type === "invite") {
       // Invite a new user
@@ -211,7 +211,7 @@ Deno.serve(async (req) => {
           token_hash,
           redirect_to,
           email_action_type,
-        }),
+        })
       );
       text = await renderAsync(
         React.createElement(InviteEmail, {
@@ -220,7 +220,7 @@ Deno.serve(async (req) => {
           redirect_to,
           email_action_type,
         }),
-        { plainText: true },
+        { plainText: true }
       );
     } else if (email_action_type === "reauthentication") {
       // OTP code
@@ -230,13 +230,13 @@ Deno.serve(async (req) => {
       html = await renderAsync(
         React.createElement(ReauthenticationEmail, {
           token,
-        }),
+        })
       );
       text = await renderAsync(
         React.createElement(ReauthenticationEmail, {
           token,
         }),
-        { plainText: true },
+        { plainText: true }
       );
     } else {
       // This error likely reached if an email_action_type has not been defined above
@@ -246,7 +246,7 @@ Deno.serve(async (req) => {
       // My guess: "email_change_new" is the currently-disabled requirement to have the *old* email addresses confirmed (in addition to confirming only via the new one in "email_change")
       // My guess: "email" is EmailOTPVerification, perhaps used when 2FA is enabled, as an additional OTP step to signing in
       throw new Error(
-        `Email action type "${email_action_type}" has not yet been implemented`,
+        `Email action type "${email_action_type}" has not yet been implemented`
       );
     }
 
@@ -256,7 +256,7 @@ Deno.serve(async (req) => {
     console.log(
       "[global] Before resend.emails.send",
       resendSendStart - timingStart,
-      "ms since function start",
+      "ms since function start"
     );
     const { error } = await resend.emails.send({
       from: `Peels <${generalEmailAddress}>`,
@@ -270,7 +270,7 @@ Deno.serve(async (req) => {
     console.log(
       "[global] After resend.emails.send",
       resendSendEnd - resendSendStart,
-      "ms for Resend send",
+      "ms for Resend send"
     );
     if (error) {
       throw error;
@@ -287,7 +287,7 @@ Deno.serve(async (req) => {
       {
         status: 401,
         headers: { "Content-Type": "application/json" },
-      },
+      }
     );
   }
 

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -62,19 +62,20 @@ const handler = async (_request: Request): Promise<Response> => {
     console.log("Listing area name:", listingAreaName);
 
     // Determine recipient_id (the user who isn't the sender)
-    const recipientId = messageData.thread.initiator_id === record.sender_id
-      ? messageData.thread.owner_id
-      : messageData.thread.initiator_id;
+    const recipientId =
+      messageData.thread.initiator_id === record.sender_id
+        ? messageData.thread.owner_id
+        : messageData.thread.initiator_id;
 
     // Determine recipient's role in the chat (listing owner (host) or the thread initiator (donor)?)
     // This ternary seems opposite to what's logical, but it is correct somehow
-    const recipientRole = messageData.thread.owner_id === record.sender_id
-      ? "initiator"
-      : "owner";
+    const recipientRole =
+      messageData.thread.owner_id === record.sender_id ? "initiator" : "owner";
 
-    const recipientName = messageData.thread.owner_id === record.sender_id
-      ? messageData.thread.initiator_first_name
-      : messageData.thread.owner_first_name;
+    const recipientName =
+      messageData.thread.owner_id === record.sender_id
+        ? messageData.thread.initiator_first_name
+        : messageData.thread.owner_first_name;
 
     // Determine which avatar(s) to show to the recipient
     let avatarMajorUrl: string | null = null;
@@ -97,7 +98,7 @@ const handler = async (_request: Request): Promise<Response> => {
         avatarMinorUrl = null; // No secondary avatar needed
         console.log(
           "Recipient is initiator (residential). Showing sender avatar:",
-          senderAvatar,
+          senderAvatar
         );
       } else {
         // For non-residential listings, show the listing's avatar as primary
@@ -109,7 +110,7 @@ const handler = async (_request: Request): Promise<Response> => {
           "Recipient is initiator (non-residential). Showing listing avatar:",
           listingAvatar,
           "and sender avatar:",
-          senderAvatar,
+          senderAvatar
         );
       }
     }
@@ -121,8 +122,8 @@ const handler = async (_request: Request): Promise<Response> => {
 
     // Do auth admin query to get recipient email (keeping this pattern for security)
     // TODO: Minify this query to just ask for the email address
-    const { data: recipientData, error: recipientError } = await supabase.auth
-      .admin.getUserById(recipientId);
+    const { data: recipientData, error: recipientError } =
+      await supabase.auth.admin.getUserById(recipientId);
     console.log("Recipient data:", recipientData);
     if (recipientError) console.log("Recipient error:", recipientError);
 
@@ -166,7 +167,7 @@ const handler = async (_request: Request): Promise<Response> => {
           avatarMajorBucket,
           avatarMinorUrl,
         }),
-        { plainText: true },
+        { plainText: true }
       ),
     });
 

--- a/supabase/functions/send-email-for-new-feature/index.ts
+++ b/supabase/functions/send-email-for-new-feature/index.ts
@@ -40,13 +40,13 @@ const handler = async (_request: Request): Promise<Response> => {
     for (const profile of profiles) {
       try {
         // Get user email from auth
-        const { data: userData, error: userError } = await supabase.auth.admin
-          .getUserById(profile.id);
+        const { data: userData, error: userError } =
+          await supabase.auth.admin.getUserById(profile.id);
 
         if (userError) {
           console.error(
             `Failed to fetch user data for ${profile.id}:`,
-            userError,
+            userError
           );
           results.push({
             userId: profile.id,
@@ -92,7 +92,7 @@ const handler = async (_request: Request): Promise<Response> => {
             }),
             {
               plainText: true,
-            },
+            }
           ),
           headers: {
             "List-Unsubscribe": "<https://www.peels.app/profile>",
@@ -120,7 +120,7 @@ const handler = async (_request: Request): Promise<Response> => {
         if (updateError) {
           console.error(
             `Failed to update flag for ${profile.id}:`,
-            updateError,
+            updateError
           );
           results.push({
             userId: profile.id,
@@ -154,7 +154,7 @@ const handler = async (_request: Request): Promise<Response> => {
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      },
+      }
     );
   } catch (error) {
     console.error("Error:", error);

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -21,8 +21,8 @@ const handler = async (_request: Request): Promise<Response> => {
 
     console.log("Creating broadcast for Resend audience...");
 
-    const { data: broadcast, error: broadcastError } = await resend.broadcasts
-      .create({
+    const { data: broadcast, error: broadcastError } =
+      await resend.broadcasts.create({
         audienceId: newsletterAudienceId,
         from: `Danny from Peels <${newsletterEmailAddress}>`,
         subject: "Our first few months of Peels",
@@ -35,7 +35,7 @@ const handler = async (_request: Request): Promise<Response> => {
             recipientName: "there",
             externalAudience: true,
           }),
-          { plainText: true },
+          { plainText: true }
         ),
         headers: {
           "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
@@ -50,7 +50,7 @@ const handler = async (_request: Request): Promise<Response> => {
     console.log("Broadcast created, sending...");
 
     const { data: sendData, error: sendError } = await resend.broadcasts.send(
-      broadcast.id,
+      broadcast.id
     );
 
     if (sendError) {
@@ -65,7 +65,7 @@ const handler = async (_request: Request): Promise<Response> => {
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      },
+      }
     );
   } catch (error) {
     console.error("Error:", error);
@@ -77,7 +77,7 @@ const handler = async (_request: Request): Promise<Response> => {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      },
+      }
     );
   }
 };

--- a/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
@@ -44,13 +44,13 @@ const handler = async (_request: Request): Promise<Response> => {
     for (const profile of profiles) {
       try {
         // Get user email from auth
-        const { data: userData, error: userError } = await supabase.auth.admin
-          .getUserById(profile.id);
+        const { data: userData, error: userError } =
+          await supabase.auth.admin.getUserById(profile.id);
 
         if (userError) {
           console.error(
             `Failed to fetch user data for ${profile.id}:`,
-            userError,
+            userError
           );
           results.push({
             userId: profile.id,
@@ -98,7 +98,7 @@ const handler = async (_request: Request): Promise<Response> => {
             }),
             {
               plainText: true,
-            },
+            }
           ),
           headers: {
             "List-Unsubscribe": "<https://www.peels.app/profile>",
@@ -126,7 +126,7 @@ const handler = async (_request: Request): Promise<Response> => {
         if (updateError) {
           console.error(
             `Failed to update flag for ${profile.id}:`,
-            updateError,
+            updateError
           );
           results.push({
             userId: profile.id,
@@ -160,7 +160,7 @@ const handler = async (_request: Request): Promise<Response> => {
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      },
+      }
     );
   } catch (error) {
     console.error("Error:", error);


### PR DESCRIPTION
This brings in the following new pages:

- **/contact:** for cases where we’d like to dynamically render an email address in a place that, if plain text, would expose it to spammers (e.g. in a newsletter like [The Rot](https://therot.substack.com)).
- **/contribute:** for a future fleshed-out contributor page. Right now it just redirects to the contribution instructions on this repo’s README file.

/contact has been set up for translations.