### PR TITLE
lighten PR checks

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -29,6 +29,7 @@ jobs:
         run: npm run check
 
       - name: Build app
+        if: github.event_name == 'pull_request'
         run: npm run build
 
   e2e-prod:

--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -78,9 +78,6 @@ jobs:
       - name: Seed local demo media
         run: npm run seed:local-media
 
-      - name: Build app for production-mode smoke test
-        run: npm run build
-
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Build app
         run: npm run build
 
-  e2e:
+  e2e-prod:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    needs: check
     permissions:
       contents: read
 
@@ -76,11 +78,14 @@ jobs:
       - name: Seed local demo media
         run: npm run seed:local-media
 
+      - name: Build app for production-mode smoke test
+        run: npm run build
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright smoke tests
-        run: npm run test:e2e
+      - name: Run Playwright production smoke tests
+        run: npm run test:e2e:prod
 
       - name: Upload Playwright artefacts
         if: failure()

--- a/README.md
+++ b/README.md
@@ -222,9 +222,12 @@ Peels keeps testing intentionally small:
 
 - `npm run check` for i18n and formatting checks
 - `npm run build` for the production build
-- `npm run test:e2e` for the headless Playwright smoke suite
+- `npm run test:e2e` for the local headless Playwright smoke suite
+- `npm run test:e2e:prod` for the production-like Playwright smoke suite
 
 The smoke suite covers seeded sign-in, public listing, profile, and chat flows against local Supabase data. It is designed to stay small and high-signal rather than grow into a broad frontend testing matrix.
+
+In CI, pull requests run `npm run check` and `npm run build`. Pushes to `main` also run the production-like Playwright smoke suite.
 
 For the first local Playwright run, install the browser once with:
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n:check": "node scripts/check-i18n-messages.mjs",
     "check": "npm run i18n:check && npm run format:check",
     "test:e2e": "playwright test",
+    "pretest:e2e:prod": "npm run build",
     "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",
     "test:e2e:debug": "playwright test --headed --workers=1",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "i18n:check": "node scripts/check-i18n-messages.mjs",
     "check": "npm run i18n:check && npm run format:check",
     "test:e2e": "playwright test",
-    "pretest:e2e:prod": "npm run build",
+    "pretest:e2e:prod": "if [ -d .next ]; then echo '.next exists, skipping build'; else npm run build; fi",
     "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",
     "test:e2e:debug": "playwright test --headed --workers=1",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n:check": "node scripts/check-i18n-messages.mjs",
     "check": "npm run i18n:check && npm run format:check",
     "test:e2e": "playwright test",
+    "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",
     "test:e2e:debug": "playwright test --headed --workers=1",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,39 +1,10 @@
 import { defineConfig } from "@playwright/test";
-
-const baseURL = "http://127.0.0.1:3000";
+import { sharedPlaywrightConfig, sharedWebServer } from "./playwright.shared";
 
 export default defineConfig({
-  testDir: "./e2e",
-  fullyParallel: false,
-  workers: 1,
-  forbidOnly: !!process.env.CI,
-  reporter: process.env.CI ? "github" : "list",
-  use: {
-    baseURL,
-    headless: true,
-    locale: "en-AU",
-    launchOptions:
-      process.platform === "darwin" ? { chromiumSandbox: true } : undefined,
-    extraHTTPHeaders: {
-      "Accept-Language": "en-AU,en;q=0.9",
-    },
-    trace: "retain-on-failure",
-    video: "retain-on-failure",
-    screenshot: "only-on-failure",
-    viewport: {
-      width: 1280,
-      height: 900,
-    },
-  },
+  ...sharedPlaywrightConfig,
   webServer: {
+    ...sharedWebServer,
     command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
   },
-  projects: [
-    {
-      name: "chromium",
-    },
-  ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,9 +12,8 @@ export default defineConfig({
     baseURL,
     headless: true,
     locale: "en-AU",
-    launchOptions: {
-      chromiumSandbox: process.platform === "darwin",
-    },
+    launchOptions:
+      process.platform === "darwin" ? { chromiumSandbox: true } : undefined,
     extraHTTPHeaders: {
       "Accept-Language": "en-AU,en;q=0.9",
     },

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
     baseURL,
     headless: true,
     locale: "en-AU",
-    launchOptions: {
-      chromiumSandbox: process.platform === "darwin",
-    },
     extraHTTPHeaders: {
       "Accept-Language": "en-AU,en;q=0.9",
     },
@@ -27,7 +24,7 @@ export default defineConfig({
     },
   },
   webServer: {
-    command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    command: "npm run start -- --hostname 127.0.0.1 --port 3000",
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -1,39 +1,10 @@
 import { defineConfig } from "@playwright/test";
-
-const baseURL = "http://127.0.0.1:3000";
+import { sharedPlaywrightConfig, sharedWebServer } from "./playwright.shared";
 
 export default defineConfig({
-  testDir: "./e2e",
-  fullyParallel: false,
-  workers: 1,
-  forbidOnly: !!process.env.CI,
-  reporter: process.env.CI ? "github" : "list",
-  use: {
-    baseURL,
-    headless: true,
-    locale: "en-AU",
-    launchOptions:
-      process.platform === "darwin" ? { chromiumSandbox: true } : undefined,
-    extraHTTPHeaders: {
-      "Accept-Language": "en-AU,en;q=0.9",
-    },
-    trace: "retain-on-failure",
-    video: "retain-on-failure",
-    screenshot: "only-on-failure",
-    viewport: {
-      width: 1280,
-      height: 900,
-    },
-  },
+  ...sharedPlaywrightConfig,
   webServer: {
+    ...sharedWebServer,
     command: "npm run start -- --hostname 127.0.0.1 --port 3000",
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
   },
-  projects: [
-    {
-      name: "chromium",
-    },
-  ],
 });

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     baseURL,
     headless: true,
     locale: "en-AU",
+    launchOptions:
+      process.platform === "darwin" ? { chromiumSandbox: true } : undefined,
     extraHTTPHeaders: {
       "Accept-Language": "en-AU,en;q=0.9",
     },

--- a/playwright.shared.ts
+++ b/playwright.shared.ts
@@ -1,0 +1,43 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const baseURL = "http://127.0.0.1:3000";
+
+const sharedPlaywrightUse: PlaywrightTestConfig["use"] = {
+  baseURL,
+  headless: true,
+  locale: "en-AU",
+  launchOptions:
+    process.platform === "darwin" ? { chromiumSandbox: true } : undefined,
+  extraHTTPHeaders: {
+    "Accept-Language": "en-AU,en;q=0.9",
+  },
+  trace: "retain-on-failure",
+  video: "retain-on-failure",
+  screenshot: "only-on-failure",
+  viewport: {
+    width: 1280,
+    height: 900,
+  },
+};
+
+const sharedPlaywrightConfig = {
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? "github" : "list",
+  use: sharedPlaywrightUse,
+  projects: [
+    {
+      name: "chromium",
+    },
+  ],
+} satisfies Omit<PlaywrightTestConfig, "webServer">;
+
+const sharedWebServer = {
+  url: baseURL,
+  reuseExistingServer: !process.env.CI,
+  timeout: 120_000,
+};
+
+export { sharedPlaywrightConfig, sharedWebServer };


### PR DESCRIPTION
## Summary
- remove automatic browser testing from pull requests
- move browser smoke coverage to a production-like main-only workflow
- add a separate Playwright config for production-mode smoke checks
- enable Chromium sandboxing on macOS for local Playwright runs

## Verification
- `npm run check`
- `npm run build`
- `npx playwright test --config=playwright.prod.config.ts --list`