### PR TITLE
drop duplicate listing coordinates

### DIFF
--- a/src/app/(forms)/profile/listings/[slug]/page.js
+++ b/src/app/(forms)/profile/listings/[slug]/page.js
@@ -43,7 +43,7 @@ export default async function EditListingPage({ params }) {
     .single();
 
   const { data: listing } = await supabase
-    .from("listings")
+    .from("listings_private_data")
     .select()
     .eq("owner_id", user.id)
     .match({ slug })

--- a/src/components/ListingRead/ListingRead.jsx
+++ b/src/components/ListingRead/ListingRead.jsx
@@ -77,6 +77,7 @@ const ListingRead = memo(function Listing({
         ? listing.name
         : listing.owner_first_name
       : getListingDisplayName(listing, user);
+  const coordinates = listing?.coordinates;
 
   if (!listing && presentation !== "demo") {
     console.log("Listing not found");
@@ -158,15 +159,15 @@ const ListingRead = memo(function Listing({
               <MapThumbnail
                 height="320px"
                 initialViewState={{
-                  longitude: listing.longitude,
-                  latitude: listing.latitude,
+                  longitude: coordinates.longitude,
+                  latitude: coordinates.latitude,
                   zoom: initialZoomLevel,
                 }}
                 interactive={false}
               >
                 <Marker
-                  longitude={listing.longitude}
-                  latitude={listing.latitude}
+                  longitude={coordinates.longitude}
+                  latitude={coordinates.latitude}
                   anchor="center"
                   onClick={(event) => {
                     event.originalEvent.stopPropagation();
@@ -216,7 +217,7 @@ const ListingRead = memo(function Listing({
                       <Button
                         variant="secondary"
                         size="small"
-                        href={`https://maps.apple.com/?ll=${listing.latitude},${listing.longitude}&q=${encodeURIComponent(
+                        href={`https://maps.apple.com/?ll=${coordinates.latitude},${coordinates.longitude}&q=${encodeURIComponent(
                           listing.name
                         )}`}
                         target="_blank"
@@ -226,7 +227,7 @@ const ListingRead = memo(function Listing({
                       <Button
                         variant="secondary"
                         size="small"
-                        href={`https://maps.google.com/?q=${listing.latitude},${listing.longitude}`}
+                        href={`https://maps.google.com/?q=${coordinates.latitude},${coordinates.longitude}`}
                         target="_blank"
                       >
                         {t("Actions.openInGoogleMaps")}

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -114,12 +114,7 @@ export default function ListingWrite({
   );
 
   const [coordinates, setCoordinates] = useState<Coordinates | null>(
-    initialListing
-      ? {
-          latitude: initialListing.latitude,
-          longitude: initialListing.longitude,
-        }
-      : null
+    initialListing?.coordinates ?? null
   );
 
   const [areaName, setAreaName] = useState<string>(
@@ -264,10 +259,6 @@ export default function ListingWrite({
         ...(listingType !== "residential" && { name: validatedName }),
         description,
         location: `POINT(${selectedCoordinates.longitude} ${selectedCoordinates.latitude})`,
-        // Temporarily store the coordinates as longitude and latitude floats in the database as well
-        // ...because I can't get the geometry type to convert to to long and lat dynamically if a user goes direct to a listing, e.g. http://localhost:3000/map?listing=9xvN9zxH0rzZ
-        longitude: selectedCoordinates.longitude,
-        latitude: selectedCoordinates.latitude,
         area_name: areaName,
         country_code: countryCode,
         accepted_items: acceptedItems.filter((item) => item.trim() !== ""),

--- a/src/components/MapImmersive/MapImmersive.jsx
+++ b/src/components/MapImmersive/MapImmersive.jsx
@@ -53,14 +53,20 @@ const DEFAULT_COORDINATES = {
   zoom: 9,
 };
 
+function getListingCoordinates(listing) {
+  return listing?.coordinates ?? null;
+}
+
 function hasValidCoordinates(listing) {
+  const coordinates = getListingCoordinates(listing);
+
   return (
     listing &&
     !listing.error &&
-    typeof listing.latitude === "number" &&
-    typeof listing.longitude === "number" &&
-    Number.isFinite(listing.latitude) &&
-    Number.isFinite(listing.longitude)
+    typeof coordinates?.latitude === "number" &&
+    typeof coordinates?.longitude === "number" &&
+    Number.isFinite(coordinates.latitude) &&
+    Number.isFinite(coordinates.longitude)
   );
 }
 
@@ -86,7 +92,9 @@ export default function MapImmersive({
   isDesktop,
   countryCode,
 }) {
-  const isFirstLoad = useRef(true);
+  const selectedListingCoordinates = getListingCoordinates(selectedListing);
+  const hasAppliedInitialPositionRef = useRef(false);
+  const centeredListingIdRef = useRef(null);
   const [lastKnownPosition, setLastKnownPosition] = useState(null);
   const [isListingInView, setIsListingInView] = useState(true);
   const hasInitialPosition =
@@ -111,11 +119,15 @@ export default function MapImmersive({
 
     // If there's a selected listing with valid coords, center on it instead of using IP location
     if (hasValidCoordinates(selectedListing)) {
+      const coordinates = getListingCoordinates(selectedListing);
+
       mapRef.current?.flyTo({
-        center: [selectedListing.longitude, selectedListing.latitude],
+        center: [coordinates.longitude, coordinates.latitude],
         zoom: 12,
         duration: 0,
       });
+      hasAppliedInitialPositionRef.current = true;
+      centeredListingIdRef.current = selectedListing.id;
     }
 
     const bounds = mapRef.current.getMap().getBounds();
@@ -133,9 +145,10 @@ export default function MapImmersive({
 
     // Check if selected listing is in view (only when it has valid coords)
     if (hasValidCoordinates(selectedListing)) {
+      const coordinates = getListingCoordinates(selectedListing);
       const isInView = bounds.contains([
-        selectedListing.longitude,
-        selectedListing.latitude,
+        coordinates.longitude,
+        coordinates.latitude,
       ]);
       setIsListingInView(isInView);
     }
@@ -144,8 +157,10 @@ export default function MapImmersive({
   const handleFlyToListing = useCallback(() => {
     if (!hasValidCoordinates(selectedListing) || !mapRef.current) return;
 
+    const coordinates = getListingCoordinates(selectedListing);
+
     mapRef.current.flyTo({
-      center: [selectedListing.longitude, selectedListing.latitude],
+      center: [coordinates.longitude, coordinates.latitude],
       duration: 1500,
     });
   }, [selectedListing]);
@@ -154,32 +169,66 @@ export default function MapImmersive({
     let protocol = new Protocol();
     maplibregl.addProtocol("pmtiles", protocol.tile);
 
-    // Only handle initial positioning on first load
-    if (isFirstLoad.current) {
-      isFirstLoad.current = false;
-
-      // If there's a selected listing in URL with valid coords, center on it
-      if (hasValidCoordinates(selectedListing)) {
-        mapRef.current?.flyTo({
-          center: [selectedListing.longitude, selectedListing.latitude],
-          zoom: 12,
-          duration: 0,
-        });
-      }
-      // If no listing but we have IP coordinates, use those
-      else if (initialCoordinates) {
-        mapRef.current?.flyTo({
-          center: [initialCoordinates.longitude, initialCoordinates.latitude],
-          zoom: initialCoordinates.zoom,
-          duration: 0,
-        });
-      }
-    }
-
     return () => {
       maplibregl.removeProtocol("pmtiles");
     };
-  }, []); // Empty dependency array as before
+  }, []);
+
+  useEffect(() => {
+    if (
+      hasAppliedInitialPositionRef.current ||
+      hasValidCoordinates(selectedListing) ||
+      !initialCoordinates ||
+      !mapRef.current
+    ) {
+      return;
+    }
+
+    hasAppliedInitialPositionRef.current = true;
+    mapRef.current.flyTo({
+      center: [initialCoordinates.longitude, initialCoordinates.latitude],
+      zoom: initialCoordinates.zoom,
+      duration: 0,
+    });
+  }, [initialCoordinates, mapRef, selectedListing]);
+
+  useEffect(() => {
+    if (
+      !mapRef.current ||
+      !hasValidCoordinates(selectedListing) ||
+      centeredListingIdRef.current === selectedListing.id
+    ) {
+      return;
+    }
+
+    const coordinates = getListingCoordinates(selectedListing);
+    const map = mapRef.current.getMap();
+    const bounds = map.getBounds();
+    const isInView = bounds.contains([
+      coordinates.longitude,
+      coordinates.latitude,
+    ]);
+
+    if (isInView) {
+      hasAppliedInitialPositionRef.current = true;
+      centeredListingIdRef.current = selectedListing.id;
+      setIsListingInView(true);
+      return;
+    }
+
+    mapRef.current.flyTo({
+      center: [coordinates.longitude, coordinates.latitude],
+      zoom: 12,
+      duration: 900,
+    });
+    hasAppliedInitialPositionRef.current = true;
+    centeredListingIdRef.current = selectedListing.id;
+  }, [
+    mapRef,
+    selectedListing,
+    selectedListingCoordinates?.latitude,
+    selectedListingCoordinates?.longitude,
+  ]);
 
   // Set mapController to set relationship between MapSearch and MapImmersive
   // Can't get this to work, perhaps delete all mapController and createMapLibreGlMapController code if I can't get it working
@@ -193,9 +242,11 @@ export default function MapImmersive({
   // Update lastKnownPosition when we have a valid position
   useEffect(() => {
     if (hasValidCoordinates(selectedListing)) {
+      const coordinates = getListingCoordinates(selectedListing);
+
       setLastKnownPosition({
-        latitude: selectedListing.latitude,
-        longitude: selectedListing.longitude,
+        latitude: coordinates.latitude,
+        longitude: coordinates.longitude,
       });
     } else if (initialCoordinates && !lastKnownPosition) {
       setLastKnownPosition(initialCoordinates);
@@ -210,9 +261,10 @@ export default function MapImmersive({
     }
 
     const bounds = mapRef.current.getMap().getBounds();
+    const coordinates = getListingCoordinates(selectedListing);
     const isInView = bounds.contains([
-      selectedListing.longitude,
-      selectedListing.latitude,
+      coordinates.longitude,
+      coordinates.latitude,
     ]);
     console.log("isInView", isInView);
     setIsListingInView(isInView);
@@ -269,13 +321,13 @@ export default function MapImmersive({
             initialViewState={{
               longitude:
                 (hasValidCoordinates(selectedListing)
-                  ? selectedListing.longitude
+                  ? selectedListingCoordinates.longitude
                   : null) ??
                 initialCoordinates?.longitude ??
                 DEFAULT_COORDINATES.longitude,
               latitude:
                 (hasValidCoordinates(selectedListing)
-                  ? selectedListing.latitude
+                  ? selectedListingCoordinates.latitude
                   : null) ??
                 initialCoordinates?.latitude ??
                 DEFAULT_COORDINATES.latitude,
@@ -308,8 +360,8 @@ export default function MapImmersive({
               .map((listing) => (
                 <DrawerTrigger key={listing.id}>
                   <Marker
-                    longitude={listing.longitude}
-                    latitude={listing.latitude}
+                    longitude={listing.coordinates.longitude}
+                    latitude={listing.coordinates.latitude}
                     anchor="center"
                     onClick={(event) => {
                       event.originalEvent.stopPropagation();

--- a/supabase/migrations/20260419093000_drop_duplicate_listing_coordinates.sql
+++ b/supabase/migrations/20260419093000_drop_duplicate_listing_coordinates.sql
@@ -1,0 +1,155 @@
+do $$
+begin
+  if exists (
+    select 1
+    from public.listings
+    where abs(latitude - extensions.st_y(location::extensions.geometry)) > 0.0000001
+       or abs(longitude - extensions.st_x(location::extensions.geometry)) > 0.0000001
+  ) then
+    raise exception 'Cannot drop listings.latitude/listings.longitude because at least one row does not match listings.location.';
+  end if;
+end
+$$;
+
+drop function if exists public.listings_in_view(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+);
+
+drop view if exists public.listings_public_data;
+drop view if exists public.listings_private_data;
+
+alter table public.listings
+  alter column location type extensions.geography(Point, 4326)
+  using extensions.st_setsrid(location::extensions.geometry, 4326)::extensions.geography(Point, 4326);
+
+alter table public.listings
+  drop column latitude,
+  drop column longitude;
+
+create or replace view public.listings_private_data with (security_invoker = 'on') as
+select
+  listings.id,
+  listings.owner_id,
+  listings.name,
+  listings.description,
+  listings.accepted_items,
+  listings.rejected_items,
+  listings.photos,
+  listings.links,
+  listings.visibility,
+  listings.type,
+  listings.avatar,
+  listings.slug,
+  jsonb_build_object(
+    'latitude', extensions.st_y(listings.location::extensions.geometry),
+    'longitude', extensions.st_x(listings.location::extensions.geometry)
+  ) as coordinates,
+  listings.country_code,
+  listings.area_name,
+  listings.is_stub,
+  profiles.first_name as owner_first_name,
+  profiles.avatar as owner_avatar,
+  (
+    select count(*) >= 2
+    from public.listings as owner_listings
+    where owner_listings.owner_id = listings.owner_id
+      and owner_listings.type in ('community', 'business')
+  ) as owner_has_multiple_non_residential_listings
+from public.listings
+left join public.profiles on listings.owner_id = profiles.id;
+
+alter view public.listings_private_data owner to postgres;
+
+create or replace view public.listings_public_data with (security_invoker = 'on') as
+select
+  id,
+  created_at,
+  name,
+  description,
+  accepted_items,
+  rejected_items,
+  case
+    when type = any (array['business'::text, 'community'::text]) then photos
+    else null::text[]
+  end as photos,
+  links,
+  type,
+  avatar,
+  slug,
+  jsonb_build_object(
+    'latitude', extensions.st_y(location::extensions.geometry),
+    'longitude', extensions.st_x(location::extensions.geometry)
+  ) as coordinates,
+  country_code,
+  area_name,
+  is_stub,
+  (
+    select count(*) >= 2
+    from public.listings as other_listings
+    where other_listings.owner_id = listings.owner_id
+      and other_listings.type in ('community', 'business')
+  ) as owner_has_multiple_non_residential_listings
+from public.listings
+where visibility = true;
+
+alter view public.listings_public_data owner to postgres;
+
+create or replace function public.listings_in_view(
+  min_lat double precision,
+  min_long double precision,
+  max_lat double precision,
+  max_long double precision
+) returns table(id bigint, type text, coordinates jsonb)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  return query
+  select
+    listings.id,
+    listings.type,
+    jsonb_build_object(
+      'latitude', extensions.st_y(listings.location::extensions.geometry),
+      'longitude', extensions.st_x(listings.location::extensions.geometry)
+    ) as coordinates
+  from public.listings
+  where listings.visibility = true
+    and listings.location OPERATOR(extensions.&&) extensions.st_makeenvelope(
+      min_long,
+      min_lat,
+      max_long,
+      max_lat,
+      4326
+    )::extensions.geography;
+end;
+$$;
+
+alter function public.listings_in_view(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+) owner to postgres;
+
+grant all on function public.listings_in_view(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+) to anon, authenticated, service_role;
+
+revoke all on table public.listings_private_data
+  from anon, authenticated, service_role;
+
+revoke all on table public.listings_public_data
+  from anon, authenticated, service_role;
+
+grant select on table public.listings_private_data
+  to authenticated, service_role;
+
+grant select on table public.listings_public_data
+  to anon, authenticated, service_role;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -174,8 +174,6 @@ insert into public.listings (
   visibility,
   type,
   avatar,
-  latitude,
-  longitude,
   country_code,
   area_name,
   is_stub
@@ -194,8 +192,6 @@ values
     true,
     'community',
     'demo/farm.jpg',
-    -33.9110,
-    151.1569,
     'AU',
     'Marrickville',
     false
@@ -213,8 +209,6 @@ values
     true,
     'business',
     'demo/brewery.jpg',
-    -33.9063,
-    151.1645,
     'AU',
     'Enmore',
     false
@@ -232,8 +226,6 @@ values
     true,
     'residential',
     null,
-    -33.8986,
-    151.1781,
     'AU',
     'Newtown',
     false
@@ -251,8 +243,6 @@ set
   visibility = excluded.visibility,
   type = excluded.type,
   avatar = excluded.avatar,
-  latitude = excluded.latitude,
-  longitude = excluded.longitude,
   country_code = excluded.country_code,
   area_name = excluded.area_name,
   is_stub = excluded.is_stub;


### PR DESCRIPTION
## Summary

- Removes the duplicate `latitude` and `longitude` columns from `public.listings` and keeps `location` as the single stored coordinate source.
- Rebuilds the listing views and viewport RPC to expose a computed `coordinates` object for the app.
- Updates map, listing read, and listing edit flows to consume `coordinates` and write only `location`.

## Why

The flat coordinate columns duplicated the PostGIS geography point and could drift from it. The views now give the frontend a reliable shape without making React parse raw geography/EWKB values.

## Validation

- `npm run supabase:reset`
- Local schema checks confirmed `public.listings` no longer has `latitude` or `longitude`, while the listing views expose `coordinates`.
- Local RPC check confirmed `listings_in_view(...)` returns seeded listings with coordinate objects.
- `npm run check`
- `npm run build` with local Supabase env overrides

Browser screenshot verification was not available locally because `agent-browser` was not installed and the Playwright MCP could not create its root-level runtime directory on the read-only filesystem.
