### PR TITLE
add Playwright smoke tests

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -81,3 +81,13 @@ jobs:
 
       - name: Run Playwright smoke tests
         run: npm run test:e2e
+
+      - name: Upload Playwright artefacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artefacts
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -30,3 +30,54 @@ jobs:
 
       - name: Build app
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Supabase stack
+        run: supabase start
+
+      - name: Replay migrations and seed data
+        run: npm run supabase:reset
+
+      - name: Write local app env
+        shell: bash
+        run: |
+          eval "$(supabase status -o env | sed 's/^/export /')"
+          cat <<EOF > .env.local
+          NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3000
+          NEXT_PUBLIC_SUPABASE_URL=${API_URL}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}
+          NEXT_PUBLIC_MAPTILER_API_KEY=playwright-local
+          NEXT_PUBLIC_PROTOMAPS_API_KEY=playwright-local
+          NEXT_PUBLIC_TURNSTILE_ENABLED=
+          EOF
+
+      - name: Seed local demo media
+        run: npm run seed:local-media
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ npm run dev
 - Heavy commenting is encouraged to make the codebase accessible to others
 - Code formatting is handled by Prettier. Please ensure your code is formatted according to `.prettierrc` before submitting a pull request
 
+### Testing
+
+Peels keeps testing intentionally small:
+
+- `npm run check` for i18n and formatting checks
+- `npm run build` for the production build
+- `npm run test:e2e` for the headless Playwright smoke suite
+
+The smoke suite covers seeded sign-in, public listing, profile, and chat flows against local Supabase data. It is designed to stay small and high-signal rather than grow into a broad frontend testing matrix.
+
+For the first local Playwright run, install the browser once with:
+
+```bash
+npx playwright install chromium
+```
+
+Map changes are still a manual smoke-check area. When you touch `/map`, verify that the page loads, listing selection still works, search still works, and nothing obviously breaks in the browser.
+
 ### Getting Help
 
 - Check existing [issues](https://github.com/dnywh/peels/issues) for known problems

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -19,8 +19,8 @@ async function signIn(
 
   await expect(page.getByTestId("sign-in-form")).toBeVisible();
 
-  await page.getByLabel("Email").fill(email);
-  await page.getByLabel("Password").fill(SEEDED_PASSWORD);
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(SEEDED_PASSWORD);
 
   await Promise.all([
     page.waitForURL((url) => url.pathname === redirectTo),

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const HOST_EMAIL = "demo-host@peels.local";
+const DONOR_EMAIL = "demo-donor@peels.local";
+const SEEDED_PASSWORD = "peels-demo-password";
+const SEEDED_THREAD_ID = "33333333-3333-4333-8333-333333333333";
+
+async function signIn(
+  page: Page,
+  {
+    email,
+    redirectTo = "/profile",
+  }: {
+    email: string;
+    redirectTo?: string;
+  }
+) {
+  await page.goto(`/sign-in?redirect_to=${encodeURIComponent(redirectTo)}`);
+
+  await expect(page.getByTestId("sign-in-form")).toBeVisible();
+
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(SEEDED_PASSWORD);
+
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === redirectTo),
+    page.getByTestId("sign-in-submit").click(),
+  ]);
+}
+
+test("auth-sign-in redirects a seeded donor into the signed-in experience", async ({
+  page,
+}) => {
+  await signIn(page, { email: DONOR_EMAIL, redirectTo: "/profile" });
+
+  await expect(page).toHaveURL(/\/profile$/);
+  await expect(page.getByTestId("profile-first-name")).toHaveText("Riley");
+});
+
+test("public-listing shows the seeded public listing and guest contact gate", async ({
+  page,
+}) => {
+  await page.goto("/listings/demo-marrickville-compost");
+
+  await expect(
+    page.getByRole("heading", { name: "Marrickville Neighbourhood Compost" })
+  ).toBeVisible();
+  await expect(page.getByTestId("listing-guest-cta")).toBeVisible();
+  await expect(page.getByTestId("listing-sign-in-to-contact")).toHaveAttribute(
+    "href",
+    "/sign-in?redirect_to=/listings/demo-marrickville-compost"
+  );
+});
+
+test("profile loads the seeded host account and listings", async ({ page }) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+  await expect(page.getByTestId("profile-first-name")).toHaveText("Avery");
+  await expect(page.getByTestId("profile-listings")).toContainText(
+    "Marrickville Neighbourhood Compost"
+  );
+  await expect(page.getByTestId("profile-listings")).toContainText(
+    "Inner West Cafe Compost Pickup"
+  );
+});
+
+test("chat loads the seeded thread and composer for a signed-in donor", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+
+  await expect(page).toHaveURL(new RegExp(`/chats/${SEEDED_THREAD_ID}$`));
+  await expect(page.getByTestId("chat-window")).toBeVisible();
+  await expect(page.getByTestId("chat-message-list")).toContainText(
+    "Hey Avery, do you take coffee grounds from a small home espresso machine?"
+  );
+  await expect(page.getByTestId("chat-message-list")).toContainText(
+    "Yes, absolutely. Small sealed containers are perfect."
+  );
+  await expect(page.getByTestId("chat-composer")).toBeVisible();
+  await expect(page.getByTestId("chat-composer-input")).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@pigment-css/nextjs-plugin": "^0.0.30",
         "@pigment-css/react": "^0.0.30",
+        "@playwright/test": "^1.54.2",
         "@types/node": "22.9.0",
         "@types/react": "19.2.2",
         "@types/react-dom": "19.2.2",
@@ -2132,6 +2133,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -4288,6 +4305,21 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6169,6 +6201,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pmtiles": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "supabase:diff": "supabase db diff",
     "i18n:check": "node scripts/check-i18n-messages.mjs",
     "check": "npm run i18n:check && npm run format:check",
+    "test:e2e": "playwright test",
+    "test:e2e:debug": "playwright test --headed --workers=1",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -56,6 +58,7 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@pigment-css/nextjs-plugin": "^0.0.30",
     "@pigment-css/react": "^0.0.30",
     "@types/node": "22.9.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "@playwright/test";
+
+const baseURL = "http://127.0.0.1:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL,
+    headless: true,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+    viewport: {
+      width: 1280,
+      height: 900,
+    },
+  },
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   use: {
     baseURL,
     headless: true,
+    locale: "en-AU",
+    extraHTTPHeaders: {
+      "Accept-Language": "en-AU,en;q=0.9",
+    },
     trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
   workers: 1,
+  forbidOnly: !!process.env.CI,
   reporter: process.env.CI ? "github" : "list",
   use: {
     baseURL,

--- a/src/components/ChatComposer/ChatComposer.tsx
+++ b/src/components/ChatComposer/ChatComposer.tsx
@@ -56,7 +56,7 @@ function ChatComposer({
   return (
     <ChatComposerForm>
       {error && <FormMessage message={{ error: error }} />}
-      <ChatComposerInner onSubmit={onSubmit}>
+      <ChatComposerInner onSubmit={onSubmit} data-testid="chat-composer">
         <TextareaComponent
           variant="chat"
           placeholder={t("Chat.placeholder", {
@@ -66,6 +66,7 @@ function ChatComposer({
           onChange={handleMessageChange}
           disabled={!isDemo && isSending}
           rows={1}
+          data-testid="chat-composer-input"
         />
         <StyledIconButton
           type={isDemo ? "button" : "submit"}
@@ -76,6 +77,7 @@ function ChatComposer({
           loading={!isDemo && isSending}
           loadingLabel={t("Status.sending")}
           disabled={isSendDisabled}
+          data-testid="chat-composer-send"
         />
       </ChatComposerInner>
     </ChatComposerForm>

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -356,7 +356,7 @@ const ChatWindow = memo(function ChatWindow({
       : existingThread.initiator_first_name;
 
   return (
-    <StyledChatWindow>
+    <StyledChatWindow data-testid="chat-window">
       <ChatHeader
         thread={existingThread ? existingThread : undefined}
         listing={listing}
@@ -365,9 +365,9 @@ const ChatWindow = memo(function ChatWindow({
         isDrawer={isDrawer}
       />
 
-      <StyledMessagesContainer>
+      <StyledMessagesContainer data-testid="chat-message-list">
         {messages.length === 0 && (
-          <EmptyState>
+          <EmptyState data-testid="chat-empty-state">
             <p>{t("Chat.empty")}</p>
           </EmptyState>
         )}

--- a/src/components/ListingCta/ListingCta.jsx
+++ b/src/components/ListingCta/ListingCta.jsx
@@ -39,7 +39,7 @@ function ListingCta({ viewer, slug, visibility = true, isStub = false }) {
 
   if (viewer === "owner") {
     return (
-      <StyledListingCta>
+      <StyledListingCta data-testid="listing-owner-cta">
         <Button
           variant="secondary"
           width="full"
@@ -58,7 +58,7 @@ function ListingCta({ viewer, slug, visibility = true, isStub = false }) {
   }
   if (isStub) {
     return (
-      <StyledListingCta>
+      <StyledListingCta data-testid="listing-stub-cta">
         <PeelsLogo color="quaternary" />
         <Text>
           <p>{t("Listings.read.stubNote")}</p>
@@ -77,11 +77,12 @@ function ListingCta({ viewer, slug, visibility = true, isStub = false }) {
   }
 
   return (
-    <StyledListingCta>
+    <StyledListingCta data-testid="listing-guest-cta">
       <Button
         variant="primary"
         width="full"
         href={`/sign-in?redirect_to=/listings/${slug}`}
+        data-testid="listing-sign-in-to-contact"
       >
         {t("Actions.signInToContact")}
       </Button>

--- a/src/components/ProfileHeader/ProfileHeader.jsx
+++ b/src/components/ProfileHeader/ProfileHeader.jsx
@@ -27,7 +27,11 @@ export default async function ProfileHeader({ profile, user }) {
         bucket="avatars"
         entityId={user.id}
       />
-      {profile?.first_name && <Heading1>{profile?.first_name}</Heading1>}
+      {profile?.first_name && (
+        <Heading1 data-testid="profile-first-name">
+          {profile?.first_name}
+        </Heading1>
+      )}
       {profile?.is_admin && <Heading2>{t("admin")}</Heading2>}
     </>
   );

--- a/src/components/ProfileListings/ProfileListings.tsx
+++ b/src/components/ProfileListings/ProfileListings.tsx
@@ -117,7 +117,7 @@ export default function ProfileListings({
   if (!listings) return null;
 
   return (
-    <ListingsList>
+    <ListingsList data-testid="profile-listings">
       {listings.map((listing) => {
         return (
           <li key={listing.id}>

--- a/src/components/SignInForm/SignInForm.jsx
+++ b/src/components/SignInForm/SignInForm.jsx
@@ -53,6 +53,7 @@ function SignInForm({ searchParams }) {
           type="email"
           placeholder="you@example.com"
           required
+          data-testid="sign-in-email"
         />
       </Field>
 
@@ -69,6 +70,7 @@ function SignInForm({ searchParams }) {
           name="password"
           placeholder={t("Common.password")}
           required={true}
+          data-testid="sign-in-password"
         />
       </Field>
 

--- a/src/components/SignInForm/SignInForm.jsx
+++ b/src/components/SignInForm/SignInForm.jsx
@@ -41,13 +41,14 @@ function SignInForm({ searchParams }) {
   };
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form onSubmit={handleSubmit} data-testid="sign-in-form">
       {searchParams?.success && (
         <FormMessage message={{ success: searchParams.success }} />
       )}
       <Field>
         <Label htmlFor="email">{t("Common.email")}</Label>
         <Input
+          id="email"
           name="email"
           type="email"
           placeholder="you@example.com"
@@ -63,6 +64,7 @@ function SignInForm({ searchParams }) {
           </StrongLink>
         </FieldHeader>
         <Input
+          id="password"
           type="password"
           name="password"
           placeholder={t("Common.password")}
@@ -79,6 +81,7 @@ function SignInForm({ searchParams }) {
         variant="primary"
         loading={isSubmitting}
         loadingText={t("Status.signingIn")}
+        data-testid="sign-in-submit"
       >
         {t("Actions.signIn")}
       </Button>

--- a/src/components/ThreadsList/ThreadsList.jsx
+++ b/src/components/ThreadsList/ThreadsList.jsx
@@ -175,7 +175,7 @@ function ThreadsList({ user, threads, currentThreadId }) {
     <ThreadsSidebar>
       <h1>{t("threadsTitle")}</h1>
       {threads?.length > 0 ? (
-        <ThreadsUnorderedList>
+        <ThreadsUnorderedList data-testid="thread-list">
           {threads.map((thread) => {
             // TODO: Consolidate with other role and otherPersonName and displayNameVerbose logic elsewhere
             const role =
@@ -208,6 +208,7 @@ function ThreadsList({ user, threads, currentThreadId }) {
                   selected={thread.id === currentThreadId}
                   unread={hasUnreadMessages}
                   onClick={() => handleThreadSelect(thread)}
+                  data-testid={`thread-preview-${thread.id}`}
                 >
                   {/* Handle either listing avatar and owner avatar combo OR initiator's avatar */}
                   <AvatarPair

--- a/src/components/ThreadsList/ThreadsList.jsx
+++ b/src/components/ThreadsList/ThreadsList.jsx
@@ -1,7 +1,5 @@
 "use client";
-import { useCallback } from "react";
-import { useRouter } from "next/navigation";
-// import Link from "next/link";
+import Link from "next/link";
 
 import AvatarPair from "@/components/AvatarPair";
 
@@ -83,7 +81,7 @@ const ThreadsUnorderedList = styled("ul")(({ theme }) => ({
   ...sharedThreadsContainerStyles({ theme }),
 }));
 
-const ThreadPreview = styled("a")(({ theme }) => ({
+const ThreadPreview = styled(Link)(({ theme }) => ({
   cursor: "pointer",
   display: "flex",
   flexDirection: "row",
@@ -159,17 +157,7 @@ const ThreadPreviewText = styled("div")(({ theme }) => ({
 
 function ThreadsList({ user, threads, currentThreadId }) {
   const t = useTranslations("Chat");
-  const router = useRouter();
   const { isThreadRead } = useUnreadMessages();
-
-  const handleThreadSelect = useCallback(
-    (thread) => {
-      if (thread.id !== currentThreadId) {
-        router.push(`/chats/${thread.id}`);
-      }
-    },
-    [currentThreadId, router]
-  );
 
   return (
     <ThreadsSidebar>
@@ -205,9 +193,12 @@ function ThreadsList({ user, threads, currentThreadId }) {
             return (
               <li key={thread.id}>
                 <ThreadPreview
+                  href={`/chats/${thread.id}`}
                   selected={thread.id === currentThreadId}
                   unread={hasUnreadMessages}
-                  onClick={() => handleThreadSelect(thread)}
+                  aria-current={
+                    thread.id === currentThreadId ? "page" : undefined
+                  }
                   data-testid={`thread-preview-${thread.id}`}
                 >
                   {/* Handle either listing avatar and owner avatar combo OR initiator's avatar */}

--- a/src/components/ThreadsList/ThreadsList.jsx
+++ b/src/components/ThreadsList/ThreadsList.jsx
@@ -101,31 +101,20 @@ const ThreadPreview = styled(Link)(({ theme }) => ({
     //   boxShadow: `0 0 4px 1rem ${theme.colors.background.sunk}`,
     // },
   },
-
-  variants: [
-    {
-      props: { selected: true },
-      style: {
-        // cursor: "auto",
-        backgroundColor: theme.colors.background.sunk,
-      },
+  '&[data-selected="true"]': {
+    backgroundColor: theme.colors.background.sunk,
+  },
+  '&[data-unread="true"]': {
+    position: "relative",
+    "&::after": {
+      content: '""',
+      width: "10px",
+      height: "10px",
+      backgroundColor: theme.colors.tab.unread,
+      borderRadius: "50%",
+      flexShrink: 0,
     },
-    {
-      props: { unread: true },
-      style: {
-        // backgroundColor: theme.colors.background.sunk,
-        position: "relative",
-        "&::after": {
-          content: '""',
-          width: "10px",
-          height: "10px",
-          backgroundColor: theme.colors.tab.unread,
-          borderRadius: "50%",
-          flexShrink: 0,
-        },
-      },
-    },
-  ],
+  },
 }));
 
 const ThreadPreviewText = styled("div")(({ theme }) => ({
@@ -194,8 +183,10 @@ function ThreadsList({ user, threads, currentThreadId }) {
               <li key={thread.id}>
                 <ThreadPreview
                   href={`/chats/${thread.id}`}
-                  selected={thread.id === currentThreadId}
-                  unread={hasUnreadMessages}
+                  data-selected={
+                    thread.id === currentThreadId ? "true" : undefined
+                  }
+                  data-unread={hasUnreadMessages ? "true" : undefined}
                   aria-current={
                     thread.id === currentThreadId ? "page" : undefined
                   }

--- a/src/components/ThreadsList/ThreadsList.jsx
+++ b/src/components/ThreadsList/ThreadsList.jsx
@@ -191,6 +191,11 @@ function ThreadsList({ user, threads, currentThreadId }) {
                     thread.id === currentThreadId ? "page" : undefined
                   }
                   data-testid={`thread-preview-${thread.id}`}
+                  onClick={(event) => {
+                    if (thread.id === currentThreadId) {
+                      event.preventDefault();
+                    }
+                  }}
                 >
                   {/* Handle either listing avatar and owner avatar combo OR initiator's avatar */}
                   <AvatarPair


### PR DESCRIPTION
## Summary

Add a small, repo-owned Playwright smoke suite for Peels and wire it into app validation without growing the test stack beyond what the project needs.

## What changed

- added headless Playwright config and four seeded smoke tests for sign-in, public listing, profile, and chat flows
- added `test:e2e` and `test:e2e:debug` scripts plus the Playwright dependency
- added stable test hooks to the relevant UI so the smoke tests do not rely on brittle selectors
- updated app validation to boot local Supabase, replay migrations and seed data, seed demo media, and run the Playwright smoke suite
- documented the intended lightweight testing workflow in the README

## Why

Peels is still a small project, but it has real user-facing auth, listing, and messaging flows where `check` and `build` alone are not enough. This keeps browser-level confidence focused on the handful of journeys that matter, while avoiding a broader frontend test matrix.

## Validation

- `npm run check`
- `npm run build`
- `npm run test:e2e`
