### PR TITLE
hotfix map marker slug on prod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,11 @@ These instructions apply to the whole repository.
 - Run `npm run i18n:check` after editing messages. Run `npm run check` before handing work back.
 - Do not put dynamic user-generated content, internal enum values, table names, route constants, CSS strings, logs, or analytics identifiers into message files.
 - For listing types and other enums, pass stable keys such as `business`, `community`, or `residential` and handle display grammar in translations, usually with ICU `select`.
+
+## Supabase
+
+- Treat `supabase/migrations/` as append-only once a migration has landed on any shared environment.
+- Do not edit an existing historical migration to change live schema behaviour on staging or production. That only affects fresh or reset environments.
+- When changing database schema, functions, views, policies, triggers, or grants, add a new forward migration instead.
+- If a previous migration introduced the object you need to change, use a new migration with `create or replace`, `alter`, or the appropriate forward-only SQL rather than modifying the old file.
+- If you are unsure whether a migration has already been applied anywhere shared, assume that it has and create a new migration.

--- a/src/features/map/hooks/useMapListingUrl.ts
+++ b/src/features/map/hooks/useMapListingUrl.ts
@@ -296,6 +296,14 @@ export function useMapListingUrl({
 
   const selectListing = useCallback(
     (listing: ListingMarker) => {
+      if (!listing.slug) {
+        console.warn(
+          "Cannot select map listing because the marker payload is missing a slug.",
+          listing
+        );
+        return;
+      }
+
       requestTokenRef.current += 1;
       activeSlugRef.current = listing.slug;
       activeTableRef.current = tableName;

--- a/supabase/migrations/20260420124500_return_slug_from_listings_in_view.sql
+++ b/supabase/migrations/20260420124500_return_slug_from_listings_in_view.sql
@@ -1,0 +1,45 @@
+create or replace function public.listings_in_view(
+  min_lat double precision,
+  min_long double precision,
+  max_lat double precision,
+  max_long double precision
+) returns table(id bigint, slug text, type text, coordinates jsonb)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  return query
+  select
+    listings.id,
+    listings.slug,
+    listings.type,
+    jsonb_build_object(
+      'latitude', extensions.st_y(listings.location::extensions.geometry),
+      'longitude', extensions.st_x(listings.location::extensions.geometry)
+    ) as coordinates
+  from public.listings
+  where listings.visibility = true
+    and listings.location OPERATOR(extensions.&&) extensions.st_makeenvelope(
+      min_long,
+      min_lat,
+      max_long,
+      max_lat,
+      4326
+    )::extensions.geography;
+end;
+$$;
+
+alter function public.listings_in_view(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+) owner to postgres;
+
+grant all on function public.listings_in_view(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+) to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

- add a forward Supabase migration that updates `public.listings_in_view` to return `slug` for existing environments
- guard the map selection flow so malformed marker payloads can't navigate to `/map?listing=undefined`

## Testing

- `npx tsc --noEmit`
- `npm run check`

## Why

Prod had already applied the older migration that defines `listings_in_view`, so editing that historical migration only affected fresh/reset environments. This PR applies the required function change to existing databases.