### PR TITLE
fix map interaction regressions

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -385,6 +385,7 @@
     "searchError": "Etwas ist schiefgelaufen. Erneut versuchen?",
     "searchNoResults": "Keine Ergebnisse. Tippe weiter oder verfeinere deine Suche",
     "returnToListing": "Zurück zum Eintrag",
+    "loadingListing": "Eintrag wird geladen…",
     "loadingPins": "Wird geladen…",
     "didYouKnow": "Wusstest du schon?",
     "steps": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -385,6 +385,7 @@
     "searchError": "Something went wrong. Try again?",
     "searchNoResults": "No results. Keep typing or refine your search",
     "returnToListing": "Return to listing",
+    "loadingListing": "Loading listing…",
     "loadingPins": "Loading…",
     "didYouKnow": "Did you know?",
     "steps": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -385,6 +385,7 @@
     "searchError": "Algo salió mal. ¿Intentarlo de nuevo?",
     "searchNoResults": "Sin resultados. Sigue escribiendo o ajusta tu búsqueda",
     "returnToListing": "Volver al anuncio",
+    "loadingListing": "Cargando anuncio…",
     "loadingPins": "Cargando…",
     "didYouKnow": "¿Sabías que?",
     "steps": {

--- a/src/contexts/UnreadMessagesContext.js
+++ b/src/contexts/UnreadMessagesContext.js
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useState, useEffect, useMemo } from "react";
 import { createClient } from "@/utils/supabase/client";
 
 const UnreadMessagesContext = createContext();
@@ -9,7 +9,7 @@ export function UnreadMessagesProvider({ children }) {
   const [unreadCount, setUnreadCount] = useState(0);
   const [threadReadStatus, setThreadReadStatus] = useState({});
   const [hasViewedChats, setHasViewedChats] = useState(false);
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   // Check for unread messages on mount
   useEffect(() => {
@@ -84,7 +84,7 @@ export function UnreadMessagesProvider({ children }) {
     return () => {
       subscription.unsubscribe();
     };
-  }, []);
+  }, [supabase]);
 
   // Real-time subscription for new messages
   useEffect(() => {

--- a/src/features/map/components/MapListingDrawerPanel.tsx
+++ b/src/features/map/components/MapListingDrawerPanel.tsx
@@ -2,7 +2,7 @@
 
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Drawer } from "vaul";
-import { styled } from "@pigment-css/react";
+import { keyframes, styled } from "@pigment-css/react";
 import { useTranslations } from "next-intl";
 import type { User } from "@supabase/supabase-js";
 
@@ -201,17 +201,17 @@ const LoadingState = styled("div")({
   padding: "0 1rem",
 });
 
+const mapDrawerPulse = keyframes({
+  "0%": { opacity: 0.55 },
+  "50%": { opacity: 1 },
+  "100%": { opacity: 0.55 },
+});
+
 const SkeletonBlock = styled("div")(({ theme }) => ({
   borderRadius: theme.corners.base,
   background: theme.colors.background.slight,
   opacity: 0.85,
-  animation: "mapDrawerPulse 1.2s ease-in-out infinite",
-
-  "@keyframes mapDrawerPulse": {
-    "0%": { opacity: 0.55 },
-    "50%": { opacity: 1 },
-    "100%": { opacity: 0.55 },
-  },
+  animation: `${mapDrawerPulse} 1.2s ease-in-out infinite`,
 }));
 
 const SkeletonHeader = styled("div")({

--- a/src/features/map/components/MapListingDrawerPanel.tsx
+++ b/src/features/map/components/MapListingDrawerPanel.tsx
@@ -20,6 +20,7 @@ import { SIDEBAR_WIDTH } from "../lib/mapUtils";
 type MapListingDrawerPanelProps = {
   user: User | null;
   selectedListing: SelectedListing | null;
+  isSelectedListingLoading: boolean;
   isDesktop: boolean;
   hasTouch: boolean;
   isDrawerHeaderShown: boolean;
@@ -193,9 +194,42 @@ const NoListingFound = styled("div")(({ theme }) => ({
   },
 }));
 
+const LoadingState = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5rem",
+  padding: "0 1rem",
+});
+
+const SkeletonBlock = styled("div")(({ theme }) => ({
+  borderRadius: theme.corners.base,
+  background: theme.colors.background.slight,
+  opacity: 0.85,
+  animation: "mapDrawerPulse 1.2s ease-in-out infinite",
+
+  "@keyframes mapDrawerPulse": {
+    "0%": { opacity: 0.55 },
+    "50%": { opacity: 1 },
+    "100%": { opacity: 0.55 },
+  },
+}));
+
+const SkeletonHeader = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+});
+
+const SkeletonText = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.75rem",
+});
+
 export default function MapListingDrawerPanel({
   user,
   selectedListing,
+  isSelectedListingLoading,
   isDesktop,
   hasTouch,
   isDrawerHeaderShown,
@@ -208,9 +242,10 @@ export default function MapListingDrawerPanel({
   const t = useTranslations();
 
   const showErrorPanel = isListingError(selectedListing);
-  const listingForDisplay = isListingError(selectedListing)
-    ? null
-    : selectedListing;
+  const listingForDisplay =
+    isSelectedListingLoading || isListingError(selectedListing)
+      ? null
+      : selectedListing;
 
   return (
     <Drawer.Portal>
@@ -239,16 +274,25 @@ export default function MapListingDrawerPanel({
             }}
           >
             <StyledHeaderText>
-              <h3 style={{ fontSize: "0.85rem" }}>
-                {listingForDisplay
-                  ? getListingDisplayName(listingForDisplay, user)
-                  : ""}
-              </h3>
-              <p>
-                {listingForDisplay
-                  ? getListingDisplayType(listingForDisplay)
-                  : ""}
-              </p>
+              {isSelectedListingLoading ? (
+                <SkeletonHeader>
+                  <SkeletonBlock style={{ height: "0.85rem", width: "65%" }} />
+                  <SkeletonBlock style={{ height: "0.8rem", width: "40%" }} />
+                </SkeletonHeader>
+              ) : (
+                <>
+                  <h3 style={{ fontSize: "0.85rem" }}>
+                    {listingForDisplay
+                      ? getListingDisplayName(listingForDisplay, user)
+                      : ""}
+                  </h3>
+                  <p>
+                    {listingForDisplay
+                      ? getListingDisplayType(listingForDisplay)
+                      : ""}
+                  </p>
+                </>
+              )}
             </StyledHeaderText>
           </StyledDrawerHeaderInner>
 
@@ -276,7 +320,20 @@ export default function MapListingDrawerPanel({
         </StyledDrawerHeader>
 
         <StyledDrawerInner>
-          {showErrorPanel ? (
+          {isSelectedListingLoading ? (
+            <LoadingState aria-busy={true}>
+              <p>{t("Map.loadingListing")}</p>
+              <SkeletonBlock style={{ height: "3rem", width: "100%" }} />
+              <SkeletonText>
+                <SkeletonBlock style={{ height: "1rem", width: "45%" }} />
+                <SkeletonBlock style={{ height: "4.5rem", width: "100%" }} />
+                <SkeletonBlock style={{ height: "1rem", width: "35%" }} />
+                <SkeletonBlock style={{ height: "7rem", width: "100%" }} />
+                <SkeletonBlock style={{ height: "1rem", width: "30%" }} />
+                <SkeletonBlock style={{ height: "5rem", width: "100%" }} />
+              </SkeletonText>
+            </LoadingState>
+          ) : showErrorPanel ? (
             <NoListingFound>
               <header>
                 <h2>{t("Map.emptyTitle")}</h2>

--- a/src/features/map/components/MapPageClient.tsx
+++ b/src/features/map/components/MapPageClient.tsx
@@ -57,7 +57,8 @@ export default function MapPageClient({
     selectedListing,
     selectedListingId,
     isListingSelected,
-    selectListingById,
+    isSelectedListingLoading,
+    selectListing,
     closeListing,
   } = useMapListingUrl({ user, initialListingSlug, initialListing });
 
@@ -72,6 +73,7 @@ export default function MapPageClient({
     isFullSnap,
     isPartialSnap,
     isDrawerHeaderShown,
+    resetDrawer,
     handleSnapChange,
   } = useMapDrawerState({ isDesktop, listingSlug, isListingSelected });
 
@@ -79,18 +81,18 @@ export default function MapPageClient({
     (listing: ListingMarker) => {
       if (listing.id === selectedListingId && isListingSelected) return;
 
-      // Optimistic pin grow + single fetch (selectListingById sets the
-      // optimistic id synchronously, fetches by id, then pushes the URL).
-      void selectListingById(listing.id);
+      resetDrawer();
+      selectListing(listing);
     },
-    [isListingSelected, selectListingById, selectedListingId]
+    [isListingSelected, resetDrawer, selectListing, selectedListingId]
   );
 
   const handleMapClick = useCallback(() => {
     if (isListingSelected) {
+      resetDrawer();
       closeListing();
     }
-  }, [closeListing, isListingSelected]);
+  }, [closeListing, isListingSelected, resetDrawer]);
 
   const handleDrawerOpenChange = useCallback(
     (open: boolean) => {
@@ -98,10 +100,11 @@ export default function MapPageClient({
       // the URL. We only act on the close transition — `open === true` is
       // already reflected by `isListingSelected` from the URL.
       if (!open && isListingSelected) {
+        resetDrawer();
         closeListing();
       }
     },
-    [closeListing, isListingSelected]
+    [closeListing, isListingSelected, resetDrawer]
   );
 
   return (
@@ -120,6 +123,7 @@ export default function MapPageClient({
             selectedListing={selectedListing}
             selectedListingId={selectedListingId}
             listingSlug={listingSlug}
+            isListingSelected={isListingSelected}
             initialCoordinates={initialCoordinates}
             onMapClick={handleMapClick}
             onMarkerClick={handleMarkerClick}
@@ -131,6 +135,7 @@ export default function MapPageClient({
           <MapListingDrawerPanel
             user={user}
             selectedListing={selectedListing}
+            isSelectedListingLoading={isSelectedListingLoading}
             isDesktop={isDesktop}
             hasTouch={hasTouch}
             isDrawerHeaderShown={isDrawerHeaderShown}

--- a/src/features/map/components/MapPageClient.tsx
+++ b/src/features/map/components/MapPageClient.tsx
@@ -107,6 +107,11 @@ export default function MapPageClient({
     [closeListing, isListingSelected, resetDrawer]
   );
 
+  const handlePanelClose = useCallback(() => {
+    resetDrawer();
+    closeListing();
+  }, [closeListing, resetDrawer]);
+
   return (
     <StyledMapPage>
       <StyledMapWrapper>
@@ -142,7 +147,7 @@ export default function MapPageClient({
             isFullSnap={isFullSnap}
             isPartialSnap={isPartialSnap}
             onToggleSnap={handleSnapChange}
-            onClose={closeListing}
+            onClose={handlePanelClose}
             drawerContentRef={drawerContentRef}
           />
         </Drawer.Root>

--- a/src/features/map/components/MapView.tsx
+++ b/src/features/map/components/MapView.tsx
@@ -45,6 +45,7 @@ type MapViewProps = {
   selectedListing: SelectedListing | null;
   selectedListingId: number | null;
   listingSlug: string | null;
+  isListingSelected: boolean;
   initialCoordinates: (ListingCoordinates & { zoom: number }) | null;
   onMapClick: () => void;
   onMarkerClick: (listing: ListingMarker) => void;
@@ -76,8 +77,9 @@ const ReturnToListingButton = styled(Button)({
 const LoadingChip = styled("div")(({ theme }) => ({
   position: "absolute",
   top: "0.75rem",
-  right: "0.75rem",
-  zIndex: 1,
+  left: "50%",
+  transform: "translateX(-50%)",
+  zIndex: 2,
   padding: "0.25rem 0.75rem",
   borderRadius: "999px",
   background: theme.colors.background.top,
@@ -155,6 +157,7 @@ export default function MapView({
   selectedListing,
   selectedListingId,
   listingSlug,
+  isListingSelected,
   initialCoordinates,
   onMapClick,
   onMarkerClick,
@@ -222,11 +225,11 @@ export default function MapView({
 
   const handleMapClickInternal = useCallback(
     (_event: MapLayerMouseEvent) => {
-      if (selectedListingId !== null || listingSlug) {
+      if (selectedListingId !== null || isListingSelected || listingSlug) {
         onMapClick();
       }
     },
-    [listingSlug, onMapClick, selectedListingId]
+    [isListingSelected, listingSlug, onMapClick, selectedListingId]
   );
 
   const handleSearchPick = useCallback(
@@ -245,7 +248,7 @@ export default function MapView({
   );
 
   const showReturnButton = Boolean(
-    selectedListing && listingSlug && !isSelectedInView
+    selectedListing && isListingSelected && !isSelectedInView
   );
 
   return (

--- a/src/features/map/hooks/useMapDrawerState.ts
+++ b/src/features/map/hooks/useMapDrawerState.ts
@@ -19,6 +19,7 @@ type UseMapDrawerStateResult = {
   isFullSnap: boolean;
   isPartialSnap: boolean;
   isDrawerHeaderShown: boolean;
+  resetDrawer: () => void;
   handleSnapChange: () => void;
 };
 
@@ -47,6 +48,15 @@ export function useMapDrawerState({
 
   const isFullSnap = snap === SNAP_POINTS.full;
   const isPartialSnap = snap === SNAP_POINTS.partial;
+
+  const resetDrawer = useCallback(() => {
+    document.documentElement.classList.remove("drawer-fully-open");
+    setSnap(SNAP_POINTS.partial);
+    setIsDrawerHeaderShown(false);
+    if (drawerContentRef.current) {
+      drawerContentRef.current.scrollTop = 0;
+    }
+  }, []);
 
   // Snap to full on desktop. On mobile we stay at the partial snap until the
   // user explicitly expands or a new listing is opened.
@@ -79,17 +89,12 @@ export function useMapDrawerState({
   // changes (including browser back/forward).
   useEffect(() => {
     if (!listingSlug) {
-      document.documentElement.classList.remove("drawer-fully-open");
-      setSnap(SNAP_POINTS.partial);
+      resetDrawer();
       return;
     }
 
-    setSnap(SNAP_POINTS.partial);
-    setIsDrawerHeaderShown(false);
-    if (drawerContentRef.current) {
-      drawerContentRef.current.scrollTop = 0;
-    }
-  }, [listingSlug]);
+    resetDrawer();
+  }, [listingSlug, resetDrawer]);
 
   // Mobile: we can attach the scroll handler directly when the drawer is
   // fully snapped because the drawer content is the scroll container.
@@ -174,6 +179,7 @@ export function useMapDrawerState({
     isFullSnap,
     isPartialSnap,
     isDrawerHeaderShown,
+    resetDrawer,
     handleSnapChange,
   };
 }

--- a/src/features/map/hooks/useMapListingUrl.ts
+++ b/src/features/map/hooks/useMapListingUrl.ts
@@ -100,19 +100,6 @@ export function useMapListingUrl({
     setCachedListing(initialListing.slug, initialListing);
   }, [initialListing, setCachedListing]);
 
-  useEffect(() => {
-    const syncListingSlug = () => {
-      setListingSlug(readListingSlugFromLocation());
-    };
-
-    syncListingSlug();
-    window.addEventListener("popstate", syncListingSlug);
-
-    return () => {
-      window.removeEventListener("popstate", syncListingSlug);
-    };
-  }, []);
-
   const getCachedListing = useCallback(
     (slug: string) => {
       return (
@@ -121,6 +108,56 @@ export function useMapListingUrl({
     },
     [tableName]
   );
+
+  useEffect(() => {
+    const syncListingSlug = () => {
+      const nextSlug = readListingSlugFromLocation();
+      setListingSlug(nextSlug);
+
+      if (!nextSlug) {
+        setIsListingSelected(false);
+        setSelectedListingId(null);
+        setIsSelectedListingLoading(false);
+        return;
+      }
+
+      setIsListingSelected(true);
+
+      if (
+        nextSlug === initialListingSlug &&
+        initialListing &&
+        initialListing.slug === nextSlug
+      ) {
+        setSelectedListing(initialListing);
+        setSelectedListingId(initialListing.id ?? null);
+        setIsSelectedListingLoading(false);
+        return;
+      }
+
+      const cachedListing = getCachedListing(nextSlug);
+      if (cachedListing) {
+        setSelectedListing(cachedListing);
+        setSelectedListingId(cachedListing.id ?? null);
+        setIsSelectedListingLoading(false);
+        return;
+      }
+
+      if (
+        nextSlug !== activeSlugRef.current ||
+        activeTableRef.current !== tableName
+      ) {
+        setSelectedListingId(null);
+        setIsSelectedListingLoading(true);
+      }
+    };
+
+    syncListingSlug();
+    window.addEventListener("popstate", syncListingSlug);
+
+    return () => {
+      window.removeEventListener("popstate", syncListingSlug);
+    };
+  }, [getCachedListing, initialListing, initialListingSlug, tableName]);
 
   const setDocumentTitle = useCallback(
     (listing: Listing | null) => {

--- a/src/features/map/hooks/useMapListingUrl.ts
+++ b/src/features/map/hooks/useMapListingUrl.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import type { User } from "@supabase/supabase-js";
 
@@ -32,9 +31,15 @@ type CachedListing = {
 };
 
 const MAP_TITLE = `Map · ${siteConfig.name}`;
+const MAX_CACHED_LISTINGS = 24;
 
 function buildCacheKey(slug: string, tableName: string) {
   return `${tableName}:${slug}`;
+}
+
+function readListingSlugFromLocation() {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("listing");
 }
 
 export function useMapListingUrl({
@@ -43,11 +48,12 @@ export function useMapListingUrl({
   initialListing,
 }: UseMapListingUrlArgs): UseMapListingUrlResult {
   const t = useTranslations();
-  const searchParams = useSearchParams();
   const supabase = useMemo(() => createClient(), []);
 
-  const listingSlug = searchParams.get("listing");
   const tableName = user ? "listings_private_data" : "listings_public_data";
+  const [listingSlug, setListingSlug] = useState<string | null>(
+    initialListingSlug ?? null
+  );
 
   const [selectedListing, setSelectedListing] =
     useState<SelectedListing | null>(initialListing ?? null);
@@ -68,12 +74,44 @@ export function useMapListingUrl({
   );
   const cacheRef = useRef<Map<string, CachedListing>>(new Map());
 
+  const setCachedListing = useCallback(
+    (slug: string, listing: Listing) => {
+      const cacheKey = buildCacheKey(slug, tableName);
+      const cache = cacheRef.current;
+
+      if (cache.has(cacheKey)) {
+        cache.delete(cacheKey);
+      }
+
+      cache.set(cacheKey, { listing });
+
+      if (cache.size > MAX_CACHED_LISTINGS) {
+        const oldestKey = cache.keys().next().value;
+        if (oldestKey) {
+          cache.delete(oldestKey);
+        }
+      }
+    },
+    [tableName]
+  );
+
   useEffect(() => {
     if (!initialListing?.slug) return;
-    cacheRef.current.set(buildCacheKey(initialListing.slug, tableName), {
-      listing: initialListing,
-    });
-  }, [initialListing, tableName]);
+    setCachedListing(initialListing.slug, initialListing);
+  }, [initialListing, setCachedListing]);
+
+  useEffect(() => {
+    const syncListingSlug = () => {
+      setListingSlug(readListingSlugFromLocation());
+    };
+
+    syncListingSlug();
+    window.addEventListener("popstate", syncListingSlug);
+
+    return () => {
+      window.removeEventListener("popstate", syncListingSlug);
+    };
+  }, []);
 
   const getCachedListing = useCallback(
     (slug: string) => {
@@ -131,7 +169,7 @@ export function useMapListingUrl({
         }
 
         const listing = data as Listing;
-        cacheRef.current.set(buildCacheKey(slug, tableName), { listing });
+        setCachedListing(slug, listing);
         setSelectedListing(listing);
         setSelectedListingId(listing.id ?? optimisticId);
         setIsSelectedListingLoading(false);
@@ -146,7 +184,7 @@ export function useMapListingUrl({
         setIsSelectedListingLoading(false);
       }
     },
-    [supabase, t, tableName]
+    [setCachedListing, supabase, t, tableName]
   );
 
   useEffect(() => {
@@ -238,6 +276,7 @@ export function useMapListingUrl({
         void fetchBySlug(listing.slug, listing.id);
       }
 
+      setListingSlug(listing.slug);
       window.history.pushState(
         null,
         "",
@@ -257,6 +296,7 @@ export function useMapListingUrl({
     setIsSelectedListingLoading(false);
     setDocumentTitle(null);
 
+    setListingSlug(null);
     window.history.pushState(null, "", "/map");
   }, [setDocumentTitle]);
 

--- a/src/features/map/hooks/useMapListingUrl.ts
+++ b/src/features/map/hooks/useMapListingUrl.ts
@@ -1,12 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-
-import { createClient } from "@/utils/supabase/client";
-import { isListing, type Listing, type SelectedListing } from "@/types/listing";
 import type { User } from "@supabase/supabase-js";
+
+import { siteConfig } from "@/config/site";
+import type { Listing, ListingMarker, SelectedListing } from "@/types/listing";
+import { isListing } from "@/types/listing";
+import { getListingDisplayName } from "@/utils/listingUtils";
+import { createClient } from "@/utils/supabase/client";
 
 type UseMapListingUrlArgs = {
   user: User | null | undefined;
@@ -17,103 +20,96 @@ type UseMapListingUrlArgs = {
 type UseMapListingUrlResult = {
   listingSlug: string | null;
   selectedListing: SelectedListing | null;
-  // The id that should appear "selected" on the map. Combines the optimistic
-  // id from the most recent tap with the resolved listing's id, so the pin
-  // grows immediately on tap and stays grown through the fetch.
   selectedListingId: number | null;
-  // True whenever there is a listing in the URL. Drives the drawer open state.
   isListingSelected: boolean;
-  // Marker click handler. Sets the optimistic id synchronously, fetches the
-  // full listing by id, then updates state + URL in one pass. The URL effect
-  // skips the normal fetch because the slug is already resolved.
-  selectListingById: (id: number) => Promise<void>;
-  // Drawer close handler.
+  isSelectedListingLoading: boolean;
+  selectListing: (listing: ListingMarker) => void;
   closeListing: () => void;
 };
 
-// Owns the URL <-> selected-listing relationship for the map page.
-//
-// Goals:
-// - Seed from SSR (`initialListing`) so a deep link doesn't re-fetch.
-// - Fix the "grow -> shrink -> grow" pin flicker by:
-//   (a) setting an optimistic pin id synchronously on tap, and
-//   (b) only fetching the listing once per selection (removes the original
-//       double fetch where handleMarkerClick + loadListingBySlug both ran).
-// - Leave `selectedListing` set while the drawer animates closed, so the
-//   last listing stays on-screen instead of flashing empty.
+type CachedListing = {
+  listing: Listing;
+};
+
+const MAP_TITLE = `Map · ${siteConfig.name}`;
+
+function buildCacheKey(slug: string, tableName: string) {
+  return `${tableName}:${slug}`;
+}
+
 export function useMapListingUrl({
   user,
   initialListingSlug,
   initialListing,
 }: UseMapListingUrlArgs): UseMapListingUrlResult {
   const t = useTranslations();
-  const router = useRouter();
   const searchParams = useSearchParams();
-  // `createClient()` builds a new Supabase browser client each call, so
-  // memoize to keep the reference stable — otherwise `fetchBySlug` /
-  // `selectListingById` churn on every render.
   const supabase = useMemo(() => createClient(), []);
 
   const listingSlug = searchParams.get("listing");
+  const tableName = user ? "listings_private_data" : "listings_public_data";
 
   const [selectedListing, setSelectedListing] =
     useState<SelectedListing | null>(initialListing ?? null);
-  const [optimisticListingId, setOptimisticListingId] = useState<number | null>(
+  const [selectedListingId, setSelectedListingId] = useState<number | null>(
     initialListing?.id ?? null
   );
-
-  // The last slug we've resolved locally. Used to skip the fetch in the URL
-  // sync effect when we were the ones that set the URL.
-  const resolvedSlugRef = useRef<string | null>(
-    initialListing?.slug ?? initialListingSlug ?? null
+  const [isListingSelected, setIsListingSelected] = useState(
+    Boolean(initialListingSlug)
+  );
+  const [isSelectedListingLoading, setIsSelectedListingLoading] = useState(
+    Boolean(initialListingSlug && !initialListing)
   );
 
-  // Which Supabase view was used when we resolved `resolvedSlugRef`. When auth
-  // loads or the session ends, `tableName` flips — we must refetch so we do not
-  // keep showing columns from the wrong view.
-  const resolvedTableRef = useRef<string | null>(
-    initialListingSlug &&
-      initialListing?.slug &&
-      initialListing.slug === initialListingSlug
-      ? user
-        ? "listings_private_data"
-        : "listings_public_data"
-      : null
-  );
-
-  const tableName = user ? "listings_private_data" : "listings_public_data";
-
-  // Monotonically increasing token for every in-flight listing fetch (by slug
-  // or by id). Responses only get to update state when their token is still
-  // the most recent one — avoids older requests overwriting newer selections
-  // when slugs flip rapidly or the public/private view changes mid-flight.
   const requestTokenRef = useRef(0);
-
-  // Id of the listing currently rendered in the drawer (or null when nothing
-  // or an error is shown). Kept in a ref so `selectListingById` can revert
-  // the optimistic pin id after a failed tap without going through stale
-  // closure values.
-  const resolvedListingIdRef = useRef<number | null>(
-    initialListing?.id ?? null
+  const activeSlugRef = useRef<string | null>(initialListing?.slug ?? null);
+  const activeTableRef = useRef<string | null>(
+    initialListing ? tableName : null
   );
-  useEffect(() => {
-    resolvedListingIdRef.current = isListing(selectedListing)
-      ? (selectedListing.id ?? null)
-      : null;
-  }, [selectedListing]);
+  const cacheRef = useRef<Map<string, CachedListing>>(new Map());
 
-  // If the public/private view flips (e.g. session finished loading) while the
-  // same listing is open, refetch with the correct view.
   useEffect(() => {
-    if (!listingSlug) return;
-    if (resolvedTableRef.current === null) return;
-    if (resolvedTableRef.current === tableName) return;
-    resolvedTableRef.current = null;
-  }, [listingSlug, tableName]);
+    if (!initialListing?.slug) return;
+    cacheRef.current.set(buildCacheKey(initialListing.slug, tableName), {
+      listing: initialListing,
+    });
+  }, [initialListing, tableName]);
+
+  const getCachedListing = useCallback(
+    (slug: string) => {
+      return (
+        cacheRef.current.get(buildCacheKey(slug, tableName))?.listing ?? null
+      );
+    },
+    [tableName]
+  );
+
+  const setDocumentTitle = useCallback(
+    (listing: Listing | null) => {
+      if (typeof document === "undefined") return;
+
+      const listingName = listing
+        ? getListingDisplayName(listing, user ?? null)
+        : "";
+      document.title = listingName
+        ? `${listingName} · ${siteConfig.name}`
+        : MAP_TITLE;
+    },
+    [user]
+  );
 
   const fetchBySlug = useCallback(
-    async (slug: string) => {
+    async (slug: string, optimisticId: number | null = null) => {
       const token = ++requestTokenRef.current;
+
+      activeSlugRef.current = slug;
+      activeTableRef.current = tableName;
+      setIsListingSelected(true);
+      setIsSelectedListingLoading(true);
+
+      if (optimisticId !== null) {
+        setSelectedListingId(optimisticId);
+      }
 
       try {
         const { data, error } = await supabase
@@ -124,146 +120,153 @@ export function useMapListingUrl({
 
         if (token !== requestTokenRef.current) return;
 
-        if (error) {
+        if (error || !data) {
           setSelectedListing({
             error: true,
             message: t("Listings.edit.notFound"),
           });
-          setOptimisticListingId(null);
+          setSelectedListingId(optimisticId);
+          setIsSelectedListingLoading(false);
           return;
         }
 
         const listing = data as Listing;
+        cacheRef.current.set(buildCacheKey(slug, tableName), { listing });
         setSelectedListing(listing);
-        resolvedSlugRef.current = slug;
-        resolvedTableRef.current = tableName;
-        setOptimisticListingId(listing.id ?? null);
-      } catch (err) {
+        setSelectedListingId(listing.id ?? optimisticId);
+        setIsSelectedListingLoading(false);
+      } catch (error) {
         if (token !== requestTokenRef.current) return;
-        console.warn("Failed to load listing by slug:", err);
+        console.warn("Failed to load listing by slug:", error);
         setSelectedListing({
           error: true,
           message: t("Listings.edit.notFound"),
         });
-        setOptimisticListingId(null);
+        setSelectedListingId(optimisticId);
+        setIsSelectedListingLoading(false);
       }
     },
     [supabase, t, tableName]
   );
 
-  // Keep state aligned with the URL. Only fetch when the slug has actually
-  // changed from what we resolved locally. We intentionally do *not* clear
-  // `selectedListing` when the slug goes away — the drawer animates out and
-  // should keep showing the last listing until it's fully closed — but we
-  // do clear the pin-selection id so the pin snaps back immediately.
   useEffect(() => {
     if (!listingSlug) {
-      // Invalidate any in-flight fetch so a late response can't re-select
-      // the listing the user just navigated away from (e.g. browser Back
-      // while a deep-link fetch is still in flight).
       requestTokenRef.current += 1;
-      resolvedSlugRef.current = null;
-      resolvedTableRef.current = null;
-      setOptimisticListingId(null);
+      activeSlugRef.current = null;
+      activeTableRef.current = null;
+      setIsListingSelected(false);
+      setSelectedListingId(null);
+      setIsSelectedListingLoading(false);
       return;
     }
 
-    // On first mount: if SSR gave us the listing for this slug, use that.
+    setIsListingSelected(true);
+
+    if (
+      listingSlug === activeSlugRef.current &&
+      activeTableRef.current === tableName
+    ) {
+      return;
+    }
+
+    requestTokenRef.current += 1;
+    activeSlugRef.current = listingSlug;
+    activeTableRef.current = tableName;
+
     if (
       listingSlug === initialListingSlug &&
       initialListing &&
-      resolvedSlugRef.current !== listingSlug
+      initialListing.slug === listingSlug
     ) {
       setSelectedListing(initialListing);
-      resolvedSlugRef.current = listingSlug;
-      resolvedTableRef.current = tableName;
-      setOptimisticListingId(initialListing.id ?? null);
+      setSelectedListingId(initialListing.id ?? null);
+      setIsSelectedListingLoading(false);
       return;
     }
 
-    if (
-      resolvedSlugRef.current === listingSlug &&
-      resolvedTableRef.current === tableName
-    ) {
+    const cachedListing = getCachedListing(listingSlug);
+    if (cachedListing) {
+      setSelectedListing(cachedListing);
+      setSelectedListingId(cachedListing.id ?? null);
+      setIsSelectedListingLoading(false);
       return;
     }
 
-    fetchBySlug(listingSlug);
-  }, [fetchBySlug, initialListing, initialListingSlug, listingSlug, tableName]);
+    setSelectedListing(null);
+    setSelectedListingId(null);
+    setIsSelectedListingLoading(true);
+    void fetchBySlug(listingSlug);
+  }, [
+    fetchBySlug,
+    getCachedListing,
+    initialListing,
+    initialListingSlug,
+    listingSlug,
+    tableName,
+  ]);
 
-  const selectListingById = useCallback(
-    async (id: number) => {
-      // Capture the pin id of the drawer's current resolved listing before
-      // the optimistic change, so we can restore it if the fetch fails.
-      const previousResolvedId = resolvedListingIdRef.current;
+  useEffect(() => {
+    if (!isListingSelected) {
+      setDocumentTitle(null);
+      return;
+    }
 
-      // Tap → pin grows immediately, even before the network round-trip.
-      setOptimisticListingId(id);
-      const token = ++requestTokenRef.current;
+    if (isListing(selectedListing)) {
+      setDocumentTitle(selectedListing);
+      return;
+    }
 
-      try {
-        const { data, error } = await supabase
-          .from(tableName)
-          .select()
-          .eq("id", id)
-          .single();
+    setDocumentTitle(null);
+  }, [isListingSelected, selectedListing, setDocumentTitle]);
 
-        if (token !== requestTokenRef.current) return;
+  const selectListing = useCallback(
+    (listing: ListingMarker) => {
+      requestTokenRef.current += 1;
+      activeSlugRef.current = listing.slug;
+      activeTableRef.current = tableName;
 
-        if (error || !data) {
-          // Tap-driven fetches happen before the URL is pushed, so surfacing
-          // an error sentinel here would either be invisible (no listing in
-          // URL → drawer stays closed) or desync the UI from the URL (still
-          // pointing at the previous listing). Revert the optimistic pin to
-          // whatever the drawer is currently showing and leave
-          // `selectedListing` alone.
-          console.warn("Failed to select listing by id:", error);
-          setOptimisticListingId(previousResolvedId);
-          return;
-        }
+      setIsListingSelected(true);
+      setSelectedListingId(listing.id);
 
-        const listing = data as Listing;
-        setSelectedListing(listing);
-        const slug = listing.slug;
-
-        if (slug) {
-          // Claim this slug so the URL sync effect doesn't refetch.
-          resolvedSlugRef.current = slug;
-          resolvedTableRef.current = tableName;
-          router.push(`/map?listing=${slug}`, { scroll: false });
-        }
-      } catch (err) {
-        if (token !== requestTokenRef.current) return;
-        console.warn("Failed to select listing by id:", err);
-        setOptimisticListingId(previousResolvedId);
+      const cachedListing = getCachedListing(listing.slug);
+      if (cachedListing) {
+        setSelectedListing(cachedListing);
+        setIsSelectedListingLoading(false);
+      } else {
+        setSelectedListing(null);
+        setIsSelectedListingLoading(true);
+        void fetchBySlug(listing.slug, listing.id);
       }
+
+      window.history.pushState(
+        null,
+        "",
+        `/map?listing=${encodeURIComponent(listing.slug)}`
+      );
     },
-    [router, supabase, tableName]
+    [fetchBySlug, getCachedListing, tableName]
   );
 
   const closeListing = useCallback(() => {
-    // Invalidate any in-flight fetches so their late responses don't reopen
-    // the drawer.
     requestTokenRef.current += 1;
-    resolvedSlugRef.current = null;
-    resolvedTableRef.current = null;
-    setOptimisticListingId(null);
-    router.push("/map", { scroll: false });
-  }, [router]);
+    activeSlugRef.current = null;
+    activeTableRef.current = null;
 
-  // Pin selection is driven entirely by the optimistic id, which is set on
-  // tap and cleared whenever the URL loses its listing slug (including on
-  // browser back/forward). `selectedListing` may stick around during the
-  // drawer close animation but the pin snaps back immediately, matching the
-  // prior behaviour.
-  const selectedListingId = optimisticListingId;
+    setIsListingSelected(false);
+    setSelectedListingId(null);
+    setIsSelectedListingLoading(false);
+    setDocumentTitle(null);
+
+    window.history.pushState(null, "", "/map");
+  }, [setDocumentTitle]);
 
   return {
     listingSlug,
     selectedListing,
     selectedListingId,
-    isListingSelected: Boolean(listingSlug),
-    selectListingById,
+    isListingSelected,
+    isSelectedListingLoading,
+    selectListing,
     closeListing,
   };
 }

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -62,6 +62,7 @@ export function isListing(
 /** Shape returned by the `listings_in_view` RPC — map markers only. */
 export type ListingMarker = {
   id: number;
+  slug: string;
   type: ListingType | null;
   coordinates: ListingCoordinates | null;
 };

--- a/supabase/migrations/20260419093000_drop_duplicate_listing_coordinates.sql
+++ b/supabase/migrations/20260419093000_drop_duplicate_listing_coordinates.sql
@@ -102,7 +102,7 @@ create or replace function public.listings_in_view(
   min_long double precision,
   max_lat double precision,
   max_long double precision
-) returns table(id bigint, type text, coordinates jsonb)
+) returns table(id bigint, slug text, type text, coordinates jsonb)
 language plpgsql
 security definer
 set search_path = ''
@@ -111,6 +111,7 @@ begin
   return query
   select
     listings.id,
+    listings.slug,
     listings.type,
     jsonb_build_object(
       'latitude', extensions.st_y(listings.location::extensions.geometry),


### PR DESCRIPTION
## Summary

- decouple map drawer open/close from App Router navigation so marker taps and deselection feel immediate again
- add slug-based listing caching and explicit drawer loading states for cold listing fetches
- move the loading lozenge to the top-centre, update map selection state handling, and stabilise the unread-messages Supabase client

## Testing

- `npm run i18n:check`
- `npm run check`
- `npx tsc --noEmit`
- `npm run build`

## Notes

- I attempted browser automation afterwards, but the local Playwright MCP setup failed before navigation with `ENOENT: no such file or directory, mkdir '/.playwright-mcp'`, so this is build-verified rather than browser-verified.