### PR TITLE
extend Peels i18n across app, content, and emails

### DIFF
--- a/.github/workflows/validate-supabase.yml
+++ b/.github/workflows/validate-supabase.yml
@@ -43,4 +43,8 @@ jobs:
 
       - name: Replay migrations and seed data
         if: steps.changes.outputs.supabase == 'true'
-        run: supabase db reset
+        run: |
+          supabase db reset || {
+            echo "supabase db reset failed once; retrying after transient restart error..."
+            supabase db reset --debug
+          }

--- a/README.md
+++ b/README.md
@@ -216,6 +216,43 @@ npm run dev
 - Heavy commenting is encouraged to make the codebase accessible to others
 - Code formatting is handled by Prettier. Please ensure your code is formatted according to `.prettierrc` before submitting a pull request
 
+### Languages and Localised Content
+
+Peels now keeps its product translations fully in-repo with `next-intl`. English lives in `messages/en.json` and is the source catalogue. Whenever you add or change user-facing UI copy, update `en` first and keep `es` and `de` complete alongside it. `fr` and `pt-BR` are also supported locales and should be updated when the change affects translated surfaces that already exist.
+
+For app UI and metadata:
+
+- Put translatable UI copy in `messages/*.json`
+- Run `npm run i18n:check` after editing message files
+- Run `npm run check` before handing work back
+- Do not put internal enum values, route constants, analytics identifiers, or user-generated content into message files
+
+For newsletter issues:
+
+- The English source issue lives at `src/content/newsletter/<slug>.mdx`
+- Locale-specific issue wrappers or translations live at `src/content/newsletter/<locale>/<slug>.mdx`
+- A locale-specific issue file can either contain a full translation or a lighter wrapper with translated metadata plus an explicit fallback notice before the English body
+- `metadata` and `customMetadata` still need to be present for each locale-specific issue file so the newsletter index, issue page, and RSS feed can show the correct localised title and description
+- RSS is generated from `/newsletter/feed.xml?locale=<locale>`, so locale-specific metadata will flow through to the feed automatically
+
+For legal and reference pages:
+
+- The English source page lives at `src/content/legal/<slug>.mdx`
+- Locale-specific versions live at `src/content/legal/<locale>/<slug>.mdx`
+- Legal translations should be treated as reviewed content, not casual copy changes
+- If a locale-specific file does not exist yet, Peels falls back to English and shows a translation notice on the page
+
+For newsletter issue emails:
+
+- The current issue email config lives in `supabase/functions/_shared/newsletter.ts`
+- When sending a new issue, update the current issue slug, issue number, and per-locale title/description there
+- The transactional/broadcast email body is now a locale-aware issue announcement in `supabase/functions/_templates/newsletter-issue-email.tsx`, which links people to the web version of the issue
+- Signed-in members receive the newsletter email in their saved locale where available, with auth metadata and English fallback covering older environments
+- External broadcast audiences can be split by locale with `NEWSLETTER_AUDIENCE_ID_EN`, `NEWSLETTER_AUDIENCE_ID_ES`, `NEWSLETTER_AUDIENCE_ID_DE`, `NEWSLETTER_AUDIENCE_ID_PT_BR`, and `NEWSLETTER_AUDIENCE_ID_FR`
+- If only the English Resend audience is configured, only the English broadcast will send
+
+In plain English: new UI strings belong in `messages/`, longform newsletter and legal content belongs in locale-aware MDX files under `src/content/`, and newsletter emails need the current issue config updated in `supabase/functions/_shared/newsletter.ts` before sending.
+
 ### Testing
 
 Peels keeps testing intentionally small:
@@ -284,7 +321,7 @@ Check out the [Next.js and Supabase Starter Kit](https://github.com/supabase/sup
 
 - Built with [Next.js](https://nextjs.org)
 - Authentication and database by [Supabase](https://supabase.com)
-- Translations powered by [next-intl](https://next-intl.dev/) and [Crowdin](https://crowdin.com/)
+- Translations powered by [next-intl](https://next-intl.dev/) with in-repo message catalogues under `messages/`
 - Maps powered by [MapTiler](https://www.maptiler.com) and [Protomaps](https://protomaps.com)
 - Styled components built with [Pigment CSS](https://github.com/mui/pigment-css)
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,0 @@
-files:
-  - source: /messages/en.json
-    translation: /messages/%two_letters_code%.json # Default: %locale%.json, which produces es-ES, de-DE etc

--- a/messages/de.json
+++ b/messages/de.json
@@ -117,6 +117,8 @@
   "Index": {
     "title": "Finde ein Zuhause für deine Küchenabfälle, wo auch immer du bist",
     "subtitle": "Peels verbindet die Menschen mit Lebensmittelkratzern mit denen, die komponieren. Es ist ein kostenloses und nicht-kommerzielles Gemeinschaftsprojekt.",
+    "metaDescription": "Peels verbindet Menschen mit Lebensmittelresten mit denjenigen, die kompostieren. Es ist ein kostenloses, nicht-kommerzielles Gemeinschaftsprojekt.",
+    "metaKeywords": "Lebensmittelabfall, Essensreste, Kompost, Kompost in meiner Nähe, Kompost-Abgabestelle, Abgabe von Lebensmittelresten",
     "hostAvatarAlt": "Der Avatar eines Peels-Gastgebers",
     "buttons": {
       "browseMap": "Karte durchsuchen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -44,6 +44,8 @@
     "admin": "Admin",
     "email": "E-Mail",
     "hidden": "Ausgeblendet",
+    "language": "Sprache",
+    "languageHint": "Besucherinnen und Besucher können die Sprache hier wechseln. Angemeldete Mitglieder können zusätzlich eine Standardsprache in ihrem Konto speichern.",
     "links": "Links",
     "listings": "Einträge",
     "loading": "Lädt...",
@@ -183,6 +185,7 @@
       "firstNameHint": "Verwende deinen Vornamen oder einen Spitznamen.",
       "emailSuccess": "Prüfe deine E-Mails für den Bestätigungslink.",
       "emailHint": "Wir senden einen Bestätigungslink an diese E-Mail.",
+      "languageHint": "Wähle die Standardsprache, die Peels und deine Konto-E-Mails verwenden sollen.",
       "newsletterSubscribedHint": "Wir senden dir gelegentliche E-Mail-Updates über Peels.",
       "newsletterNotSubscribedHint": "Wir senden dir nur notwendige E-Mails zu deinem Konto oder deinen Einträgen."
     },
@@ -358,6 +361,9 @@
   },
   "Legal": {
     "agreement": "Ich habe die Peels-<terms>Nutzungsbedingungen</terms> und die <privacy>Datenschutzerklärung</privacy> gelesen und stimme ihnen zu",
+    "fallbackTitle": "Diese Seite ist derzeit nur auf Englisch verfügbar",
+    "fallbackBody": "Wir übersetzen einige unserer rechtlichen und referenzbezogenen Seiten noch. Vorerst ist die vollständige Seite unten auf Englisch verfügbar.",
+    "lastUpdated": "Zuletzt aktualisiert am {date}",
     "privacy": "Datenschutz",
     "terms": "Bedingungen"
   },
@@ -405,13 +411,18 @@
   },
   "Newsletter": {
     "title": "Newsletter",
+    "description": "Gelegentliche Neuigkeiten darüber, wie Peels gemeinschaftliches Kompostieren auf der ganzen Welt unterstützt.",
     "inboxTitle": "Direkt in dein Postfach",
     "inboxDescription": "Aktiviere den Empfang künftiger Newsletter-Ausgaben per E-Mail.",
     "rss": "Oder abonniere den <link>RSS-Feed</link>.",
     "latestIssue": "Neueste Ausgabe",
     "pastIssues": "Frühere Ausgaben",
     "issueSubtitle": "Ausgabe #{number} · Veröffentlicht am {date}",
+    "issueTile": "Ausgabe #{number} · {date}",
     "parent": "Newsletter",
+    "fallbackTitle": "Diese Ausgabe ist derzeit nur auf Englisch verfügbar",
+    "fallbackBody": "Wir arbeiten noch an Übersetzungen der Newsletter-Ausgaben. Bis dahin ist die vollständige Ausgabe unten die englische Version.",
+    "readFullIssue": "Diese vollständige Ausgabe auf Peels lesen",
     "stampAlt": "Eine Briefmarke",
     "aside": {
       "title": "Über diesen Newsletter",
@@ -450,8 +461,8 @@
         "answer": "Peels is a non-commercial, community-led project. We may incorporate as a not-for-profit in the future and accept grant funding or sponsorships for further development, but we never intend to start charging for the service."
       },
       "fogo": {
-        "question": "I have a FOGO bin. Is community composting still relevant?",
-        "answer": "Lucky you! Unfortunately, you’re in the minority. Most people don’t yet have access to kerbside compost collection. As long as that’s the case, there’ll be a need for community composting resources."
+        "question": "Ich habe bereits eine kommunale Sammlung für Lebensmittelreste. Ist gemeinschaftliches Kompostieren trotzdem relevant?",
+        "answer": "Ja. Viele Menschen haben noch immer keinen verlässlichen Zugang zu einer Sammlung von Lebensmittelresten, und gemeinschaftliches Kompostieren kann ausserdem lokaler, sozialer und lehrreicher sein als ein stadtweites Angebot. Peels soll sowohl Orte mit bestehender Sammlung als auch Orte unterstützen, die so ein Angebot erst noch aufbauen."
       },
       "mapPrivacy": {
         "question": "I’m not comfortable putting my address on a map. Can I still participate?",
@@ -462,12 +473,12 @@
         "answer": "<p>You’re awesome. Thank you.</p><p>If you’re inclined to help on the technical side, check out our <repo>GitHub repo</repo>. It has information on how to contribute, plus some existing issues that could do with your eyes.</p> <p>Community organising is also a big part of getting Peels off the ground. Please don’t hesistate to <email>email us</email> if that’s something you could help with.</p>"
       },
       "promotion": {
-        "question": "How can I promote Peels to my community?",
-        "answer": "<p>First off, thank you! Peels only works with a thriving map of listings, so getting the word out is crucial.</p><p>Check out our <promoKit>promo kit</promoKit> which includes social media tiles and and a printable poster in bothletter and A4 sizes. Don’t hesistate to <email>reach out</email> for something more specific to your community.</p>"
+        "question": "Wie kann ich Peels in meiner Community bekannt machen?",
+        "answer": "<p>Erst einmal: Danke! Peels funktioniert nur mit einer lebendigen Karte voller Einträge, deshalb ist Weiterempfehlen so wichtig.</p><p>Schau dir unser <promoKit>Promo-Kit</promoKit> an. Es enthält Social-Media-Grafiken und druckbare Poster im US-Letter- und A4-Format. <email>Melde dich gern</email>, wenn du etwas Spezifischeres für deine Community brauchst.</p>"
       },
       "government": {
-        "question": "I represent local or state government. How can I get involved?",
-        "answer": "<p>We’ve already partnered with councils from all over Australia, and are always keen to work with more (around the world, too!). Please <email>email us</email>.</p>"
+        "question": "Ich vertrete eine lokale oder regionale Behörde. Wie kann ich mich einbringen?",
+        "answer": "<p>Wir arbeiten gern mit öffentlichen Stellen, Gemeinschaftsorganisationen und Bildungsinitiativen zusammen, überall dort, wo Peels dabei helfen kann, mehr Lebensmittelreste vor der Deponie zu bewahren. Bitte <email>schreib uns</email>.</p>"
       }
     },
     "supportFaq": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -117,6 +117,8 @@
   "Index": {
     "title": "Find a home for your food scraps, wherever you are",
     "subtitle": "Peels connects folks with food scraps to those who compost. It’s a free, non-commercial, community project.",
+    "metaDescription": "Peels connects folks with food scraps to those who compost. It’s a free, non-commercial, community project.",
+    "metaKeywords": "food waste, food scraps, share waste, sharewaste, makesoil, compost near me, compost drop-off, food scrap drop-off",
     "hostAvatarAlt": "The avatar for a Peels host",
     "buttons": {
       "browseMap": "Browse the map",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,6 +44,8 @@
     "admin": "Admin",
     "email": "Email",
     "hidden": "Hidden",
+    "language": "Language",
+    "languageHint": "Guests can switch language here. Signed-in members can also save a default language in their account settings.",
     "links": "Links",
     "listings": "Listings",
     "loading": "Loading...",
@@ -183,6 +185,7 @@
       "firstNameHint": "Use your first name or a nickname.",
       "emailSuccess": "Check your email for the verification link.",
       "emailHint": "We’ll send a verification link to this email.",
+      "languageHint": "Choose the default language you want Peels and account emails to use.",
       "newsletterSubscribedHint": "We’ll send you occasional email updates about Peels.",
       "newsletterNotSubscribedHint": "We’ll only send you necessary account or listing-related emails."
     },
@@ -358,6 +361,9 @@
   },
   "Legal": {
     "agreement": "I have read and agree to the Peels <terms>terms of use</terms> and <privacy>privacy policy</privacy>",
+    "fallbackTitle": "This page is currently available in English",
+    "fallbackBody": "We’re still translating some of our legal and reference pages. For now, the full page below is the English version.",
+    "lastUpdated": "Last updated {date}",
     "privacy": "Privacy",
     "terms": "Terms"
   },
@@ -405,13 +411,18 @@
   },
   "Newsletter": {
     "title": "Newsletter",
+    "description": "Occasional updates on how Peels is supporting community composting around the world.",
     "inboxTitle": "Get these in your inbox",
     "inboxDescription": "Opt-in to receive future issues of the newsletter via email.",
     "rss": "Or subscribe to the <link>RSS feed</link>.",
     "latestIssue": "Latest issue",
     "pastIssues": "Past issues",
     "issueSubtitle": "Issue #{number} · Published {date}",
+    "issueTile": "Issue #{number} · {date}",
     "parent": "Newsletter",
+    "fallbackTitle": "This issue is currently available in English",
+    "fallbackBody": "We’re still translating newsletter issues. For now, the full issue below is the English version.",
+    "readFullIssue": "Read this full issue on Peels",
     "stampAlt": "A postage stamp",
     "aside": {
       "title": "About this newsletter",
@@ -450,8 +461,8 @@
         "answer": "Peels is a non-commercial, community-led project. We may incorporate as a not-for-profit in the future and accept grant funding or sponsorships for further development, but we never intend to start charging for the service."
       },
       "fogo": {
-        "question": "I have a FOGO bin. Is community composting still relevant?",
-        "answer": "Lucky you! Unfortunately, you’re in the minority. Most people don’t yet have access to kerbside compost collection. As long as that’s the case, there’ll be a need for community composting resources."
+        "question": "I already have municipal food-scrap collection. Is community composting still relevant?",
+        "answer": "Absolutely. Many people still don’t have access to reliable food-scrap collection, and community composting can also be more local, social, and educational than a council or city-wide service. Peels is designed to support both the places that already have collection and the places still building it."
       },
       "mapPrivacy": {
         "question": "I’m not comfortable putting my address on a map. Can I still participate?",
@@ -463,11 +474,11 @@
       },
       "promotion": {
         "question": "How can I promote Peels to my community?",
-        "answer": "<p>First off, thank you! Peels only works with a thriving map of listings, so getting the word out is crucial.</p><p>Check out our <promoKit>promo kit</promoKit> which includes social media tiles and and a printable poster in bothletter and A4 sizes. Don’t hesistate to <email>reach out</email> for something more specific to your community.</p>"
+        "answer": "<p>First off, thank you! Peels only works with a thriving map of listings, so getting the word out is crucial.</p><p>Check out our <promoKit>promo kit</promoKit> which includes social media tiles and printable posters in both US letter and A4 sizes. Don’t hesitate to <email>reach out</email> if you need something more specific for your community.</p>"
       },
       "government": {
-        "question": "I represent local or state government. How can I get involved?",
-        "answer": "<p>We’ve already partnered with councils from all over Australia, and are always keen to work with more (around the world, too!). Please <email>email us</email>.</p>"
+        "question": "I represent local or regional government. How can I get involved?",
+        "answer": "<p>We’re keen to work with public-sector teams, community organisations, and educators anywhere Peels can help more people keep food scraps out of landfill. Please <email>email us</email>.</p>"
       }
     },
     "supportFaq": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -44,6 +44,8 @@
     "admin": "Administración",
     "email": "Correo electrónico",
     "hidden": "Oculto",
+    "language": "Idioma",
+    "languageHint": "Aquí las personas que visitan Peels pueden cambiar el idioma. Quienes inician sesión también pueden guardar un idioma predeterminado en su cuenta.",
     "links": "Enlaces",
     "listings": "Anuncios",
     "loading": "Cargando...",
@@ -183,6 +185,7 @@
       "firstNameHint": "Usa tu nombre o un apodo.",
       "emailSuccess": "Revisa tu correo para ver el enlace de verificación.",
       "emailHint": "Enviaremos un enlace de verificación a este correo.",
+      "languageHint": "Elige el idioma predeterminado que quieres que usen Peels y los correos de tu cuenta.",
       "newsletterSubscribedHint": "Te enviaremos actualizaciones ocasionales por correo sobre Peels.",
       "newsletterNotSubscribedHint": "Solo te enviaremos correos necesarios relacionados con tu cuenta o tus anuncios."
     },
@@ -358,6 +361,9 @@
   },
   "Legal": {
     "agreement": "He leído y acepto los <terms>términos de uso</terms> y la <privacy>política de privacidad</privacy> de Peels",
+    "fallbackTitle": "Esta página solo está disponible en inglés por ahora",
+    "fallbackBody": "Todavía estamos traduciendo algunas de nuestras páginas legales y de referencia. Por ahora, la página completa de abajo está en inglés.",
+    "lastUpdated": "Última actualización: {date}",
     "privacy": "Privacidad",
     "terms": "Términos"
   },
@@ -405,13 +411,18 @@
   },
   "Newsletter": {
     "title": "Boletín",
+    "description": "Actualizaciones ocasionales sobre cómo Peels impulsa el compostaje comunitario en distintos lugares del mundo.",
     "inboxTitle": "Recíbelo en tu correo",
     "inboxDescription": "Activa la opción para recibir futuros números del boletín por correo.",
     "rss": "O suscríbete al <link>feed RSS</link>.",
     "latestIssue": "Último número",
     "pastIssues": "Números anteriores",
     "issueSubtitle": "Número #{number} · Publicado el {date}",
+    "issueTile": "Número #{number} · {date}",
     "parent": "Boletín",
+    "fallbackTitle": "Este número solo está disponible en inglés por ahora",
+    "fallbackBody": "Todavía estamos traduciendo los números del boletín. Por ahora, la edición completa que aparece abajo está en inglés.",
+    "readFullIssue": "Leer este número completo en Peels",
     "stampAlt": "Un sello postal",
     "aside": {
       "title": "Acerca de este boletín",
@@ -450,8 +461,8 @@
         "answer": "Peels es un proyecto no comercial dirigido por la comunidad. Podemos incorporar como una organización sin ánimo de lucro en el futuro y aceptar subvenciones o patrocinios para futuros desarrollos pero nunca pretendemos empezar a cobrar por el servicio."
       },
       "fogo": {
-        "question": "Tengo una papelera de FOGO, ¿sigue siendo relevante la composición de la comunidad?",
-        "answer": "¡Suerte! Desafortunadamente, eres una minoría. La mayoría de la gente todavía no tiene acceso a la colección de compost bordado. Mientras sea así, se necesitarán recursos comunitarios de composición."
+        "question": "Ya tengo recogida municipal de restos de comida. ¿Sigue siendo relevante el compostaje comunitario?",
+        "answer": "Sí. Mucha gente todavía no tiene acceso a un servicio fiable de recogida de restos de comida, y el compostaje comunitario también puede ser más local, social y educativo que un servicio municipal o de ciudad. Peels está pensado para apoyar tanto a los lugares que ya cuentan con recogida como a los que todavía la están construyendo."
       },
       "mapPrivacy": {
         "question": "No me siento cómodo poniendo mi dirección en un mapa. ¿Puedo participar todavía?",
@@ -463,11 +474,11 @@
       },
       "promotion": {
         "question": "¿Cómo puedo promocionar Peels a mi comunidad?",
-        "answer": "<p>¡Primero que nada, gracias! Peels solo trabaja con un impresionante mapa de listados, así que sacar la palabra es crucial.</p><p>Echa un vistazo a nuestro <promoKit>kit promocional</promoKit> que incluye baldosas de redes sociales y un póster imprimible en tamaños A4 y ambos. No dudes en <email>alcanzar</email> para algo más específico para tu comunidad.</p>"
+        "answer": "<p>Antes que nada, ¡gracias! Peels solo funciona con un mapa vivo de anuncios, así que correr la voz es fundamental.</p><p>Echa un vistazo a nuestro <promoKit>kit promocional</promoKit>, que incluye piezas para redes sociales y pósteres imprimibles en tamaños A4 y US letter. No dudes en <email>escribirnos</email> si necesitas algo más específico para tu comunidad.</p>"
       },
       "government": {
-        "question": "Yo represento al gobierno local o estatal, ¿cómo puedo deshacerme?",
-        "answer": "<p>We’ve already partnered with councils from all over Australia, and are always keen to work with more (around the world, too!). Please <email>email us</email>.</p>"
+        "question": "Represento a un gobierno local o regional. ¿Cómo puedo participar?",
+        "answer": "<p>Nos interesa colaborar con equipos del sector público, organizaciones comunitarias y personas dedicadas a la educación ambiental allí donde Peels pueda ayudar a desviar más restos de comida del vertedero. <email>Escríbenos</email>.</p>"
       }
     },
     "supportFaq": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -117,6 +117,8 @@
   "Index": {
     "title": "Encuentra un hogar para tus restos de comida, estés donde estés",
     "subtitle": "Peels conecta a personas con restos de comida con quienes hacen compost. Es un proyecto comunitario, gratuito y sin fines de lucro.",
+    "metaDescription": "Peels conecta a personas con restos de comida con quienes hacen compost. Es un proyecto comunitario, gratuito y sin fines de lucro.",
+    "metaKeywords": "desperdicio alimentario, restos de comida, compost, compost cerca de mí, punto de compostaje, entrega de restos de comida",
     "hostAvatarAlt": "El avatar de un anfitrión de Peels",
     "buttons": {
       "browseMap": "Explorar el mapa",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,0 +1,514 @@
+{
+  "App": {
+    "map": "Carte",
+    "chats": "Messages",
+    "profile": "Profil",
+    "about": "À propos"
+  },
+  "Actions": {
+    "add": "Ajouter",
+    "addListing": "Ajouter une annonce",
+    "addMorePhotos": "Ajouter d’autres photos",
+    "addPhotos": "Ajouter des photos",
+    "backToPeels": "Retour à Peels",
+    "cancel": "Annuler",
+    "close": "Fermer",
+    "continue": "Continuer",
+    "delete": "Supprimer",
+    "deleteListing": "Supprimer l’annonce",
+    "done": "Terminé",
+    "edit": "Modifier",
+    "emailLink": "M’envoyer le lien par e-mail",
+    "exportData": "Exporter les données",
+    "home": "Accueil",
+    "joinPeels": "Rejoindre Peels",
+    "noCancel": "Non, annuler",
+    "openInAppleMaps": "Ouvrir dans Apple Maps",
+    "openInGoogleMaps": "Ouvrir dans Google Maps",
+    "replace": "Remplacer",
+    "resetPassword": "Réinitialiser le mot de passe",
+    "saveChanges": "Enregistrer les modifications",
+    "seeNearbyListings": "Voir les annonces à proximité",
+    "sendLink": "Envoyer le lien",
+    "signIn": "Se connecter",
+    "signInToContact": "Se connecter pour contacter",
+    "signOut": "Se déconnecter",
+    "signUp": "S’inscrire",
+    "update": "Mettre à jour",
+    "viewFullListing": "Voir l’annonce complète",
+    "viewListing": "Voir l’annonce"
+  },
+  "Common": {
+    "account": "Compte",
+    "actions": "Actions",
+    "admin": "Administration",
+    "email": "E-mail",
+    "hidden": "Masqué",
+    "language": "Langue",
+    "languageHint": "Les personnes qui visitent Peels peuvent changer la langue ici. Les membres connectés peuvent aussi enregistrer une langue par défaut dans les paramètres du compte.",
+    "links": "Liens",
+    "listings": "Annonces",
+    "loading": "Chargement...",
+    "newsletter": "Infolettre",
+    "notSubscribed": "Non abonné",
+    "optional": "optionnel",
+    "password": "Mot de passe",
+    "photos": "Photos",
+    "source": "Origine",
+    "stub": "Brouillon",
+    "subscribed": "Abonné"
+  },
+  "Status": {
+    "adding": "Ajout en cours...",
+    "copying": "Copie en cours...",
+    "deleting": "Suppression en cours...",
+    "emailing": "Envoi de l’e-mail...",
+    "resetting": "Réinitialisation...",
+    "saving": "Enregistrement...",
+    "sending": "Envoi...",
+    "signingIn": "Connexion...",
+    "signingOut": "Déconnexion...",
+    "signingUp": "Inscription...",
+    "updating": "Mise à jour...",
+    "uploading": "Téléversement...",
+    "verifying": "Vérification...",
+    "working": "Traitement..."
+  },
+  "Errors": {
+    "alreadyYourEmail": "C’est déjà votre adresse e-mail.",
+    "emptyListingName": "{type, select, business {Le nom du commerce ne peut pas être vide.} community {Le nom de la communauté ne peut pas être vide.} other {Le nom de l’annonce ne peut pas être vide.}}",
+    "emptyName": "Le nom ne peut pas être vide.",
+    "accountDeleted": "Votre compte a été supprimé. C’est dommage de vous voir partir.",
+    "accountExists": "Un compte existe déjà avec cette adresse e-mail. Connectez-vous à la place.",
+    "deleteAccountFailed": "Erreur lors de la suppression du compte",
+    "duplicateListing": "Une annonce identique existe déjà.",
+    "emailRequired": "L’adresse e-mail est obligatoire",
+    "failedDeleteListing": "Impossible de supprimer l’annonce.",
+    "failedDeletePhoto": "Impossible de supprimer la photo. Veuillez réessayer.",
+    "generic": "Hum, quelque chose ne va pas. Pouvez-vous réessayer ?",
+    "genericLater": "Une erreur s’est produite. Veuillez réessayer plus tard.",
+    "missingLocation": "Veuillez sélectionner un emplacement.",
+    "missingSignUpFields": "Un prénom, une adresse e-mail et un mot de passe sont requis.",
+    "passwordMismatch": "Ces mots de passe ne correspondent pas.",
+    "photoUploadFailed": "Une erreur s’est produite lors de l’envoi de vos photos. Veuillez réessayer.",
+    "avatarUploadFailed": "Une erreur s’est produite lors de l’envoi de votre photo. Veuillez réessayer.",
+    "requiredPasswordFields": "Ces deux champs sont obligatoires.",
+    "resetPasswordDenied": "Hum, quelque chose ne va pas. Vous n’avez peut-être pas l’autorisation de réinitialiser ce mot de passe ou vous avez tenté de réutiliser un mot de passe récent.",
+    "resetPasswordSuccess": "Votre mot de passe a été mis à jour. Retour au compostage !",
+    "savePhotosFailed": "L’annonce a été créée, mais les photos n’ont pas pu être enregistrées.",
+    "signUpFailed": "Échec de l’inscription",
+    "tooManyListings": "Vous avez atteint le nombre maximal d’annonces autorisées. Supprimez-en une parmi vos trois annonces actuelles pour en créer une nouvelle.",
+    "tooManyMessages": "Vous avez envoyé trop de messages. Veuillez réessayer plus tard.",
+    "tooManyThreads": "Vous avez lancé trop de nouvelles conversations au cours de la dernière heure. Veuillez réessayer plus tard.",
+    "firstNameTooShort": "Veuillez utiliser au moins 2 caractères pour votre prénom.",
+    "firstNameTooLong": "Les prénoms peuvent comporter au maximum 24 caractères.",
+    "firstNameNotAllowed": "Ce prénom n’est pas autorisé sur Peels.",
+    "firstNameInvalidChars": "Les prénoms ne peuvent contenir que des lettres, des espaces, des traits d’union et des apostrophes.",
+    "disposableEmailNotAllowed": "Veuillez utiliser une adresse e-mail durable plutôt qu’une boîte jetable.",
+    "updateEmailFailed": "Hum, quelque chose ne va pas. Vérifiez votre e-mail ou réessayez.",
+    "updateFirstNameFailed": "Désolé, nous n’avons pas pu mettre à jour votre prénom.",
+    "updateNewsletterFailed": "Désolé, nous n’avons pas pu mettre à jour votre préférence d’infolettre.",
+    "unexpected": "Une erreur inattendue s’est produite. Veuillez réessayer plus tard.",
+    "validationSummary": "Veuillez corriger {count, plural, one {l’erreur ci-dessus} other {les erreurs ci-dessus}} puis réessayer.",
+    "verificationChallenge": "Veuillez terminer la vérification de sécurité.",
+    "verificationFailed": "La vérification a échoué. Veuillez réessayer.",
+    "forgotPasswordSuccess": "Vérifiez votre boîte de réception (et vos spams) pour trouver un lien de réinitialisation du mot de passe, si cette adresse e-mail est bien liée à un compte Peels."
+  },
+  "Index": {
+    "title": "Trouvez une destination pour vos restes alimentaires, où que vous soyez",
+    "subtitle": "Peels met en relation des personnes qui ont des restes alimentaires avec celles qui compostent. C’est un projet communautaire gratuit et non commercial.",
+    "hostAvatarAlt": "L’avatar d’une personne hôte sur Peels",
+    "buttons": {
+      "browseMap": "Parcourir la carte",
+      "signUp": "S’inscrire sur Peels",
+      "addListing": "Ajouter une annonce"
+    },
+    "howItWorks": {
+      "title": "Voici comment ça marche",
+      "subtitle": "Partager des restes alimentaires avec des voisin·es, des jardins partagés ou même des commerces locaux, c’est simple. Voici comment.",
+      "footer": "C’est tout ! <page>Lancez-vous</page> et allez rencontrer votre voisinage.",
+      "findAHost": {
+        "title": "Trouver un hôte",
+        "subtitle": "Sélectionnez un repère sur la carte pour voir qui se trouve à proximité."
+      },
+      "contact": {
+        "title": "Contacter",
+        "subtitle": "Organisez le dépôt ou la collecte de vos restes par messagerie."
+      },
+      "dropOff": {
+        "title": "Déposer",
+        "subtitle": "Ou récupérer, si vous avez contacté un commerce local qui souhaite donner ses restes."
+      }
+    },
+    "newsletter": {
+      "title": "Quoi de neuf",
+      "subtitle": "Des nouvelles occasionnelles sur la façon dont Peels soutient le compostage communautaire dans différents endroits du monde.",
+      "footer": "Consultez notre page <page>Infolettre</page> pour voir les anciens numéros et savoir comment vous abonner."
+    },
+    "faq": {
+      "title": "Vous vous demandez peut-être...",
+      "subtitle": "Ça n’existe pas déjà ? Quelle est votre mission ? Vous avez des questions, nous avons, espérons-le, des réponses.",
+      "footer": "Rendez-vous sur notre page <page>Support</page> si vous avez d’autres questions."
+    }
+  },
+  "SignUp": {
+    "header": {
+      "signUpTo": "S’inscrire pour",
+      "contactHosts": "contacter des hôtes",
+      "startComposting": "commencer à composter",
+      "checkYourEmail": "Vérifiez votre e-mail"
+    },
+    "body": {
+      "thanks": "Merci pour votre inscription{name, select, empty {} other {, {name}}} ! Vérifiez votre boîte de réception et vos spams pour trouver le lien de vérification. Ce lien expirera dans une heure."
+    },
+    "footer": {
+      "nextSteps": "Vérifiez votre boîte de réception ainsi que vos spams pour retrouver le lien de vérification. Ce lien expirera dans une heure.",
+      "neverGotEmail": "Vous n’avez jamais reçu l’e-mail ? Vérifiez votre dossier spam.",
+      "reachOut": "Contactez-nous",
+      "stillNeedHelp": "si vous avez encore besoin d’aide.",
+      "haveAccount": "Vous avez déjà un compte ?"
+    }
+  },
+  "Profile": {
+    "addListing": "Ajouter une annonce",
+    "addAnotherListing": "Ajouter une autre annonce",
+    "listingCardAlt": "{type, select, residential {Votre avatar pour cette annonce résidentielle} community {Votre avatar pour cette annonce communautaire} business {Votre avatar pour cette annonce professionnelle} other {Votre avatar pour cette annonce}}",
+    "listingCardType": "{type, select, residential {Annonce résidentielle} community {Annonce communautaire} business {Annonce professionnelle} other {Annonce}}",
+    "listingPrompt": "Ajoutez-vous, votre lieu communautaire ou votre entreprise sur la carte",
+    "sections": {
+      "listings": "Annonces",
+      "account": "Compte",
+      "actions": "Actions"
+    },
+    "account": {
+      "firstName": "Prénom",
+      "firstNameHint": "Utilisez votre prénom ou un surnom.",
+      "emailSuccess": "Vérifiez votre e-mail pour retrouver le lien de vérification.",
+      "emailHint": "Nous enverrons un lien de vérification à cette adresse.",
+      "languageHint": "Choisissez la langue par défaut que Peels et les e-mails de votre compte doivent utiliser.",
+      "newsletterSubscribedHint": "Nous vous enverrons des nouvelles occasionnelles de Peels par e-mail.",
+      "newsletterNotSubscribedHint": "Nous vous enverrons uniquement les e-mails nécessaires liés à votre compte ou à vos annonces."
+    },
+    "actions": {
+      "signOutTitle": "Se déconnecter",
+      "signOutDescription": "À bientôt !",
+      "exportTitle": "Exporter les données",
+      "exportDescription": "Obtenez une copie de vos données Peels",
+      "exportDialogTitle": "Bientôt disponible",
+      "exportDialog": "Nous travaillons encore sur cette fonctionnalité. En attendant, <link>contactez-nous</link> et demandez-nous d’exporter vos données manuellement.",
+      "deleteTitle": "Supprimer le compte",
+      "deleteDescription": "Supprimez votre compte{count, plural, =0 {} one {, annonce,} other {, annonces,}} et toutes vos données",
+      "deleteConfirm": "{count, plural, =0 {Oui, supprimer mon compte} one {Oui, supprimer mon compte et mon annonce} other {Oui, supprimer mon compte et mes annonces}}",
+      "deleteDialog": "Êtes-vous sûr de vouloir supprimer votre compte ?{count, plural, =0 {} one { Votre annonce sera aussi supprimée.} other { Vos annonces seront aussi supprimées.}}"
+    }
+  },
+  "Auth": {
+    "complete": {
+      "title": "Connexion en cours...",
+      "body": "Nous confirmons votre lien de manière sécurisée. Vous serez redirigé dans un instant."
+    },
+    "forgotPassword": {
+      "title": "Mot de passe oublié",
+      "sentTitle": "E-mail envoyé",
+      "body": "Cela arrive à tout le monde. Saisissez votre adresse e-mail ci-dessous pour recevoir un lien de réinitialisation du mot de passe."
+    },
+    "resetPassword": {
+      "title": "Réinitialiser le mot de passe",
+      "successTitle": "Mot de passe mis à jour",
+      "body": "Veuillez saisir votre nouveau mot de passe ci-dessous.",
+      "newPassword": "Nouveau mot de passe",
+      "confirmPassword": "Confirmer le mot de passe"
+    },
+    "signIn": {
+      "title": "Se connecter à Peels",
+      "firstTime": "Première visite ici ? <link>Inscrivez-vous</link>",
+      "forgotPassword": "Mot de passe oublié ?"
+    },
+    "signUp": {
+      "firstName": "Prénom",
+      "newPassword": "Votre nouveau mot de passe",
+      "newsletterOptIn": "Envoyez-moi l’infolettre occasionnelle de Peels par e-mail",
+      "errorWithSupport": "{error} Si vous pensez qu’il s’agit d’une erreur, <link>envoyez-nous un e-mail</link>."
+    },
+    "turnstile": {
+      "expired": "La vérification a expiré. Veuillez la terminer de nouveau.",
+      "timeout": "Le contrôle de sécurité ne s’est pas terminé. Essayez de désactiver les bloqueurs de publicité puis réessayez. Si cela échoue encore, essayez un autre navigateur ou un autre réseau.",
+      "unsupported": "Ce navigateur ne peut pas effectuer le contrôle de sécurité. Veuillez essayer un autre navigateur ou un autre réseau.",
+      "failed": "La vérification de sécurité a échoué avec l’erreur n°{code}. Veuillez réessayer ou utiliser un autre navigateur."
+    }
+  },
+  "Listings": {
+    "new": {
+      "listingTypeTitle": "Quel type d’annonce ?",
+      "hostTypeTitle": "Où acceptez-vous des restes alimentaires ?",
+      "listingTypeLabel": "Type d’annonce",
+      "hostTypeLabel": "Type d’hôte",
+      "options": {
+        "host": {
+          "title": "J’accepte des restes alimentaires",
+          "description": "Les autres peuvent organiser un dépôt de restes à votre domicile ou dans votre jardin partagé"
+        },
+        "business": {
+          "title": "Mon entreprise donne des restes",
+          "description": "Les autres peuvent récupérer du marc de café de votre café, du houblon de votre brasserie, ou quelque chose de semblable"
+        },
+        "residential": {
+          "title": "Chez moi",
+          "description": "J’accepte des restes à une adresse résidentielle"
+        },
+        "community": {
+          "title": "Dans un lieu communautaire",
+          "description": "Je gère un jardin partagé ou un lieu similaire"
+        }
+      }
+    },
+    "edit": {
+      "title": "Modifier l’annonce",
+      "notFound": "Annonce introuvable"
+    },
+    "form": {
+      "basics": "Informations de base",
+      "placeName": "Nom du lieu",
+      "placeNamePlaceholder": "{type, select, business {Nom de votre commerce} community {Nom de votre communauté} other {Nom de votre lieu}}",
+      "yourFirstName": "Votre prénom",
+      "location": "Emplacement",
+      "selectCountry": "Sélectionner un pays",
+      "locationPlaceholder": "Le nom de votre rue ou un endroit proche",
+      "customLocation": "Emplacement personnalisé",
+      "locationHint": "{type, select, residential {Commencez à taper, puis sélectionnez une des options proposées dans la liste.} other {Commencez à taper, puis sélectionnez une des adresses proposées dans la liste.}}",
+      "dragPinHint": "Faites glisser le repère pour affiner{obscure, select, true { ou brouiller} other {}} votre emplacement.",
+      "businessAddress": "Adresse de votre commerce",
+      "communityAddress": "Adresse de votre communauté",
+      "residentialAddress": "Votre rue ou votre quartier",
+      "donationDetails": "Détails du don",
+      "donationDetailsPlaceholder": "Les détails de votre don",
+      "donationDetailsHint": "Quel type de restes vous avez à donner et comment se passe la collecte. Enregistrez les liens dans la section dédiée ci-dessous.",
+      "descriptionLabel": "Courte description ou consignes",
+      "descriptionPlaceholder": "{type, select, residential {À propos de votre annonce} community {À propos de votre communauté} business {À propos de votre commerce} other {À propos de votre annonce}}",
+      "communityDescriptionHint": "Horaires d’ouverture et installations de compostage. Enregistrez les restes acceptés et les liens dans les sections dédiées ci-dessous.",
+      "residentialDescriptionHint": "Votre installation de compostage et vos disponibilités générales. Enregistrez les restes acceptés dans la section dédiée ci-dessous.",
+      "compostingDetails": "Détails du compostage",
+      "compostingDetailsHint": "Soyez précis pour que les gens sachent exactement ce qu’il faut éviter. Saisissez chaque élément séparément pour faciliter la lecture.",
+      "acceptedLabel": "Quels restes acceptez-vous ?",
+      "rejectedLabel": "Quels restes n’acceptez-vous pas ?",
+      "addItem": "Ajouter un élément",
+      "addAnotherItem": "Ajouter un autre élément",
+      "acceptedPlaceholder": "Un élément que vous acceptez (ex. ‘pelures de fruits’)",
+      "acceptedSecondaryPlaceholder": "Un autre élément que vous acceptez",
+      "rejectedPlaceholder": "Un élément que vous n’acceptez pas (ex. ‘viande’)",
+      "rejectedSecondaryPlaceholder": "Un autre élément que vous n’acceptez pas",
+      "media": "Médias",
+      "mediaHint": "Montrez éventuellement {subject} aux membres de Peels.",
+      "mediaResidential": "un peu plus de votre annonce",
+      "mediaCommunity": "un peu plus de votre projet communautaire",
+      "mediaBusiness": "votre commerce sous un autre angle",
+      "externalLinks": "Liens externes",
+      "addLink": "Ajouter un lien",
+      "linkPlaceholder": "Votre site web ou réseau social",
+      "visibility": "Visibilité",
+      "visibilityHint": "Besoin d’une pause avec Peels ? Cachez temporairement cette annonce de la carte.",
+      "mapVisibility": "Visibilité sur la carte",
+      "showOnMap": "Afficher cette annonce sur la carte",
+      "hideFromMap": "Masquer cette annonce de la carte",
+      "adminHint": "Contrôles réservés à l’administration pour cette annonce.",
+      "stubSettings": "Paramètres du brouillon",
+      "regularListing": "Ceci est une annonce normale créée par vous",
+      "stubListing": "Cette annonce est un brouillon que d’autres personnes peuvent revendiquer",
+      "stubActiveHint": "Cette annonce ne contiendra pas vos coordonnées. D’autres personnes pourront la revendiquer et la reprendre.",
+      "stubInactiveHint": "Cette annonce sera présentée comme n’importe quelle autre."
+    },
+    "read": {
+      "contact": "Contacter {name}",
+      "about": "À propos",
+      "donationDetails": "Détails du don",
+      "accepted": "Ce qui est accepté",
+      "rejected": "Ce qui n’est pas accepté",
+      "location": "Emplacement",
+      "residentialLocation": "{name} habite à {area}. Demandez l’emplacement exact quand vous organisez un dépôt de restes alimentaires.",
+      "nonResidentialLocation": "{name} est {type} situé à {area}.",
+      "thisArea": "cette zone",
+      "businessType": "un commerce",
+      "communityType": "un lieu communautaire",
+      "signInForPhotos": "<link>Connectez-vous</link> pour voir les photos de cette personne hôte.",
+      "ownerNote": "C’est votre propre annonce{stub, select, true {, marquée comme brouillon} other {}}. {visibility, select, true {Tout va bien !} other {Vous l’avez masquée de la carte, donc vous seul pouvez la voir pour le moment.}}",
+      "stubNote": "Ceci est un brouillon créé par l’équipe Peels. Vérifiez bien les informations avant de vous déplacer.",
+      "stubClaim": "Vous êtes la personne responsable ? <link>Contactez-nous</link> pour revendiquer cette annonce ou demander des modifications.",
+      "firstTime": "Première visite ici ? <link>Inscrivez-vous</link>",
+      "residentOf": "Habite à {area}",
+      "localResident": "Personne du voisinage",
+      "communityIn": "Communauté à {area}",
+      "localCommunity": "Communauté locale",
+      "businessIn": "Commerce à {area}",
+      "localBusiness": "Commerce local",
+      "avatarAlt": "L’avatar de cette annonce"
+    },
+    "delete": {
+      "confirm": "Oui, supprimer l’annonce",
+      "dialog": "Êtes-vous sûr de vouloir supprimer votre annonce ? Cette action est irréversible.",
+      "success": "Votre annonce a été supprimée."
+    },
+    "photos": {
+      "alt": "Photo n°{number}",
+      "dropHere": "Déposez les photos ici",
+      "tooMany": "Vous pouvez téléverser au maximum {max} photos",
+      "tooLargeOne": "Votre photo est trop volumineuse. La taille maximale est de {max} Mo.",
+      "tooLargeMany": "Une ou plusieurs photos sont trop volumineuses. La taille maximale est de {max} Mo par photo."
+    }
+  },
+  "Upload": {
+    "avatarAlt": "Votre avatar",
+    "avatarHint": "Pensez à téléverser une photo afin que les membres sachent à qui ils s’adressent."
+  },
+  "Legal": {
+    "agreement": "J’ai lu et j’accepte les <terms>conditions d’utilisation</terms> et la <privacy>politique de confidentialité</privacy> de Peels",
+    "fallbackTitle": "Cette page n’est disponible qu’en anglais pour le moment",
+    "fallbackBody": "Nous sommes encore en train de traduire certaines pages juridiques et de référence. Pour l’instant, la page complète ci-dessous est en anglais.",
+    "lastUpdated": "Dernière mise à jour le {date}",
+    "privacy": "Confidentialité",
+    "terms": "Conditions"
+  },
+  "Chat": {
+    "send": "Envoyer",
+    "placeholder": "Envoyer un message{name, select, empty {} other { à {name}}}...",
+    "empty": "Aucun message pour le moment",
+    "threadsTitle": "Messages",
+    "noChats": "Aucune conversation pour le moment",
+    "youReachedOut": "Vous avez contacté {name}",
+    "personReachedOut": "{name} vous a contacté",
+    "personReachedOutAbout": "{name} vous a contacté au sujet de {listing}",
+    "drawerTitle": "Panneau de discussion",
+    "drawerDescription": "Conversation liée à cette annonce.",
+    "report": "Signaler ou bloquer",
+    "reportTitle": "Mettons cela au clair",
+    "reportBody": "Désolé d’apprendre que vous avez des difficultés avec {name}. Veuillez <link>nous contacter</link> pour signaler le problème ou pour empêcher cette personne de vous contacter à nouveau."
+  },
+  "Map": {
+    "drawerTitle": "Détails de l’annonce",
+    "drawerDescription": "Détails de l’annonce sélectionnée.",
+    "emptyTitle": "Rien à l’horizon",
+    "emptyBody": "L’annonce que vous cherchez n’existe pas ou a été supprimée. Désolé pour la déception.",
+    "searchPlaceholder": "Rechercher",
+    "searchError": "Quelque chose s’est mal passé. Réessayer ?",
+    "searchNoResults": "Aucun résultat. Continuez à taper ou affinez votre recherche",
+    "returnToListing": "Revenir à l’annonce",
+    "loadingListing": "Chargement de l’annonce…",
+    "loadingPins": "Chargement…",
+    "didYouKnow": "Le saviez-vous ?",
+    "steps": {
+      "find": {
+        "title": "Trouver un hôte",
+        "description": "Sélectionnez un repère sur la carte."
+      },
+      "contact": {
+        "title": "Contacter",
+        "description": "Organisez un dépôt par messagerie."
+      },
+      "dropOff": {
+        "title": "Déposer",
+        "description": "Allez rencontrer votre voisinage !"
+      }
+    }
+  },
+  "Newsletter": {
+    "title": "Infolettre",
+    "description": "Des nouvelles occasionnelles sur la façon dont Peels soutient le compostage communautaire dans différents endroits du monde.",
+    "inboxTitle": "Recevez-la dans votre boîte mail",
+    "inboxDescription": "Activez cette option pour recevoir les prochains numéros de l’infolettre par e-mail.",
+    "rss": "Ou abonnez-vous au <link>flux RSS</link>.",
+    "latestIssue": "Dernier numéro",
+    "pastIssues": "Anciens numéros",
+    "issueSubtitle": "Numéro #{number} · Publié le {date}",
+    "issueTile": "Numéro #{number} · {date}",
+    "parent": "Infolettre",
+    "fallbackTitle": "Ce numéro n’est disponible qu’en anglais pour le moment",
+    "fallbackBody": "Nous sommes encore en train de traduire les numéros de l’infolettre. Pour l’instant, la version complète ci-dessous est en anglais.",
+    "readFullIssue": "Lire ce numéro complet sur Peels",
+    "stampAlt": "Un timbre-poste",
+    "aside": {
+      "title": "À propos de cette infolettre",
+      "bodyGuest": "Voici la version web de l’infolettre envoyée par e-mail aux personnes abonnées. <link>Rejoignez Peels</link> pour recevoir les prochains numéros.",
+      "bodySubscribed": "Voici la version web de l’infolettre envoyée par e-mail aux personnes abonnées. N’hésitez pas à la partager largement.",
+      "bodyMember": "Voici la version web de l’infolettre envoyée par e-mail aux personnes abonnées. <link>Modifiez vos préférences</link> pour recevoir les prochains numéros."
+    },
+    "callout": {
+      "guestTitle": "Rejoignez Peels pour recevoir l’infolettre",
+      "guestBody": "Vous devez être membre de Peels pour recevoir l’infolettre par e-mail. L’inscription est gratuite et ne prend que quelques secondes.",
+      "alreadySubscribedTitle": "Vous êtes déjà abonné",
+      "alreadySubscribedBody": "Vous devriez voir apparaître le prochain numéro dans votre boîte mail. En attendant, n’hésitez pas à partager cette page avec quelqu’un.",
+      "notSubscribedTitle": "Vous n’êtes pas abonné",
+      "notSubscribedBody": "Modifiez votre préférence d’infolettre sur votre page Profil.",
+      "editPreference": "Modifier la préférence d’infolettre"
+    }
+  },
+  "NotFound": {
+    "body": "Désolé, nous n’avons pas trouvé la page que vous cherchiez."
+  },
+  "Support": {
+    "title": "Aide",
+    "subtitle": "Nous mettons cette page à jour régulièrement avec des réponses aux questions fréquentes. N’hésitez pas à <link>nous contacter</link> pour toute autre chose.",
+    "peelsFaq": {
+      "title": "À propos de Peels",
+      "whosBehind": {
+        "question": "Qui est derrière Peels ?",
+        "answer": "<p>Peels est un projet mené par <danny>Danny White</danny>, designer produit avec 10 ans d’expérience sur des produits tels qu’Airbnb, ChatGPT, Kickstarter et Facebook. Il a contribué au lancement du programme de compostage de Pocket City Farms et a auparavant créé un guide de voyage sur la réduction du gaspillage alimentaire.</p><p>Nous voulons que Peels existe sur le long terme, c’est pourquoi le projet est <opensource>open source</opensource> et accueille volontiers vos contributions.</p>"
+      },
+      "howDifferent": {
+        "question": "En quoi Peels est-il différent de ShareWaste ?",
+        "answer": "<p>ShareWaste était un précurseur de Peels avec une idée similaire : relier localement des personnes afin de détourner la matière organique de l’enfouissement. Malheureusement, ShareWaste a fermé fin 2024.</p><p>Pour l’instant, nous essayons surtout de combler le vide laissé par ShareWaste. Vous pouvez considérer Peels comme un remplaçant direct.</p><p>Nous avons aussi d’autres idées en préparation, notamment des guides locaux autour du compostage. Restez à l’écoute.</p>"
+      },
+      "financialModel": {
+        "question": "Quel est le modèle économique ? Êtes-vous à but non lucratif ?",
+        "answer": "Peels est un projet non commercial, porté par la communauté. À l’avenir, nous pourrions nous structurer comme organisme à but non lucratif et accepter des subventions ou des partenariats pour poursuivre le développement, mais nous n’avons jamais l’intention de faire payer le service."
+      },
+      "fogo": {
+        "question": "J’ai déjà une collecte municipale des déchets alimentaires. Le compostage communautaire reste-t-il pertinent ?",
+        "answer": "Absolument. Beaucoup de personnes n’ont toujours pas accès à une collecte fiable des déchets alimentaires, et le compostage communautaire peut aussi être plus local, plus social et plus pédagogique qu’un service municipal ou à l’échelle d’une ville. Peels est conçu pour soutenir à la fois les endroits qui disposent déjà d’une collecte et ceux qui sont encore en train de la mettre en place."
+      },
+      "mapPrivacy": {
+        "question": "Je ne suis pas à l’aise à l’idée de mettre mon adresse sur une carte. Puis-je quand même participer ?",
+        "answer": "<p>Oui ! Nous encourageons les personnes avec une annonce résidentielle à rendre leur emplacement plus approximatif, par exemple à une rue voisine ou un coin de rue, et à utiliser un pseudonyme si cela leur convient mieux.</p><p>Même si vous choisissez d’utiliser votre vrai nom et de téléverser une photo, seuls les membres de Peels connectés pourront voir ces détails.</p>"
+      },
+      "getInvolved": {
+        "question": "J’aimerais aider à construire Peels. Comment puis-je m’impliquer ?",
+        "answer": "<p>C’est formidable, merci.</p><p>Si vous avez envie d’aider sur le plan technique, consultez notre <repo>dépôt GitHub</repo>. Vous y trouverez des informations pour contribuer ainsi que des sujets ouverts qui pourraient bénéficier de votre regard.</p><p>L’organisation communautaire joue aussi un rôle important dans le développement de Peels. N’hésitez pas à <email>nous écrire</email> si vous pouvez aider sur ce plan.</p>"
+      },
+      "promotion": {
+        "question": "Comment puis-je faire connaître Peels dans ma communauté ?",
+        "answer": "<p>Merci d’abord ! Peels ne fonctionne qu’avec une carte vivante pleine d’annonces, donc faire passer le mot est essentiel.</p><p>Consultez notre <promoKit>kit promo</promoKit>, qui comprend des visuels pour les réseaux sociaux et des affiches imprimables aux formats US letter et A4. N’hésitez pas à <email>nous écrire</email> si vous avez besoin de quelque chose de plus spécifique pour votre communauté.</p>"
+      },
+      "government": {
+        "question": "Je représente une collectivité locale ou régionale. Comment puis-je participer ?",
+        "answer": "<p>Nous souhaitons travailler avec des équipes du secteur public, des organisations communautaires et des personnes du monde éducatif partout où Peels peut aider davantage de personnes à détourner les restes alimentaires de l’enfouissement. Merci de <email>nous écrire</email>.</p>"
+      }
+    },
+    "supportFaq": {
+      "title": "Utiliser Peels",
+      "manageEmails": {
+        "question": "Comment gérer les e-mails que je reçois ?",
+        "answer": "<p>Nous n’envoyons que les e-mails nécessaires au bon fonctionnement de Peels. Cela comprend un ou deux e-mails liés au compte et des notifications quand un autre membre de Peels vous envoie un message.</p><p>Les notifications par e-mail sont obligatoires pour les personnes qui hébergent une annonce, car cela signifie qu’une personne intéressée souhaite organiser un dépôt de restes (ou récupérer quelque chose). Les personnes qui ne souhaitent plus recevoir d’e-mails peuvent soit masquer leur annonce de la carte, soit la supprimer entièrement.</p><p>Les personnes sans annonce ne peuvent pas recevoir de messages, et donc pas d’e-mails, à moins d’avoir initié le contact avec une personne hôte.</p><p>Tout le monde peut signaler ou bloquer d’autres membres de Peels via la messagerie. Bloquer quelqu’un l’empêche de vous envoyer d’autres messages ou e-mails.</p>"
+      }
+    }
+  },
+  "Contact": {
+    "title": "Nous contacter",
+    "subtitle": "Voici comment joindre l’équipe Peels.",
+    "via": {
+      "therot": "Bonjour, personne lectrice de The Rot ! Merci d’être passée par ici. Voici un contact direct pour joindre Danny.",
+      "general": "Bonjour ! Voici quelques adresses e-mail pour nous contacter."
+    },
+    "contactLabel": "Si vous voulez",
+    "contactOptions": {
+      "general": "Poser une question générale",
+      "support": "Obtenir de l’aide",
+      "dw": "Parler à Danny",
+      "newsletter": "Parler de l’infolettre"
+    },
+    "emailLabel": "Le mieux est d’écrire à",
+    "copyButton": {
+      "copied": "Copié !",
+      "copying": "Copie en cours...",
+      "copyFailed": "Échec de la copie",
+      "copyAddress": "Copier l’adresse"
+    }
+  }
+}

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -117,6 +117,8 @@
   "Index": {
     "title": "Trouvez une destination pour vos restes alimentaires, où que vous soyez",
     "subtitle": "Peels met en relation des personnes qui ont des restes alimentaires avec celles qui compostent. C’est un projet communautaire gratuit et non commercial.",
+    "metaDescription": "Peels met en relation des personnes qui ont des restes alimentaires avec celles qui compostent. C’est un projet communautaire gratuit et non commercial.",
+    "metaKeywords": "gaspillage alimentaire, restes alimentaires, compost, compost près de chez moi, point de dépôt compost, dépôt de restes alimentaires",
     "hostAvatarAlt": "L’avatar d’une personne hôte sur Peels",
     "buttons": {
       "browseMap": "Parcourir la carte",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1,0 +1,514 @@
+{
+  "App": {
+    "map": "Mapa",
+    "chats": "Conversas",
+    "profile": "Perfil",
+    "about": "Sobre"
+  },
+  "Actions": {
+    "add": "Adicionar",
+    "addListing": "Adicionar anúncio",
+    "addMorePhotos": "Adicionar mais fotos",
+    "addPhotos": "Adicionar fotos",
+    "backToPeels": "Voltar ao Peels",
+    "cancel": "Cancelar",
+    "close": "Fechar",
+    "continue": "Continuar",
+    "delete": "Eliminar",
+    "deleteListing": "Eliminar anúncio",
+    "done": "Feito",
+    "edit": "Editar",
+    "emailLink": "Enviar-me o link por e-mail",
+    "exportData": "Exportar dados",
+    "home": "Início",
+    "joinPeels": "Entrar no Peels",
+    "noCancel": "Não, cancelar",
+    "openInAppleMaps": "Abrir no Apple Maps",
+    "openInGoogleMaps": "Abrir no Google Maps",
+    "replace": "Substituir",
+    "resetPassword": "Redefinir senha",
+    "saveChanges": "Guardar alterações",
+    "seeNearbyListings": "Ver anúncios próximos",
+    "sendLink": "Enviar o link",
+    "signIn": "Entrar",
+    "signInToContact": "Entrar para falar",
+    "signOut": "Sair",
+    "signUp": "Criar conta",
+    "update": "Atualizar",
+    "viewFullListing": "Ver anúncio completo",
+    "viewListing": "Ver anúncio"
+  },
+  "Common": {
+    "account": "Conta",
+    "actions": "Ações",
+    "admin": "Administração",
+    "email": "E-mail",
+    "hidden": "Oculto",
+    "language": "Idioma",
+    "languageHint": "Quem visita o Peels pode mudar o idioma aqui. Pessoas com sessão iniciada também podem guardar um idioma padrão nas configurações da conta.",
+    "links": "Links",
+    "listings": "Anúncios",
+    "loading": "Carregando...",
+    "newsletter": "Boletim",
+    "notSubscribed": "Não inscrito",
+    "optional": "opcional",
+    "password": "Senha",
+    "photos": "Fotos",
+    "source": "Fonte",
+    "stub": "Rascunho",
+    "subscribed": "Inscrito"
+  },
+  "Status": {
+    "adding": "Adicionando...",
+    "copying": "Copiando...",
+    "deleting": "Excluindo...",
+    "emailing": "Enviando e-mail...",
+    "resetting": "Redefinindo...",
+    "saving": "Salvando...",
+    "sending": "Enviando...",
+    "signingIn": "Entrando...",
+    "signingOut": "Saindo...",
+    "signingUp": "Criando conta...",
+    "updating": "Atualizando...",
+    "uploading": "Enviando...",
+    "verifying": "Verificando...",
+    "working": "Processando..."
+  },
+  "Errors": {
+    "alreadyYourEmail": "Este já é o seu endereço de e-mail.",
+    "emptyListingName": "{type, select, business {O nome do negócio não pode ficar vazio.} community {O nome da comunidade não pode ficar vazio.} other {O nome do anúncio não pode ficar vazio.}}",
+    "emptyName": "O nome não pode ficar vazio.",
+    "accountDeleted": "A sua conta foi excluída. É uma pena ver você partir.",
+    "accountExists": "Já existe uma conta com este e-mail. Faça login em vez disso.",
+    "deleteAccountFailed": "Erro ao excluir a conta",
+    "duplicateListing": "Já existe um anúncio idêntico.",
+    "emailRequired": "O e-mail é obrigatório",
+    "failedDeleteListing": "Não foi possível excluir o anúncio.",
+    "failedDeletePhoto": "Não foi possível excluir a foto. Tente novamente.",
+    "generic": "Hum, algo não parece certo. Pode tentar de novo?",
+    "genericLater": "Algo deu errado. Tente novamente mais tarde.",
+    "missingLocation": "Selecione um local.",
+    "missingSignUpFields": "Nome, e-mail e senha são obrigatórios.",
+    "passwordMismatch": "Essas senhas não coincidem.",
+    "photoUploadFailed": "Houve um erro ao enviar as suas fotos. Tente novamente.",
+    "avatarUploadFailed": "Houve um erro ao enviar a sua foto. Tente novamente.",
+    "requiredPasswordFields": "Os dois campos são obrigatórios.",
+    "resetPasswordDenied": "Hum, algo não parece certo. Talvez você não tenha permissão para redefinir esta senha ou tenha tentado reutilizar uma senha recente.",
+    "resetPasswordSuccess": "A sua senha foi atualizada. Vamos voltar à compostagem!",
+    "savePhotosFailed": "O anúncio foi criado, mas não foi possível salvar as fotos.",
+    "signUpFailed": "Não foi possível concluir o cadastro",
+    "tooManyListings": "Você atingiu o número máximo de anúncios permitidos. Exclua um dos seus três anúncios atuais para criar um novo.",
+    "tooManyMessages": "Você enviou mensagens demais. Tente novamente mais tarde.",
+    "tooManyThreads": "Você iniciou conversas demais na última hora. Tente novamente mais tarde.",
+    "firstNameTooShort": "Use pelo menos 2 caracteres no seu nome.",
+    "firstNameTooLong": "Os nomes podem ter no máximo 24 caracteres.",
+    "firstNameNotAllowed": "Esse nome não é permitido no Peels.",
+    "firstNameInvalidChars": "Os nomes só podem incluir letras, espaços, hífens e apóstrofos.",
+    "disposableEmailNotAllowed": "Use um endereço de e-mail de longo prazo em vez de uma caixa descartável.",
+    "updateEmailFailed": "Hum, algo não parece certo. Verifique o seu e-mail ou tente novamente.",
+    "updateFirstNameFailed": "Desculpe, não foi possível atualizar o seu nome.",
+    "updateNewsletterFailed": "Desculpe, não foi possível atualizar a sua preferência do boletim.",
+    "unexpected": "Ocorreu um erro inesperado. Tente novamente mais tarde.",
+    "validationSummary": "Corrija {count, plural, one {o erro acima} other {os erros acima}} e tente novamente.",
+    "verificationChallenge": "Conclua a verificação de segurança.",
+    "verificationFailed": "A verificação falhou. Tente novamente.",
+    "forgotPasswordSuccess": "Verifique a sua caixa de entrada (e o spam) para encontrar o link de redefinição de senha, caso esse e-mail esteja ligado a uma conta do Peels."
+  },
+  "Index": {
+    "title": "Encontre um destino para os seus restos de comida, esteja onde estiver",
+    "subtitle": "O Peels liga pessoas com restos de comida a quem faz compostagem. É um projeto comunitário, gratuito e sem fins comerciais.",
+    "hostAvatarAlt": "O avatar de uma pessoa anfitriã do Peels",
+    "buttons": {
+      "browseMap": "Explorar o mapa",
+      "signUp": "Criar conta no Peels",
+      "addListing": "Adicionar um anúncio"
+    },
+    "howItWorks": {
+      "title": "Funciona assim",
+      "subtitle": "Compartilhar restos de comida com vizinhos, hortas comunitárias ou até negócios locais é simples. Veja como.",
+      "footer": "É isso! <page>Vá lá para fora</page> e conheça a sua vizinhança.",
+      "findAHost": {
+        "title": "Encontrar um anfitrião",
+        "subtitle": "Selecione um marcador no mapa para ver quem está por perto."
+      },
+      "contact": {
+        "title": "Entrar em contato",
+        "subtitle": "Combine a entrega ou a coleta dos seus restos pelo chat."
+      },
+      "dropOff": {
+        "title": "Entregar",
+        "subtitle": "Ou recolher, se você entrou em contato com um negócio local que tenha restos para doar."
+      }
+    },
+    "newsletter": {
+      "title": "Novidades",
+      "subtitle": "Atualizações ocasionais sobre como o Peels apoia a compostagem comunitária em vários lugares do mundo.",
+      "footer": "Visite a nossa página de <page>Boletim</page> para ver todas as edições anteriores e saber como se inscrever."
+    },
+    "faq": {
+      "title": "Talvez você esteja se perguntando...",
+      "subtitle": "Isso já não existe? Qual é a missão do Peels? Você tem perguntas, e nós temos, esperamos, respostas.",
+      "footer": "Visite a nossa página de <page>Suporte</page> se tiver mais perguntas."
+    }
+  },
+  "SignUp": {
+    "header": {
+      "signUpTo": "Criar conta para",
+      "contactHosts": "falar com anfitriões",
+      "startComposting": "começar a compostar",
+      "checkYourEmail": "Verifique o seu e-mail"
+    },
+    "body": {
+      "thanks": "Obrigado por se cadastrar{name, select, empty {} other {, {name}}}! Verifique a sua caixa de entrada e a pasta de spam para encontrar o link de verificação. Este link expira em uma hora."
+    },
+    "footer": {
+      "nextSteps": "Verifique a sua caixa de entrada e a pasta de spam para encontrar o link de verificação. Este link expira em uma hora.",
+      "neverGotEmail": "Não recebeu o e-mail? Verifique a pasta de spam.",
+      "reachOut": "Entre em contato",
+      "stillNeedHelp": "se ainda precisar de ajuda.",
+      "haveAccount": "Já tem uma conta?"
+    }
+  },
+  "Profile": {
+    "addListing": "Adicionar um anúncio",
+    "addAnotherListing": "Adicionar outro anúncio",
+    "listingCardAlt": "{type, select, residential {Seu avatar para este anúncio residencial} community {Seu avatar para este anúncio comunitário} business {Seu avatar para este anúncio comercial} other {Seu avatar para este anúncio}}",
+    "listingCardType": "{type, select, residential {Anúncio residencial} community {Anúncio comunitário} business {Anúncio comercial} other {Anúncio}}",
+    "listingPrompt": "Coloque você, o seu espaço comunitário ou o seu negócio no mapa",
+    "sections": {
+      "listings": "Anúncios",
+      "account": "Conta",
+      "actions": "Ações"
+    },
+    "account": {
+      "firstName": "Primeiro nome",
+      "firstNameHint": "Use o seu primeiro nome ou um apelido.",
+      "emailSuccess": "Verifique o seu e-mail para encontrar o link de verificação.",
+      "emailHint": "Vamos enviar um link de verificação para este e-mail.",
+      "languageHint": "Escolha o idioma padrão que você quer que o Peels e os e-mails da sua conta usem.",
+      "newsletterSubscribedHint": "Vamos enviar a você atualizações ocasionais por e-mail sobre o Peels.",
+      "newsletterNotSubscribedHint": "Só enviaremos a você e-mails necessários relacionados com a sua conta ou com os seus anúncios."
+    },
+    "actions": {
+      "signOutTitle": "Sair",
+      "signOutDescription": "Até breve!",
+      "exportTitle": "Exportar dados",
+      "exportDescription": "Baixe uma cópia dos seus dados do Peels",
+      "exportDialogTitle": "Em breve",
+      "exportDialog": "Ainda estamos trabalhando nesta funcionalidade. Enquanto isso, <link>fale conosco</link> e peça para exportarmos os seus dados manualmente.",
+      "deleteTitle": "Excluir conta",
+      "deleteDescription": "Exclua a sua conta{count, plural, =0 {} one {, anúncio,} other {, anúncios,}} e todos os seus dados",
+      "deleteConfirm": "{count, plural, =0 {Sim, excluir minha conta} one {Sim, excluir minha conta e anúncio} other {Sim, excluir minha conta e anúncios}}",
+      "deleteDialog": "Tem certeza de que deseja excluir a sua conta?{count, plural, =0 {} one { O seu anúncio também será excluído.} other { Os seus anúncios também serão excluídos.}}"
+    }
+  },
+  "Auth": {
+    "complete": {
+      "title": "Entrando...",
+      "body": "Estamos confirmando o seu link com segurança. Você será redirecionado em instantes."
+    },
+    "forgotPassword": {
+      "title": "Esqueci a senha",
+      "sentTitle": "E-mail enviado",
+      "body": "Isso acontece com todo mundo. Digite o seu e-mail abaixo para receber um link para redefinir a senha."
+    },
+    "resetPassword": {
+      "title": "Redefinir senha",
+      "successTitle": "Senha atualizada",
+      "body": "Digite a sua nova senha abaixo.",
+      "newPassword": "Nova senha",
+      "confirmPassword": "Confirmar senha"
+    },
+    "signIn": {
+      "title": "Entrar no Peels",
+      "firstTime": "Primeira vez por aqui? <link>Cria uma conta</link>",
+      "forgotPassword": "Esqueceu a senha?"
+    },
+    "signUp": {
+      "firstName": "Primeiro nome",
+      "newPassword": "A sua nova senha",
+      "newsletterOptIn": "Enviem-me atualizações ocasionais por e-mail sobre o Peels",
+      "errorWithSupport": "{error} Se achar que isso pode estar errado, <link>envie um e-mail para nós</link>."
+    },
+    "turnstile": {
+      "expired": "A verificação expirou. Conclua-a novamente.",
+      "timeout": "A verificação de segurança não foi concluída. Tente desativar bloqueadores de anúncios e tente de novo. Se continuar falhando, use outro navegador ou outra rede.",
+      "unsupported": "Este navegador não consegue concluir a verificação de segurança. Tente outro navegador ou outra rede.",
+      "failed": "A verificação de segurança falhou com o erro #{code}. Tente novamente ou use outro navegador."
+    }
+  },
+  "Listings": {
+    "new": {
+      "listingTypeTitle": "Que tipo de anúncio?",
+      "hostTypeTitle": "Onde você aceita restos de comida?",
+      "listingTypeLabel": "Tipo de anúncio",
+      "hostTypeLabel": "Tipo de anfitrião",
+      "options": {
+        "host": {
+          "title": "Eu aceito restos de comida",
+          "description": "Outras pessoas podem combinar a entrega de restos na sua casa ou na sua horta comunitária"
+        },
+        "business": {
+          "title": "O meu negócio doa restos",
+          "description": "Outras pessoas podem recolher borra de café do seu café, lúpulo da sua cervejaria ou algo parecido"
+        },
+        "residential": {
+          "title": "Na minha casa",
+          "description": "Eu aceito restos em um endereço residencial"
+        },
+        "community": {
+          "title": "Em um espaço comunitário",
+          "description": "Eu cuido de uma horta comunitária ou algo semelhante"
+        }
+      }
+    },
+    "edit": {
+      "title": "Editar anúncio",
+      "notFound": "Anúncio não encontrado"
+    },
+    "form": {
+      "basics": "Informações básicas",
+      "placeName": "Nome do lugar",
+      "placeNamePlaceholder": "{type, select, business {Nome do seu negócio} community {Nome da sua comunidade} other {Nome do seu lugar}}",
+      "yourFirstName": "Seu nome",
+      "location": "Localização",
+      "selectCountry": "Selecione um país",
+      "locationPlaceholder": "Sua rua ou algum ponto próximo",
+      "customLocation": "Localização personalizada",
+      "locationHint": "{type, select, residential {Comece a digitar e depois selecione uma das opções sugeridas no menu.} other {Comece a digitar e depois selecione um dos endereços sugeridos no menu.}}",
+      "dragPinHint": "Arraste o pino para refinar{obscure, select, true { ou ocultar} other {}} a sua localização.",
+      "businessAddress": "Endereço do seu negócio",
+      "communityAddress": "Endereço da sua comunidade",
+      "residentialAddress": "Sua rua ou bairro",
+      "donationDetails": "Detalhes da doação",
+      "donationDetailsPlaceholder": "Os detalhes da sua doação",
+      "donationDetailsHint": "Que tipo de restos você tem para doar e como a retirada funciona. Salve quaisquer links para a seção dedicada abaixo.",
+      "descriptionLabel": "Descrição curta ou instruções",
+      "descriptionPlaceholder": "{type, select, residential {Sobre o seu anúncio} community {Sobre a sua comunidade} business {Sobre o seu negócio} other {Sobre o seu anúncio}}",
+      "communityDescriptionHint": "Horários de funcionamento e estrutura de compostagem. Salve os restos aceitos e quaisquer links para as seções dedicadas abaixo.",
+      "residentialDescriptionHint": "Como é a sua compostagem e qual é a sua disponibilidade em geral. Salve os restos aceitos para a seção dedicada abaixo.",
+      "compostingDetails": "Detalhes da compostagem",
+      "compostingDetailsHint": "Seja específico para que as pessoas saibam exatamente o que evitar. Insira os itens separadamente para facilitar a leitura.",
+      "acceptedLabel": "Quais restos você aceita?",
+      "rejectedLabel": "Quais restos você não aceita?",
+      "addItem": "Adicionar item",
+      "addAnotherItem": "Adicionar outro item",
+      "acceptedPlaceholder": "Um item que você aceita (por exemplo, ‘cascas de fruta’)",
+      "acceptedSecondaryPlaceholder": "Outro item que você aceita",
+      "rejectedPlaceholder": "Um item que você não aceita (por exemplo, ‘carne’)",
+      "rejectedSecondaryPlaceholder": "Outro item que você não aceita",
+      "media": "Mídia",
+      "mediaHint": "Opcionalmente mostre {subject} para outras pessoas no Peels.",
+      "mediaResidential": "um pouco mais sobre o seu anúncio",
+      "mediaCommunity": "um pouco mais sobre o seu projeto comunitário",
+      "mediaBusiness": "mais sobre o seu negócio",
+      "externalLinks": "Links externos",
+      "addLink": "Adicionar link",
+      "linkPlaceholder": "Seu site ou rede social",
+      "visibility": "Visibilidade",
+      "visibilityHint": "Precisa de uma pausa do Peels? Oculte temporariamente este anúncio do mapa.",
+      "mapVisibility": "Visibilidade no mapa",
+      "showOnMap": "Mostrar este anúncio no mapa",
+      "hideFromMap": "Ocultar este anúncio do mapa",
+      "adminHint": "Controles apenas para admin deste anúncio.",
+      "stubSettings": "Configurações de rascunho",
+      "regularListing": "Este é um anúncio normal criado por você",
+      "stubListing": "Este anúncio é um rascunho que outras pessoas podem reivindicar",
+      "stubActiveHint": "Este anúncio não mostrará as suas informações de contato. Outras pessoas podem reivindicá-lo e assumir o controle.",
+      "stubInactiveHint": "Este anúncio será apresentado como qualquer outro."
+    },
+    "read": {
+      "contact": "Falar com {name}",
+      "about": "Sobre",
+      "donationDetails": "Detalhes da doação",
+      "accepted": "O que é aceito",
+      "rejected": "O que não é aceito",
+      "location": "Localização",
+      "residentialLocation": "{name} mora em {area}. Peça a localização exata quando combinar a entrega dos restos de comida.",
+      "nonResidentialLocation": "{name} é {type} localizado em {area}.",
+      "thisArea": "esta área",
+      "businessType": "um negócio",
+      "communityType": "um espaço comunitário",
+      "signInForPhotos": "<link>Entre</link> para ver as fotos desta pessoa anfitriã.",
+      "ownerNote": "Este é o seu próprio anúncio{stub, select, true {, marcado como rascunho} other {}}. {visibility, select, true {Está com tudo certo!} other {Você o ocultou do mapa, então só você consegue vê-lo agora.}}",
+      "stubNote": "Este é um rascunho criado pela equipe do Peels. Confira as informações antes de visitar.",
+      "stubClaim": "Você é a pessoa responsável? <link>Fale conosco</link> para reivindicar este anúncio ou pedir alterações.",
+      "firstTime": "Primeira vez por aqui? <link>Cadastre-se</link>",
+      "residentOf": "Morador(a) de {area}",
+      "localResident": "Morador(a) local",
+      "communityIn": "Comunidade em {area}",
+      "localCommunity": "Comunidade local",
+      "businessIn": "Negócio em {area}",
+      "localBusiness": "Negócio local",
+      "avatarAlt": "O avatar deste anúncio"
+    },
+    "delete": {
+      "confirm": "Sim, excluir anúncio",
+      "dialog": "Tem certeza de que deseja excluir o seu anúncio? Essa ação não pode ser desfeita.",
+      "success": "O seu anúncio foi excluído."
+    },
+    "photos": {
+      "alt": "Foto {number}",
+      "dropHere": "Solte as fotos aqui",
+      "tooMany": "Você só pode enviar até {max} fotos",
+      "tooLargeOne": "A sua foto é grande demais. O tamanho máximo é {max} MB.",
+      "tooLargeMany": "Uma ou mais fotos estão grandes demais. O tamanho máximo é {max} MB por foto."
+    }
+  },
+  "Upload": {
+    "avatarAlt": "Seu avatar",
+    "avatarHint": "Considere enviar uma foto para que outras pessoas saibam com quem estão falando."
+  },
+  "Legal": {
+    "agreement": "Li e concordo com os <terms>termos de uso</terms> e a <privacy>política de privacidade</privacy> do Peels",
+    "fallbackTitle": "Esta página está disponível apenas em inglês por enquanto",
+    "fallbackBody": "Ainda estamos traduzindo algumas das nossas páginas legais e de referência. Por enquanto, a página completa abaixo está em inglês.",
+    "lastUpdated": "Última atualização em {date}",
+    "privacy": "Privacidade",
+    "terms": "Termos"
+  },
+  "Chat": {
+    "send": "Enviar",
+    "placeholder": "Envie uma mensagem{name, select, empty {} other { para {name}}}...",
+    "empty": "Ainda não há mensagens",
+    "threadsTitle": "Conversas",
+    "noChats": "Ainda não há conversas",
+    "youReachedOut": "Você entrou em contato com {name}",
+    "personReachedOut": "{name} entrou em contato com você",
+    "personReachedOutAbout": "{name} entrou em contato com você sobre {listing}",
+    "drawerTitle": "Painel da conversa",
+    "drawerDescription": "Conversa deste anúncio.",
+    "report": "Denunciar ou bloquear",
+    "reportTitle": "Vamos resolver isso",
+    "reportBody": "É uma pena saber que você está tendo problemas com {name}. <link>Fale conosco</link> para denunciar a situação ou impedir novos contatos dessa pessoa."
+  },
+  "Map": {
+    "drawerTitle": "Detalhes do anúncio",
+    "drawerDescription": "Detalhes do anúncio selecionado.",
+    "emptyTitle": "Nada por aqui",
+    "emptyBody": "O anúncio que você procura não existe ou foi removido. Desculpe a decepção.",
+    "searchPlaceholder": "Buscar",
+    "searchError": "Algo deu errado. Tentar novamente?",
+    "searchNoResults": "Nenhum resultado. Continue digitando ou refine a busca",
+    "returnToListing": "Voltar ao anúncio",
+    "loadingListing": "Carregando anúncio…",
+    "loadingPins": "Carregando…",
+    "didYouKnow": "Você sabia?",
+    "steps": {
+      "find": {
+        "title": "Encontrar anfitrião",
+        "description": "Selecione um marcador no mapa."
+      },
+      "contact": {
+        "title": "Contatar",
+        "description": "Combine a entrega pelo chat."
+      },
+      "dropOff": {
+        "title": "Entregar",
+        "description": "Conheça a sua vizinhança!"
+      }
+    }
+  },
+  "Newsletter": {
+    "title": "Boletim",
+    "description": "Atualizações ocasionais sobre como o Peels apoia a compostagem comunitária em vários lugares do mundo.",
+    "inboxTitle": "Receba na sua caixa de entrada",
+    "inboxDescription": "Ative para receber futuras edições do boletim por e-mail.",
+    "rss": "Ou assine o <link>feed RSS</link>.",
+    "latestIssue": "Edição mais recente",
+    "pastIssues": "Edições anteriores",
+    "issueSubtitle": "Edição #{number} · Publicada em {date}",
+    "issueTile": "Edição #{number} · {date}",
+    "parent": "Boletim",
+    "fallbackTitle": "Esta edição está disponível apenas em inglês por enquanto",
+    "fallbackBody": "Ainda estamos traduzindo as edições do boletim. Por enquanto, a edição completa abaixo está em inglês.",
+    "readFullIssue": "Ler esta edição completa no Peels",
+    "stampAlt": "Um selo postal",
+    "aside": {
+      "title": "Sobre este boletim",
+      "bodyGuest": "Esta é a versão web do boletim enviado por e-mail às pessoas inscritas. <link>Entre no Peels</link> para receber as próximas edições.",
+      "bodySubscribed": "Esta é a versão web do boletim enviado por e-mail às pessoas inscritas. Fique à vontade para compartilhar.",
+      "bodyMember": "Esta é a versão web do boletim enviado por e-mail às pessoas inscritas. <link>Edite as suas preferências</link> para receber as próximas edições."
+    },
+    "callout": {
+      "guestTitle": "Entre no Peels para receber o boletim",
+      "guestBody": "Você precisa ser membro do Peels para receber o boletim por e-mail. Criar uma conta é grátis e leva só alguns segundos.",
+      "alreadySubscribedTitle": "Você já está inscrito",
+      "alreadySubscribedBody": "A próxima edição deve aparecer no seu e-mail. Enquanto isso, fique à vontade para compartilhar esta página com alguém.",
+      "notSubscribedTitle": "Você não está inscrito",
+      "notSubscribedBody": "Mude a sua preferência do boletim na página de Perfil.",
+      "editPreference": "Editar preferência do boletim"
+    }
+  },
+  "NotFound": {
+    "body": "Desculpe, não encontrámos a página que você procurava."
+  },
+  "Support": {
+    "title": "Suporte",
+    "subtitle": "Atualizamos esta página regularmente com respostas para perguntas frequentes. Fique à vontade para <link>entrar em contato</link> sobre qualquer outra coisa.",
+    "peelsFaq": {
+      "title": "Sobre o Peels",
+      "whosBehind": {
+        "question": "Quem está por trás do Peels?",
+        "answer": "<p>O Peels é um projeto liderado por <danny>Danny White</danny>, designer de produto com 10 anos de experiência em produtos como Airbnb, ChatGPT, Kickstarter e Facebook. Ele ajudou a iniciar o programa de compostagem da Pocket City Farms e antes criou um guia de viagem sobre redução de desperdício de alimentos.</p><p>Queremos que o Peels exista por muito tempo, por isso o projeto foi <opensource>aberto em código aberto</opensource> e recebe contribuições com entusiasmo.</p>"
+      },
+      "howDifferent": {
+        "question": "Em que o Peels é diferente do ShareWaste?",
+        "answer": "<p>O ShareWaste foi um antecessor do Peels com uma ideia parecida: conectar pessoas localmente para desviar material orgânico do aterro. Infelizmente, o ShareWaste encerrou as atividades no fim de 2024.</p><p>No momento, estamos tentando preencher esse vazio. Você pode pensar no Peels como um substituto direto do ShareWaste.</p><p>Também temos várias outras ideias em andamento, incluindo guias locais sobre compostagem. Fique de olho.</p>"
+      },
+      "financialModel": {
+        "question": "Qual é o modelo financeiro? Vocês são sem fins lucrativos?",
+        "answer": "O Peels é um projeto não comercial, guiado pela comunidade. No futuro, talvez nos formalizemos como organização sem fins lucrativos e aceitemos bolsas ou patrocínios para continuar o desenvolvimento, mas não pretendemos cobrar pelo serviço."
+      },
+      "fogo": {
+        "question": "Já tenho coleta municipal de restos de comida. A compostagem comunitária continua relevante?",
+        "answer": "Sem dúvida. Muita gente ainda não tem acesso a uma coleta confiável de restos de comida, e a compostagem comunitária também pode ser mais local, social e educativa do que um serviço municipal ou de cidade. O Peels foi pensado para apoiar tanto os lugares que já têm coleta como os que ainda a estão a construir."
+      },
+      "mapPrivacy": {
+        "question": "Não me sinto confortável em colocar o meu endereço em um mapa. Ainda posso participar?",
+        "answer": "<p>Sim! Incentivamos pessoas com anúncios residenciais a deixar a localização mais aproximada, como uma esquina próxima, e a usar um pseudônimo se isso for mais confortável.</p><p>Mesmo que você escolha usar o seu nome real e enviar uma foto, apenas membros do Peels com sessão iniciada conseguem ver esses detalhes.</p>"
+      },
+      "getInvolved": {
+        "question": "Quero ajudar a construir o Peels. Como posso participar?",
+        "answer": "<p>Você é demais. Obrigado.</p><p>Se quiser ajudar do lado técnico, dê uma olhada no nosso <repo>repositório no GitHub</repo>. Lá tem informações sobre como contribuir e também algumas questões que podem se beneficiar da sua ajuda.</p><p>A organização comunitária também é parte importante de fazer o Peels crescer. Não hesite em <email>nos mandar um e-mail</email> se puder ajudar nisso.</p>"
+      },
+      "promotion": {
+        "question": "Como posso divulgar o Peels na minha comunidade?",
+        "answer": "<p>Antes de mais nada, obrigado! O Peels só funciona com um mapa vivo de anúncios, por isso espalhar a palavra é fundamental.</p><p>Dê uma olhada no nosso <promoKit>kit promocional</promoKit>, que inclui peças para redes sociais e cartazes imprimíveis nos formatos US letter e A4. Fique à vontade para <email>escrever para nós</email> se precisar de algo mais específico para a sua comunidade.</p>"
+      },
+      "government": {
+        "question": "Represento um governo local ou regional. Como posso participar?",
+        "answer": "<p>Temos interesse em colaborar com equipes do setor público, organizações comunitárias e pessoas da área da educação em qualquer lugar onde o Peels possa ajudar a desviar mais restos de comida do aterro. <email>Envie um e-mail para nós</email>.</p>"
+      }
+    },
+    "supportFaq": {
+      "title": "Usando o Peels",
+      "manageEmails": {
+        "question": "Como eu gerencio quais e-mails recebo?",
+        "answer": "<p>Enviamos apenas os e-mails necessários para que o Peels funcione. Isso inclui um ou dois e-mails relacionados à conta e notificações quando outra pessoa do Peels enviar uma mensagem para você.</p><p>As notificações por e-mail são obrigatórias para pessoas anfitriãs de anúncios, porque isso indica que alguém quer combinar uma entrega de restos (ou retirar algo). Quem hospeda um anúncio e não quiser mais receber e-mails pode ocultá-lo do mapa ou excluí-lo completamente.</p><p>Pessoas sem anúncios não podem receber mensagens, e portanto e-mails, a menos que iniciem o contato com uma pessoa anfitriã.</p><p>Qualquer pessoa pode denunciar ou bloquear membros do Peels pelo sistema de mensagens. Bloquear alguém impede novas mensagens e novos e-mails dessa pessoa.</p>"
+      }
+    }
+  },
+  "Contact": {
+    "title": "Contato",
+    "subtitle": "Veja como falar com a equipe do Peels.",
+    "via": {
+      "therot": "Olá, pessoa leitora do The Rot! Obrigado por passar por aqui. Aqui vai um contato direto do Danny.",
+      "general": "Olá! Aqui estão alguns endereços de e-mail que você pode usar para falar com a gente."
+    },
+    "contactLabel": "Se quiser",
+    "contactOptions": {
+      "general": "Fazer uma pergunta geral",
+      "support": "Pedir ajuda com algo",
+      "dw": "Falar com o Danny",
+      "newsletter": "Falar sobre o boletim"
+    },
+    "emailLabel": "O melhor é escrever para",
+    "copyButton": {
+      "copied": "Copiado!",
+      "copying": "Copiando...",
+      "copyFailed": "Falha ao copiar",
+      "copyAddress": "Copiar endereço"
+    }
+  }
+}

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -117,6 +117,8 @@
   "Index": {
     "title": "Encontre um destino para os seus restos de comida, esteja onde estiver",
     "subtitle": "O Peels liga pessoas com restos de comida a quem faz compostagem. É um projeto comunitário, gratuito e sem fins comerciais.",
+    "metaDescription": "O Peels liga pessoas com restos de comida a quem faz compostagem. É um projeto comunitário, gratuito e sem fins comerciais.",
+    "metaKeywords": "desperdício de alimentos, restos de comida, compostagem, compostagem perto de mim, ponto de entrega para compostagem, entrega de restos de comida",
     "hostAvatarAlt": "O avatar de uma pessoa anfitriã do Peels",
     "buttons": {
       "browseMap": "Explorar o mapa",

--- a/src/app/(core)/(interact)/(centered)/profile/page.js
+++ b/src/app/(core)/(interact)/(centered)/profile/page.js
@@ -3,13 +3,13 @@ import ProfileHeader from "@/components/ProfileHeader";
 import ProfileAccountSettings from "@/components/ProfileAccountSettings";
 import ProfileListings from "@/components/ProfileListings";
 import ProfileActions from "@/components/ProfileActions";
-import LegalFooter from "@/components/LegalFooter";
+import SiteFooter from "@/components/SiteFooter";
 import { styled } from "@pigment-css/react";
 import { Suspense } from "react";
 import Toast from "@/components/Toast";
 import { getTranslations } from "next-intl/server";
 import { siteConfig } from "@/config/site";
-import { normaliseLocale } from "@/i18n/config";
+import { defaultLocale, normaliseLocale } from "@/i18n/config";
 
 export async function generateMetadata() {
   const t = await getTranslations("Profile.sections");
@@ -48,7 +48,7 @@ export default async function ProfilePage() {
     (typeof userMetadataPreferredLocale === "string"
       ? normaliseLocale(userMetadataPreferredLocale)
       : undefined) ??
-    "en";
+    defaultLocale;
 
   return (
     <>
@@ -81,7 +81,7 @@ export default async function ProfilePage() {
         <ProfileActions listings={listings} />
       </Section>
 
-      <LegalFooter />
+      <SiteFooter />
     </>
   );
 }

--- a/src/app/(core)/(interact)/(centered)/profile/page.js
+++ b/src/app/(core)/(interact)/(centered)/profile/page.js
@@ -42,9 +42,12 @@ export default async function ProfilePage() {
     supabase.from("profiles").select().eq("id", user.id).single(),
   ]);
 
+  const userMetadataPreferredLocale = user?.user_metadata?.preferred_locale;
   const preferredLocale =
     normaliseLocale(profile?.preferred_locale) ??
-    normaliseLocale(user?.user_metadata?.preferred_locale) ??
+    (typeof userMetadataPreferredLocale === "string"
+      ? normaliseLocale(userMetadataPreferredLocale)
+      : undefined) ??
     "en";
 
   return (

--- a/src/app/(core)/(interact)/(centered)/profile/page.js
+++ b/src/app/(core)/(interact)/(centered)/profile/page.js
@@ -8,10 +8,19 @@ import { styled } from "@pigment-css/react";
 import { Suspense } from "react";
 import Toast from "@/components/Toast";
 import { getTranslations } from "next-intl/server";
+import { siteConfig } from "@/config/site";
+import { normaliseLocale } from "@/i18n/config";
 
-export const metadata = {
-  title: "Profile",
-};
+export async function generateMetadata() {
+  const t = await getTranslations("Profile.sections");
+
+  return {
+    title: t("account"),
+    openGraph: {
+      title: `${t("account")} · ${siteConfig.name}`,
+    },
+  };
+}
 
 // Keep URL-based feedback in a client leaf so server rendering is driven by auth/data only.
 export default async function ProfilePage() {
@@ -33,6 +42,11 @@ export default async function ProfilePage() {
     supabase.from("profiles").select().eq("id", user.id).single(),
   ]);
 
+  const preferredLocale =
+    normaliseLocale(profile?.preferred_locale) ??
+    normaliseLocale(user?.user_metadata?.preferred_locale) ??
+    "en";
+
   return (
     <>
       <Suspense>
@@ -50,7 +64,13 @@ export default async function ProfilePage() {
 
       <Section>
         <h2>{t("account")}</h2>
-        <ProfileAccountSettings user={user} profile={profile} />
+        <ProfileAccountSettings
+          user={user}
+          profile={{
+            ...(profile ?? {}),
+            preferred_locale: preferredLocale,
+          }}
+        />
       </Section>
 
       <Section>

--- a/src/app/(core)/(static)/(index)/page.js
+++ b/src/app/(core)/(static)/(index)/page.js
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { siteConfig } from "@/config/site";
 import IntroHeader from "@/components/IntroHeader";
@@ -13,11 +14,30 @@ import HeaderBlock from "@/components/HeaderBlock";
 import FooterBlock from "@/components/FooterBlock";
 import { styled } from "@pigment-css/react";
 
-export const metadata = {
-  title: {
-    absolute: `${siteConfig.name}: ${siteConfig.description}`,
-  },
-};
+export async function generateMetadata() {
+  const t = await getTranslations("Index");
+  const description = t("metaDescription");
+  const keywords = t("metaKeywords")
+    .split(",")
+    .map((keyword) => keyword.trim())
+    .filter(Boolean);
+
+  return {
+    title: {
+      absolute: `${siteConfig.name}: ${t("title")}`,
+    },
+    description,
+    keywords,
+    openGraph: {
+      title: `${siteConfig.name}: ${t("title")}`,
+      description,
+    },
+    twitter: {
+      title: `${siteConfig.name}: ${t("title")}`,
+      description,
+    },
+  };
+}
 
 export default function Index() {
   const t = useTranslations("Index");

--- a/src/app/(core)/(static)/(legal)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/(legal)/[slug]/page.tsx
@@ -1,12 +1,15 @@
 // For documentation, see analagous setup for newsletter issues
-import dynamic from "next/dynamic";
 import type { Metadata } from "next/types";
 import StaticPageMain from "@/components/StaticPageMain";
 import StaticPageHeader from "@/components/StaticPageHeader";
 import LongformTextContainer from "@/components/LongformTextContainer";
+import TranslationNotice from "@/components/TranslationNotice";
 import { getAllContentSlugs } from "@/lib/content/utils";
-import { getLegalPageMetadata } from "@/lib/content/handlers/legal";
-import { formatPublishDate } from "@/utils/dateUtils";
+import {
+  getLegalPageMetadata,
+  getLegalPageModule,
+} from "@/lib/content/handlers/legal";
+import { getLocale, getTranslations } from "next-intl/server";
 
 type LegalPageProps = {
   params: Promise<{ slug: string }>;
@@ -16,7 +19,8 @@ export async function generateMetadata({
   params,
 }: LegalPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const { metadata } = await getLegalPageMetadata(slug);
+  const locale = await getLocale();
+  const { metadata } = await getLegalPageMetadata(slug, locale);
 
   if (metadata) {
     return {
@@ -38,7 +42,14 @@ export async function generateStaticParams() {
 
 export default async function LegalPage({ params }: LegalPageProps) {
   const { slug } = await params;
-  const { metadata, customMetadata } = await getLegalPageMetadata(slug);
+  const locale = await getLocale();
+  const t = await getTranslations({ locale, namespace: "Legal" });
+  const { metadata, customMetadata, formattedDate } =
+    await getLegalPageMetadata(slug, locale);
+  const {
+    file: { default: LegalPageMarkdown },
+    isFallback,
+  } = await getLegalPageModule(slug, locale);
 
   // Set unique inline title if verbose title passed through (assuming customMetadata has even been provided)
   // E.g. 'Privacy' in the <title> and 'Privacy policy' in the inline <h1>
@@ -51,16 +62,10 @@ export default async function LegalPage({ params }: LegalPageProps) {
   // Set description to last updated date, if provided
   // TODO: Any way to use this in OG metadata?
   //   TODO use consistent date formatting here, chat messages (maybe), and newsletter issues
-  const pageDescription = customMetadata
-    ? customMetadata.updatedDate
-      ? `Last updated ${formatPublishDate(customMetadata.updatedDate)}`
-      : metadata.description
-    : metadata.description;
-
-  //   Dynamically import MDX files
-  const LegalPageMarkdown = dynamic(
-    () => import(`@/content/legal/${slug}.mdx`)
-  );
+  const pageDescription =
+    customMetadata?.updatedDate && formattedDate
+      ? t("lastUpdated", { date: formattedDate })
+      : metadata.description;
 
   return (
     // // Largely matches newsletter/(issues) page.tsx
@@ -69,6 +74,12 @@ export default async function LegalPage({ params }: LegalPageProps) {
       <section>
         <StaticPageHeader title={pageTitle} subtitle={pageDescription} />
         <LongformTextContainer>
+          {isFallback && (
+            <TranslationNotice
+              title={t("fallbackTitle")}
+              body={t("fallbackBody")}
+            />
+          )}
           <LegalPageMarkdown />
         </LongformTextContainer>
       </section>

--- a/src/app/(core)/(static)/(legal)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/(legal)/[slug]/page.tsx
@@ -1,4 +1,4 @@
-// For documentation, see analagous setup for newsletter issues
+// For documentation, see analogous setup for newsletter issues
 import type { Metadata } from "next/types";
 import StaticPageMain from "@/components/StaticPageMain";
 import StaticPageHeader from "@/components/StaticPageHeader";

--- a/src/app/(core)/(static)/layout.jsx
+++ b/src/app/(core)/(static)/layout.jsx
@@ -1,6 +1,6 @@
 import TabBar from "@/components/TabBar";
 import { TabBarProvider } from "@/contexts/TabBarContext";
-import LegalFooter from "@/components/LegalFooter";
+import SiteFooter from "@/components/SiteFooter";
 import { styled } from "@pigment-css/react";
 import AccountButton from "@/components/AccountButton";
 
@@ -29,7 +29,7 @@ export default async function Layout({ children }) {
         <StyledAccountButton />
         <TabBar breakpoint="md" position="fixed" />
         {children}
-        <LegalFooter />
+        <SiteFooter />
         <TabBar breakpoint="sm" />
       </StaticPage>
     </TabBarProvider>

--- a/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
@@ -16,16 +16,27 @@ import FooterBlock from "@/components/FooterBlock";
 import { getNewsletterIssueImageUrl } from "@/utils/storage";
 import TranslationNotice from "@/components/TranslationNotice";
 import { getLocale, getTranslations } from "next-intl/server";
+import { getLocaleFromSearchParams } from "@/utils/authRedirects";
 
 type NewsletterIssuePageProps = {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ locale?: string | string[] | undefined }>;
+};
+
+const resolveNewsletterIssueLocale = async (
+  searchParams: NewsletterIssuePageProps["searchParams"]
+) => {
+  const requestedLocale = getLocaleFromSearchParams(await searchParams);
+
+  return requestedLocale ?? (await getLocale());
 };
 
 export async function generateMetadata({
   params,
+  searchParams,
 }: NewsletterIssuePageProps): Promise<Metadata> {
   const { slug } = await params;
-  const locale = await getLocale();
+  const locale = await resolveNewsletterIssueLocale(searchParams);
   const { metadata, customMetadata } = await getNewsletterIssueMetadata(
     slug,
     locale
@@ -60,9 +71,10 @@ export async function generateStaticParams() {
 
 export default async function NewsletterIssuePage({
   params,
+  searchParams,
 }: NewsletterIssuePageProps) {
   const { slug } = await params;
-  const locale = await getLocale();
+  const locale = await resolveNewsletterIssueLocale(searchParams);
   const t = await getTranslations({ locale, namespace: "Newsletter" });
   const { metadata, customMetadata, formattedDate } =
     await getNewsletterIssueMetadata(slug, locale);

--- a/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { getNewsletterIssueImageUrl } from "@/utils/storage";
 import TranslationNotice from "@/components/TranslationNotice";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getLocaleFromSearchParams } from "@/utils/authRedirects";
+import { defaultLocale } from "@/i18n/config";
 
 type NewsletterIssuePageProps = {
   params: Promise<{ slug: string }>;
@@ -76,6 +77,10 @@ export default async function NewsletterIssuePage({
   const { slug } = await params;
   const locale = await resolveNewsletterIssueLocale(searchParams);
   const t = await getTranslations({ locale, namespace: "Newsletter" });
+  const rssHref =
+    locale === defaultLocale
+      ? "/newsletter/feed.xml"
+      : `/newsletter/feed.xml?locale=${locale}`;
   const { metadata, customMetadata, formattedDate } =
     await getNewsletterIssueMetadata(slug, locale);
   const title = customMetadata.verboseTitle
@@ -118,11 +123,7 @@ export default async function NewsletterIssuePage({
         <FooterBlock>
           <p>
             {t.rich("rss", {
-              link: (chunks) => (
-                <Link href={`/newsletter/feed.xml?locale=${locale}`}>
-                  {chunks}
-                </Link>
-              ),
+              link: (chunks) => <Link href={rssHref}>{chunks}</Link>,
             })}
           </p>
         </FooterBlock>

--- a/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import Link from "next/link";
 import type { Metadata } from "next/types";
 import StaticPageMain from "@/components/StaticPageMain";
@@ -7,12 +6,16 @@ import LongformTextContainer from "@/components/LongformTextContainer";
 import NewsletterCallout from "@/components/NewsletterCallout";
 import { siteConfig } from "@/config/site";
 import { getAllContentSlugs } from "@/lib/content/utils";
-import { getNewsletterIssueMetadata } from "@/lib/content/handlers/newsletter";
+import {
+  getNewsletterIssueMetadata,
+  getNewsletterIssueModule,
+} from "@/lib/content/handlers/newsletter";
 import StaticPageSection from "@/components/StaticPageSection";
 import HeaderBlock from "@/components/HeaderBlock";
 import FooterBlock from "@/components/FooterBlock";
 import { getNewsletterIssueImageUrl } from "@/utils/storage";
-import { getTranslations } from "next-intl/server";
+import TranslationNotice from "@/components/TranslationNotice";
+import { getLocale, getTranslations } from "next-intl/server";
 
 type NewsletterIssuePageProps = {
   params: Promise<{ slug: string }>;
@@ -22,7 +25,11 @@ export async function generateMetadata({
   params,
 }: NewsletterIssuePageProps): Promise<Metadata> {
   const { slug } = await params;
-  const { metadata, customMetadata } = await getNewsletterIssueMetadata(slug);
+  const locale = await getLocale();
+  const { metadata, customMetadata } = await getNewsletterIssueMetadata(
+    slug,
+    locale
+  );
 
   if (metadata) {
     return {
@@ -55,25 +62,21 @@ export default async function NewsletterIssuePage({
   params,
 }: NewsletterIssuePageProps) {
   const { slug } = await params;
-  const t = await getTranslations("Newsletter");
+  const locale = await getLocale();
+  const t = await getTranslations({ locale, namespace: "Newsletter" });
   const { metadata, customMetadata, formattedDate } =
-    await getNewsletterIssueMetadata(slug);
+    await getNewsletterIssueMetadata(slug, locale);
   const title = customMetadata.verboseTitle
     ? customMetadata.verboseTitle
     : metadata.title;
-  // const authors = `${metadata.authors ?? ""}`;
   const issueNumber = customMetadata.issueNumber;
-
-  //  Dynamically import MDX files
-  const NewsletterIssueMarkdown = dynamic(
-    () => import(`@/content/newsletter/${slug}.mdx`)
-  );
-  //   console.log(authors); // TODO: Open Graph authors
+  const {
+    file: { default: NewsletterIssueMarkdown },
+    isFallback,
+  } = await getNewsletterIssueModule(slug, locale);
 
   return (
-    // Largely matches (legal) page.tsx, with some additions below the textual content
     <StaticPageMain>
-      {/* Nest header and main content together so they visually hug */}
       <section>
         <StaticPageHeader
           title={title}
@@ -84,6 +87,12 @@ export default async function NewsletterIssuePage({
           parent={t("parent")}
         />
         <LongformTextContainer>
+          {isFallback && (
+            <TranslationNotice
+              title={t("fallbackTitle")}
+              body={t("fallbackBody")}
+            />
+          )}
           <NewsletterIssueMarkdown />
         </LongformTextContainer>
       </section>
@@ -91,14 +100,16 @@ export default async function NewsletterIssuePage({
       <StaticPageSection>
         <HeaderBlock>
           <h2>{t("inboxTitle")}</h2>
-          <p>{siteConfig.newsletter.description}</p>
+          <p>{t("description")}</p>
         </HeaderBlock>
         <NewsletterCallout />
         <FooterBlock>
           <p>
             {t.rich("rss", {
               link: (chunks) => (
-                <Link href="/newsletter/feed.xml">{chunks}</Link>
+                <Link href={`/newsletter/feed.xml?locale=${locale}`}>
+                  {chunks}
+                </Link>
               ),
             })}
           </p>

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request) {
   });
 
   newsletterIssues.forEach((issue) => {
-    const issueLink = `${siteConfig.url}/newsletter/${issue.slug}`;
+    const issueLink = `${siteConfig.url}/newsletter/${issue.slug}?locale=${locale}`;
     const issueImage = new URL(
       getNewsletterIssueImageUrl(
         issue.customMetadata.issueNumber,
@@ -35,7 +35,7 @@ export async function GET(request: Request) {
     ).toString();
     feed.addItem({
       title: issue.metadata.title,
-      link: `${siteConfig.url}/newsletter/${issue.slug}`,
+      link: issueLink,
       description: issue.metadata.description,
       author: issue.metadata.authors.map((author) => ({
         name: author,

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -14,11 +14,12 @@ export async function GET(request: Request) {
     normaliseLocale(requestUrl.searchParams.get("locale")) ?? defaultLocale;
   const t = await getTranslations({ locale, namespace: "Newsletter" });
   const newsletterIssues = await getAllNewsletterIssues(locale);
+  const feedUrl = `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`;
   const feed = new Feed({
     title: `${siteConfig.name}: ${t("title")}`,
     description: t("description"),
-    id: `${siteConfig.url}/newsletter`,
-    link: `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`,
+    id: feedUrl,
+    link: feedUrl,
     favicon: `${siteConfig.url}/favicon.ico`,
     language: locale,
     copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.name}`,

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -3,21 +3,26 @@ import { Feed } from "feed";
 import { getAllNewsletterIssues } from "@/lib/content/handlers/newsletter";
 import { siteConfig } from "@/config/site";
 import { getNewsletterIssueImageUrl } from "@/utils/storage";
+import { defaultLocale, normaliseLocale } from "@/i18n/config";
+import { getTranslations } from "next-intl/server";
 
-export const dynamic = "force-static"; // Force as prerendered static content on build, not dynamic (otherwise issues don't populate)
+export const dynamic = "force-dynamic";
 
-const feed = new Feed({
-  title: `${siteConfig.name}: Newsletter`, // Peels: Newsletter (matches layout.tsx)
-  description: siteConfig.newsletter.description,
-  id: `${siteConfig.url}/newsletter`,
-  link: `${siteConfig.url}/newsletter/feed.xml`,
-  favicon: `${siteConfig.url}/favicon.ico`,
-  language: "en",
-  copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.name}`,
-});
-
-export async function GET() {
-  const newsletterIssues = await getAllNewsletterIssues();
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const locale =
+    normaliseLocale(requestUrl.searchParams.get("locale")) ?? defaultLocale;
+  const t = await getTranslations({ locale, namespace: "Newsletter" });
+  const newsletterIssues = await getAllNewsletterIssues(locale);
+  const feed = new Feed({
+    title: `${siteConfig.name}: ${t("title")}`,
+    description: t("description"),
+    id: `${siteConfig.url}/newsletter`,
+    link: `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`,
+    favicon: `${siteConfig.url}/favicon.ico`,
+    language: locale,
+    copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.name}`,
+  });
 
   newsletterIssues.forEach((issue) => {
     const issueLink = `${siteConfig.url}/newsletter/${issue.slug}`;
@@ -38,7 +43,7 @@ export async function GET() {
       image: issueImage,
       content: `${
         issue.metadata.description ? `<p>${issue.metadata.description}</p>` : ""
-      }<p><a href="${issueLink}">Read this full issue on Peels</a></p>`,
+      }<p><a href="${issueLink}">${t("readFullIssue")}</a></p>`,
       date: new Date(issue.customMetadata.publishDate),
     });
   });

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -10,23 +10,32 @@ export const revalidate = 3600;
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
-  const locale =
-    normaliseLocale(requestUrl.searchParams.get("locale")) ?? defaultLocale;
+  const requestedLocale = requestUrl.searchParams.get("locale");
+  const locale = normaliseLocale(requestedLocale) ?? defaultLocale;
   const t = await getTranslations({ locale, namespace: "Newsletter" });
   const newsletterIssues = await getAllNewsletterIssues(locale);
-  const feedUrl = `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`;
+  const feedUrl = new URL("/newsletter/feed.xml", siteConfig.url);
+
+  if (requestedLocale && locale !== defaultLocale) {
+    feedUrl.searchParams.set("locale", locale);
+  }
+
   const feed = new Feed({
     title: `${siteConfig.name}: ${t("title")}`,
     description: t("description"),
-    id: feedUrl,
-    link: feedUrl,
+    id: feedUrl.toString(),
+    link: feedUrl.toString(),
     favicon: `${siteConfig.url}/favicon.ico`,
     language: locale,
     copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.name}`,
   });
 
   newsletterIssues.forEach((issue) => {
-    const issueLink = `${siteConfig.url}/newsletter/${issue.slug}?locale=${locale}`;
+    const issueUrl = new URL(`/newsletter/${issue.slug}`, siteConfig.url);
+    if (locale !== defaultLocale) {
+      issueUrl.searchParams.set("locale", locale);
+    }
+    const issueLink = issueUrl.toString();
     const issueImage = new URL(
       getNewsletterIssueImageUrl(
         issue.customMetadata.issueNumber,

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -6,7 +6,7 @@ import { getNewsletterIssueImageUrl } from "@/utils/storage";
 import { defaultLocale, normaliseLocale } from "@/i18n/config";
 import { getTranslations } from "next-intl/server";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
@@ -51,6 +51,7 @@ export async function GET(request: Request) {
   return new Response(feed.rss2(), {
     headers: {
       "Content-Type": "application/rss+xml",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/src/app/(core)/(static)/newsletter/feed.xml/route.ts
+++ b/src/app/(core)/(static)/newsletter/feed.xml/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
   const newsletterIssues = await getAllNewsletterIssues(locale);
   const feedUrl = new URL("/newsletter/feed.xml", siteConfig.url);
 
-  if (requestedLocale && locale !== defaultLocale) {
+  if (requestedLocale) {
     feedUrl.searchParams.set("locale", locale);
   }
 

--- a/src/app/(core)/(static)/newsletter/page.tsx
+++ b/src/app/(core)/(static)/newsletter/page.tsx
@@ -8,27 +8,31 @@ import HeaderBlock from "@/components/HeaderBlock";
 import FooterBlock from "@/components/FooterBlock";
 import StaticPageMain from "@/components/StaticPageMain";
 import { styled } from "@pigment-css/react";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
-export const metadata = {
-  title: "Newsletter",
-  description: siteConfig.newsletter.description,
-  openGraph: {
-    title: `Newsletter · ${siteConfig.name}`,
-    description: siteConfig.newsletter.description,
-  },
-};
+export async function generateMetadata() {
+  const locale = await getLocale();
+  const t = await getTranslations({ locale, namespace: "Newsletter" });
+  const description = t("description");
+
+  return {
+    title: t("title"),
+    description,
+    openGraph: {
+      title: `${t("title")} · ${siteConfig.name}`,
+      description,
+    },
+  };
+}
 
 export default async function NewsletterPage() {
-  const t = await getTranslations("Newsletter");
+  const locale = await getLocale();
+  const t = await getTranslations({ locale, namespace: "Newsletter" });
 
   return (
     <StaticPageMain>
       <AboveTheFoldSection>
-        <StaticPageHeader
-          title={t("title")}
-          subtitle={siteConfig.newsletter.description}
-        />
+        <StaticPageHeader title={t("title")} subtitle={t("description")} />
         <NewsletterIssuesList />
       </AboveTheFoldSection>
 
@@ -42,7 +46,9 @@ export default async function NewsletterPage() {
           <p>
             {t.rich("rss", {
               link: (chunks) => (
-                <Link href="/newsletter/feed.xml">{chunks}</Link>
+                <Link href={`/newsletter/feed.xml?locale=${locale}`}>
+                  {chunks}
+                </Link>
               ),
             })}
           </p>

--- a/src/app/(core)/(static)/newsletter/page.tsx
+++ b/src/app/(core)/(static)/newsletter/page.tsx
@@ -9,6 +9,7 @@ import FooterBlock from "@/components/FooterBlock";
 import StaticPageMain from "@/components/StaticPageMain";
 import { styled } from "@pigment-css/react";
 import { getLocale, getTranslations } from "next-intl/server";
+import { defaultLocale } from "@/i18n/config";
 
 export async function generateMetadata() {
   const locale = await getLocale();
@@ -28,6 +29,10 @@ export async function generateMetadata() {
 export default async function NewsletterPage() {
   const locale = await getLocale();
   const t = await getTranslations({ locale, namespace: "Newsletter" });
+  const rssHref =
+    locale === defaultLocale
+      ? "/newsletter/feed.xml"
+      : `/newsletter/feed.xml?locale=${locale}`;
 
   return (
     <StaticPageMain>
@@ -45,11 +50,7 @@ export default async function NewsletterPage() {
         <FooterBlock>
           <p>
             {t.rich("rss", {
-              link: (chunks) => (
-                <Link href={`/newsletter/feed.xml?locale=${locale}`}>
-                  {chunks}
-                </Link>
-              ),
+              link: (chunks) => <Link href={rssHref}>{chunks}</Link>,
             })}
           </p>
         </FooterBlock>

--- a/src/app/(forms)/sign-in/page.tsx
+++ b/src/app/(forms)/sign-in/page.tsx
@@ -4,13 +4,18 @@ import StrongLink from "@/components/StrongLink";
 import SignInForm from "@/components/SignInForm";
 import FormFooter from "@/components/FormFooter";
 import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
 
-export const metadata = {
-  title: "Sign In",
-  openGraph: {
-    title: `Sign In · ${siteConfig.name}`,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("Auth.signIn");
+
+  return {
+    title: t("title"),
+    openGraph: {
+      title: `${t("title")} · ${siteConfig.name}`,
+    },
+  };
+}
 
 export default async function SignIn(props: {
   searchParams: Promise<{

--- a/src/app/(forms)/sign-up/page.tsx
+++ b/src/app/(forms)/sign-up/page.tsx
@@ -6,13 +6,18 @@ import FormFooter from "@/components/FormFooter";
 import StrongLink from "@/components/StrongLink";
 import EncodedEmailLink from "@/components/EncodedEmailLink";
 import SignUpForm from "@/components/SignUpForm";
+import type { Metadata } from "next";
 
-export const metadata = {
-  title: "Sign Up",
-  openGraph: {
-    title: `Sign Up · ${siteConfig.name}`,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations();
+
+  return {
+    title: t("Actions.signUp"),
+    openGraph: {
+      title: `${t("Actions.signUp")} · ${siteConfig.name}`,
+    },
+  };
+}
 
 export default async function SignUp(props: {
   searchParams: Promise<{

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -373,27 +373,33 @@ export const updatePreferredLocaleAction = async (formData: FormData) => {
     return { error: t("generic") };
   }
 
-  const [{ error: profileError }, { error: authError }] = await Promise.all([
-    supabase
-      .from("profiles")
-      .update({
-        preferred_locale: nextLocale,
-      })
-      .eq("id", user.id),
-    supabase.auth.updateUser({
-      data: {
-        preferred_locale: nextLocale,
-      },
-    }),
-  ]);
+  const { error: profileError } = await supabase
+    .from("profiles")
+    .update({
+      preferred_locale: nextLocale,
+    })
+    .eq("id", user.id);
 
-  if (authError) {
-    console.error("Error updating preferred locale:", authError);
-    return { error: t("genericLater") };
-  }
+  const profileUpdated =
+    !profileError || isMissingPreferredLocaleColumn(profileError);
 
   if (profileError && !isMissingPreferredLocaleColumn(profileError)) {
-    console.error("Error updating preferred locale:", profileError);
+    console.error("Error updating preferred locale profile:", profileError);
+  }
+
+  const { error: authError } = await supabase.auth.updateUser({
+    data: {
+      preferred_locale: nextLocale,
+    },
+  });
+
+  const authUpdated = !authError;
+
+  if (authError) {
+    console.error("Error updating preferred locale auth metadata:", authError);
+  }
+
+  if (!profileUpdated && !authUpdated) {
     return { error: t("genericLater") };
   }
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -16,20 +16,12 @@ import {
 } from "@/utils/utils";
 import { getUserLocale, setUserLocale } from "@/i18n/services/locale";
 import { resolveAuthLocale } from "@/utils/authRedirects";
+import { isMissingPreferredLocaleColumn } from "@/utils/postgrest";
 import { normaliseLocale } from "@/i18n/config";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-
-function isMissingPreferredLocaleColumn(error: {
-  code?: string | null;
-  message?: string | null;
-}) {
-  return (
-    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
-  );
-}
 
 function translateFirstNameFieldError(
   t: Awaited<ReturnType<typeof getTranslations>>,

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -14,10 +14,22 @@ import {
   isTurnstileEnabled,
   validateTurnstileToken,
 } from "@/utils/utils";
+import { getUserLocale, setUserLocale } from "@/i18n/services/locale";
+import { resolveAuthLocale } from "@/utils/authRedirects";
+import { normaliseLocale } from "@/i18n/config";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+
+function isMissingPreferredLocaleColumn(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  return (
+    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
+  );
+}
 
 function translateFirstNameFieldError(
   t: Awaited<ReturnType<typeof getTranslations>>,
@@ -45,6 +57,9 @@ export const signUpAction = async (formData: FormData, request?: Request) => {
   const email = (formData.get("email")?.toString() ?? "").trim();
   const password = formData.get("password")?.toString();
   const rawFirstName = formData.get("first_name")?.toString();
+  const locale = resolveAuthLocale(
+    formData.get("locale")?.toString() ?? (await getUserLocale())
+  );
   const firstNameValidation = validateFirstName(formData.get("first_name"));
   if (!firstNameValidation.isValid) {
     const preservedData = new URLSearchParams();
@@ -161,10 +176,11 @@ export const signUpAction = async (formData: FormData, request?: Request) => {
     options: {
       // Note: We validate Turnstile server-side above, so we don't pass captchaToken to Supabase
       // This allows us to have granular control (only on sign-up, not sign-in/password reset)
-      emailRedirectTo: `${origin || getBaseUrl()}/auth/complete?next=/profile`,
+      emailRedirectTo: `${origin || getBaseUrl()}/auth/complete?next=/profile&locale=${locale}`,
       data: {
         first_name,
         is_newsletter_subscribed: newsletterPreference,
+        preferred_locale: locale,
         http_referrer: referrer,
         utm_source: utmSource || null,
         utm_medium: utmMedium || null,
@@ -228,15 +244,16 @@ export const forgotPasswordAction = async (formData: FormData) => {
   const supabase = await createClient();
   const origin = (await headers()).get("origin");
   const callbackUrl = formData.get("callbackUrl")?.toString();
+  const locale = resolveAuthLocale(
+    formData.get("locale")?.toString() ?? (await getUserLocale())
+  );
 
   if (!email) {
     return encodedRedirect("error", "/forgot-password", t("emailRequired"));
   }
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${
-      origin || getBaseUrl()
-    }/auth/complete?next=/profile/reset-password`,
+    redirectTo: `${origin || getBaseUrl()}/auth/complete?next=/profile/reset-password&locale=${locale}`,
   });
 
   if (error) {
@@ -290,9 +307,18 @@ export const updateFirstNameAction = async (formData: FormData) => {
 export const sendEmailChangeEmailAction = async (formData: FormData) => {
   const t = await getTranslations("Errors");
   const supabase = await createClient();
-  const { error } = await supabase.auth.updateUser({
-    email: formData.get("email") as string,
-  });
+  const origin = (await headers()).get("origin");
+  const locale = resolveAuthLocale(
+    formData.get("locale")?.toString() ?? (await getUserLocale())
+  );
+  const { error } = await supabase.auth.updateUser(
+    {
+      email: formData.get("email") as string,
+    },
+    {
+      emailRedirectTo: `${origin || getBaseUrl()}/auth/complete?next=/profile&locale=${locale}`,
+    }
+  );
 
   if (error) {
     console.error("Error sending email change email:", error);
@@ -324,6 +350,64 @@ export const updateNewsletterPreferenceAction = async (formData: FormData) => {
     console.error("Error updating newsletter preference:", error);
     return { error: t("updateNewsletterFailed") };
   }
+
+  return { success: true };
+};
+
+export const setDisplayLocaleAction = async (formData: FormData) => {
+  const nextLocale = normaliseLocale(formData.get("locale")?.toString());
+
+  if (!nextLocale) {
+    return { error: "Invalid locale" };
+  }
+
+  await setUserLocale(nextLocale);
+  revalidatePath("/", "layout");
+
+  return { success: true };
+};
+
+export const updatePreferredLocaleAction = async (formData: FormData) => {
+  const t = await getTranslations("Errors");
+  const supabase = await createClient();
+  const nextLocale = normaliseLocale(
+    formData.get("preferred_locale")?.toString()
+  );
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user?.id || !nextLocale) {
+    return { error: t("generic") };
+  }
+
+  const [{ error: profileError }, { error: authError }] = await Promise.all([
+    supabase
+      .from("profiles")
+      .update({
+        preferred_locale: nextLocale,
+      })
+      .eq("id", user.id),
+    supabase.auth.updateUser({
+      data: {
+        preferred_locale: nextLocale,
+      },
+    }),
+  ]);
+
+  if (authError) {
+    console.error("Error updating preferred locale:", authError);
+    return { error: t("genericLater") };
+  }
+
+  if (profileError && !isMissingPreferredLocaleColumn(profileError)) {
+    console.error("Error updating preferred locale:", profileError);
+    return { error: t("genericLater") };
+  }
+
+  await setUserLocale(nextLocale);
+  revalidatePath("/profile");
+  revalidatePath("/", "layout");
 
   return { success: true };
 };

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,10 @@
 import { createClient } from "@/utils/supabase/server";
-import { appendSuccessParam, normaliseNextPath } from "@/utils/authRedirects";
+import {
+  appendSuccessParam,
+  getLocaleFromSearchParams,
+  normaliseNextPath,
+} from "@/utils/authRedirects";
+import { setUserLocale } from "@/i18n/services/locale";
 import { NextResponse } from "next/server";
 
 const isAuthDebugEnabled = process.env.NEXT_PUBLIC_AUTH_DEBUG === "true";
@@ -23,6 +28,7 @@ export async function GET(request: Request) {
   const requestedNextPath =
     requestUrl.searchParams.get("next") ??
     requestUrl.searchParams.get("redirect_to");
+  const locale = getLocaleFromSearchParams(requestUrl.searchParams);
   const nextPath = normaliseNextPath(requestedNextPath, "/profile");
 
   if (code) {
@@ -44,6 +50,10 @@ export async function GET(request: Request) {
       authType === "email_change"
         ? appendSuccessParam(nextPath, "email_change")
         : nextPath;
+
+    if (locale) {
+      await setUserLocale(locale);
+    }
 
     debugAuth("code-exchange-success", {
       nextPath: resolvedNextPath,
@@ -68,6 +78,9 @@ export async function GET(request: Request) {
   completeUrl.searchParams.set("next", nextPath);
   if (authType) {
     completeUrl.searchParams.set("type", authType);
+  }
+  if (locale) {
+    completeUrl.searchParams.set("locale", locale);
   }
   return NextResponse.redirect(completeUrl);
 }

--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -2,9 +2,11 @@ import { createClient } from "@/utils/supabase/server";
 import {
   appendSuccessParam,
   getDefaultNextPathByType,
+  getLocaleFromSearchParams,
   isSupportedEmailAuthType,
   normaliseNextPath,
 } from "@/utils/authRedirects";
+import { setUserLocale } from "@/i18n/services/locale";
 import { NextResponse } from "next/server";
 
 const INVALID_LINK_MESSAGE =
@@ -34,6 +36,7 @@ export async function GET(request: Request) {
   const requestedNextPath =
     requestUrl.searchParams.get("next") ??
     requestUrl.searchParams.get("redirect_to");
+  const locale = getLocaleFromSearchParams(requestUrl.searchParams);
   const defaultNextPath = getDefaultNextPathByType(authType);
   const nextPath = normaliseNextPath(requestedNextPath, defaultNextPath);
 
@@ -68,6 +71,10 @@ export async function GET(request: Request) {
     authType === "email_change"
       ? appendSuccessParam(nextPath, "email_change")
       : nextPath;
+
+  if (locale) {
+    await setUserLocale(locale);
+  }
 
   debugAuth("verify-otp-success", {
     authType,

--- a/src/app/auth/session/route.ts
+++ b/src/app/auth/session/route.ts
@@ -2,9 +2,11 @@ import { createClient } from "@/utils/supabase/server";
 import {
   appendSuccessParam,
   getDefaultNextPathByType,
+  getLocaleFromSearchParams,
   isSupportedEmailAuthType,
   normaliseNextPath,
 } from "@/utils/authRedirects";
+import { setUserLocale } from "@/i18n/services/locale";
 import { NextResponse } from "next/server";
 
 const isAuthDebugEnabled = process.env.NEXT_PUBLIC_AUTH_DEBUG === "true";
@@ -22,6 +24,7 @@ export async function POST(request: Request) {
         access_token?: unknown;
         refresh_token?: unknown;
         next?: unknown;
+        locale?: unknown;
         type?: unknown;
       }
     | undefined;
@@ -58,6 +61,9 @@ export async function POST(request: Request) {
     typeof body?.next === "string" ? body.next : null,
     defaultNextPath
   );
+  const locale = getLocaleFromSearchParams({
+    locale: typeof body?.locale === "string" ? body.locale : undefined,
+  });
 
   try {
     const supabase = await createClient();
@@ -82,6 +88,10 @@ export async function POST(request: Request) {
       type === "email_change"
         ? appendSuccessParam(nextPath, "email_change")
         : nextPath;
+
+    if (locale) {
+      await setUserLocale(locale);
+    }
 
     debugAuth("set-session-success", { type, nextPath: resolvedNextPath });
     return NextResponse.json({ ok: true, next: resolvedNextPath });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { NextIntlClientProvider } from "next-intl";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getLocale } from "next-intl/server";
 import { Metadata } from "next";
 import { siteConfig } from "@/config/site";
 import { getStaticFontUrl, usesHostedStaticAssets } from "@/utils/storage";
@@ -184,37 +184,31 @@ const Body = styled("body")(({ theme }) => ({
   backgroundColor: theme.colors.background.sunk,
 }));
 
-export async function generateMetadata(): Promise<Metadata> {
-  const locale = await getLocale();
-  const t = await getTranslations();
-  const description = t("Index.subtitle");
-
-  return {
-    metadataBase: new URL(siteConfig.url),
-    title: {
-      default: siteConfig.name,
-      template: `%s · ${siteConfig.name}`,
+export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
+  title: {
+    default: siteConfig.name,
+    template: `%s · ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+  keywords: [...siteConfig.meta.keywords],
+  openGraph: {
+    title: siteConfig.name,
+    type: "website",
+    description: siteConfig.description,
+    siteName: siteConfig.name,
+  },
+  alternates: {
+    types: {
+      "application/rss+xml": [
+        {
+          title: `${siteConfig.name}: Newsletter`,
+          url: `${siteConfig.url}/newsletter/feed.xml`,
+        },
+      ],
     },
-    description,
-    keywords: [...siteConfig.meta.keywords],
-    openGraph: {
-      title: siteConfig.name,
-      type: "website",
-      description,
-      siteName: siteConfig.name,
-    },
-    alternates: {
-      types: {
-        "application/rss+xml": [
-          {
-            title: `${siteConfig.name}: ${t("Newsletter.title")}`,
-            url: `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`,
-          },
-        ],
-      },
-    },
-  };
-}
+  },
+};
 
 export default async function RootLayout({
   children,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { NextIntlClientProvider } from "next-intl";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Metadata } from "next";
 import { siteConfig } from "@/config/site";
 import { getStaticFontUrl, usesHostedStaticAssets } from "@/utils/storage";
@@ -184,36 +184,37 @@ const Body = styled("body")(({ theme }) => ({
   backgroundColor: theme.colors.background.sunk,
 }));
 
-export const metadata: Metadata = {
-  // Force the Peels URL (siteConfig.url) instead of what might render as a preview deployment URL (VERCEL_URL)
-  // Might be related to local-only build issue: metadataBase property in metadata export is not set for resolving social open graph or twitter images, using "https://www.peels.app". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
-  metadataBase: new URL(siteConfig.url),
-  title: {
-    default: siteConfig.name,
-    template: `%s · ${siteConfig.name}`, // E.g. "Page title here · Peels"
-  },
-  description: siteConfig.description,
-  keywords: [...siteConfig.meta.keywords],
-  openGraph: {
-    title: siteConfig.name,
-    type: "website",
-    description: siteConfig.description,
-    siteName: siteConfig.name,
-    // url: siteConfig.url, // Should be the canonical URL of your object, not site root URL
-  },
-  // RSS feed for newsletter
-  // https://didoesdigital.com/blog/nextjs-blog-09-rss/
-  alternates: {
-    types: {
-      "application/rss+xml": [
-        {
-          title: `${siteConfig.name}: Newsletter`, // Peels: Newsletter (matches route.ts)
-          url: `${siteConfig.url}/newsletter/feed.xml`,
-        },
-      ],
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations();
+  const description = t("Index.subtitle");
+
+  return {
+    metadataBase: new URL(siteConfig.url),
+    title: {
+      default: siteConfig.name,
+      template: `%s · ${siteConfig.name}`,
     },
-  },
-};
+    description,
+    keywords: [...siteConfig.meta.keywords],
+    openGraph: {
+      title: siteConfig.name,
+      type: "website",
+      description,
+      siteName: siteConfig.name,
+    },
+    alternates: {
+      types: {
+        "application/rss+xml": [
+          {
+            title: `${siteConfig.name}: ${t("Newsletter.title")}`,
+            url: `${siteConfig.url}/newsletter/feed.xml?locale=${locale}`,
+          },
+        ],
+      },
+    },
+  };
+}
 
 export default async function RootLayout({
   children,

--- a/src/components/AuthHashCompletion.tsx
+++ b/src/components/AuthHashCompletion.tsx
@@ -35,6 +35,7 @@ export default function AuthHashCompletion() {
     const hashType = hashParams.get("type");
     const preferredNextPath =
       queryParams.get("next") ?? queryParams.get("redirect_to");
+    const preferredLocale = queryParams.get("locale");
     const requestedType = queryParams.get("type") ?? hashType;
     const defaultNextPath = getDefaultNextPathByType(requestedType);
     const nextPath = normaliseNextPath(preferredNextPath, defaultNextPath);
@@ -62,6 +63,9 @@ export default function AuthHashCompletion() {
       if (!completeParams.get("type") && requestedType) {
         completeParams.set("type", requestedType);
       }
+      if (!completeParams.get("locale") && preferredLocale) {
+        completeParams.set("locale", preferredLocale);
+      }
       completeUrl.search = completeParams.toString();
       completeUrl.hash = window.location.hash;
 
@@ -83,6 +87,9 @@ export default function AuthHashCompletion() {
       callbackUrl.searchParams.set("next", nextPath);
       if (requestedType) {
         callbackUrl.searchParams.set("type", requestedType);
+      }
+      if (preferredLocale) {
+        callbackUrl.searchParams.set("locale", preferredLocale);
       }
       window.location.assign(callbackUrl.toString());
       return;
@@ -157,6 +164,7 @@ export default function AuthHashCompletion() {
             refresh_token: refreshToken,
             type,
             next: typedNextPath,
+            locale: preferredLocale,
           }),
         });
 

--- a/src/components/DropdownIcon/DropdownIcon.jsx
+++ b/src/components/DropdownIcon/DropdownIcon.jsx
@@ -3,7 +3,9 @@ import { styled } from "@pigment-css/react";
 
 // See ChevronRightIcon too, which was a fork of this (and more basic primitive)
 // In fact, perhaps this should have a ChevronDownIcon embedded
-const StyledIconWrapper = styled(IconWrapper)(({ theme }) => ({
+const StyledIconWrapper = styled(IconWrapper, {
+  shouldForwardProp: (prop) => prop !== "variant",
+})(({ theme }) => ({
   pointerEvents: "none",
   position: "absolute",
   right: "0.75rem",

--- a/src/components/DropdownIcon/DropdownIcon.jsx
+++ b/src/components/DropdownIcon/DropdownIcon.jsx
@@ -10,11 +10,24 @@ const StyledIconWrapper = styled(IconWrapper)(({ theme }) => ({
   top: "50%",
   transform: "translateY(-50%)",
   stroke: theme.colors.text.ui.tertiary,
+
+  variants: [
+    {
+      props: { variant: "compact" },
+      style: {
+        right: "0.625rem",
+      },
+    },
+  ],
 }));
 
-function DropdownIcon() {
+function DropdownIcon({ variant = "default" }) {
   return (
-    <StyledIconWrapper size={20} strokeWidth={2}>
+    <StyledIconWrapper
+      variant={variant}
+      size={variant === "compact" ? 18 : 20}
+      strokeWidth={variant === "compact" ? 1.75 : 2}
+    >
       <path d="m6 9 6 6 6-6" />
     </StyledIconWrapper>
   );

--- a/src/components/LegalFooter/LegalFooter.tsx
+++ b/src/components/LegalFooter/LegalFooter.tsx
@@ -1,6 +1,8 @@
 import { siteConfig } from "@/config/site";
 import Link from "next/link";
 import PeelsLogo from "@/components/PeelsLogo";
+import LocalePicker from "@/components/LocalePicker";
+import { createClient } from "@/utils/supabase/server";
 import { styled } from "@pigment-css/react";
 import { getTranslations } from "next-intl/server";
 
@@ -8,6 +10,10 @@ const currentYear = new Date().getFullYear();
 
 export default async function LegalFooter() {
   const t = await getTranslations();
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   return (
     <StyledFooter>
@@ -15,6 +21,8 @@ export default async function LegalFooter() {
       <p>
         © {currentYear} {siteConfig.name}
       </p>
+
+      {!user && <LocalePicker compact={true} />}
 
       <StyledNav>
         <Link href={siteConfig.links.about}>{t("App.about")}</Link>

--- a/src/components/LegalFooter/LegalFooter.tsx
+++ b/src/components/LegalFooter/LegalFooter.tsx
@@ -5,15 +5,14 @@ import PeelsLogo from "@/components/PeelsLogo";
 import LocalePicker from "@/components/LocalePicker";
 import { styled } from "@pigment-css/react";
 import { getTranslations } from "next-intl/server";
+import { hasSupabaseAuthCookie } from "@/utils/supabase/authCookies";
 
 const currentYear = new Date().getFullYear();
 
 export default async function LegalFooter() {
   const t = await getTranslations();
   const cookieStore = await cookies();
-  const hasSupabaseAuthCookie = cookieStore
-    .getAll()
-    .some(({ name }) => name.includes("auth-token"));
+  const hasSignedInSession = hasSupabaseAuthCookie(cookieStore.getAll());
 
   return (
     <StyledFooter>
@@ -22,7 +21,7 @@ export default async function LegalFooter() {
         © {currentYear} {siteConfig.name}
       </p>
 
-      {!hasSupabaseAuthCookie && <LocalePicker compact={true} />}
+      {!hasSignedInSession && <LocalePicker compact={true} />}
 
       <StyledNav>
         <Link href={siteConfig.links.about}>{t("App.about")}</Link>

--- a/src/components/LegalFooter/LegalFooter.tsx
+++ b/src/components/LegalFooter/LegalFooter.tsx
@@ -1,8 +1,8 @@
 import { siteConfig } from "@/config/site";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import PeelsLogo from "@/components/PeelsLogo";
 import LocalePicker from "@/components/LocalePicker";
-import { createClient } from "@/utils/supabase/server";
 import { styled } from "@pigment-css/react";
 import { getTranslations } from "next-intl/server";
 
@@ -10,10 +10,10 @@ const currentYear = new Date().getFullYear();
 
 export default async function LegalFooter() {
   const t = await getTranslations();
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const cookieStore = await cookies();
+  const hasSupabaseAuthCookie = cookieStore
+    .getAll()
+    .some(({ name }) => name.includes("auth-token"));
 
   return (
     <StyledFooter>
@@ -22,7 +22,7 @@ export default async function LegalFooter() {
         © {currentYear} {siteConfig.name}
       </p>
 
-      {!user && <LocalePicker compact={true} />}
+      {!hasSupabaseAuthCookie && <LocalePicker compact={true} />}
 
       <StyledNav>
         <Link href={siteConfig.links.about}>{t("App.about")}</Link>

--- a/src/components/LegalFooter/index.js
+++ b/src/components/LegalFooter/index.js
@@ -1,2 +1,0 @@
-export * from "./LegalFooter";
-export { default } from "./LegalFooter";

--- a/src/components/LocalePicker/LocalePicker.tsx
+++ b/src/components/LocalePicker/LocalePicker.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useTransition } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { localeLabels, locales, type Locale } from "@/i18n/config";
+import { setDisplayLocaleAction } from "@/app/actions";
+import Select from "@/components/Select";
+import Field from "@/components/Field";
+import InputHint from "@/components/InputHint";
+import { styled } from "@pigment-css/react";
+
+const Container = styled("div")(({ theme }) => ({
+  width: "100%",
+  maxWidth: "18rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  alignItems: "stretch",
+
+  "@media (min-width: 768px)": {
+    alignItems: "center",
+  },
+}));
+
+type LocalePickerProps = {
+  showHint?: boolean;
+  compact?: boolean;
+};
+
+export default function LocalePicker({
+  showHint = false,
+  compact = false,
+}: LocalePickerProps) {
+  const t = useTranslations();
+  const locale = useLocale() as Locale;
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (nextLocale: Locale) => {
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("locale", nextLocale);
+      await setDisplayLocaleAction(formData);
+      router.refresh();
+    });
+  };
+
+  return (
+    <Container style={compact ? { maxWidth: "11rem" } : undefined}>
+      <Field>
+        <Select
+          variant={compact ? "compact" : "default"}
+          name="locale"
+          value={locale}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+            handleChange(event.target.value as Locale)
+          }
+          disabled={isPending}
+          aria-label={t("Common.language")}
+        >
+          {locales.map((optionLocale) => (
+            <option key={optionLocale} value={optionLocale}>
+              {localeLabels[optionLocale]}
+            </option>
+          ))}
+        </Select>
+        {showHint && (
+          <InputHint variant="default">{t("Common.languageHint")}</InputHint>
+        )}
+      </Field>
+    </Container>
+  );
+}

--- a/src/components/LocalePicker/LocalePicker.tsx
+++ b/src/components/LocalePicker/LocalePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { localeLabels, locales, type Locale } from "@/i18n/config";
@@ -36,13 +36,29 @@ export default function LocalePicker({
   const locale = useLocale() as Locale;
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
   const handleChange = (nextLocale: Locale) => {
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("locale", nextLocale);
-      await setDisplayLocaleAction(formData);
-      router.refresh();
+    startTransition(() => {
+      void (async () => {
+        setError(null);
+
+        try {
+          const formData = new FormData();
+          formData.set("locale", nextLocale);
+          const result = await setDisplayLocaleAction(formData);
+
+          if (result?.error) {
+            setError(t("Errors.genericLater"));
+            return;
+          }
+
+          router.refresh();
+        } catch (error) {
+          console.error("Error updating display locale:", error);
+          setError(t("Errors.genericLater"));
+        }
+      })();
     });
   };
 
@@ -65,9 +81,11 @@ export default function LocalePicker({
             </option>
           ))}
         </Select>
-        {showHint && (
+        {error ? (
+          <InputHint variant="error">{error}</InputHint>
+        ) : showHint ? (
           <InputHint variant="default">{t("Common.languageHint")}</InputHint>
-        )}
+        ) : null}
       </Field>
     </Container>
   );

--- a/src/components/LocalePicker/index.ts
+++ b/src/components/LocalePicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LocalePicker";

--- a/src/components/NewsletterIssueTile/NewsletterIssueTile.tsx
+++ b/src/components/NewsletterIssueTile/NewsletterIssueTile.tsx
@@ -11,7 +11,7 @@ interface NewsletterIssueTileProps {
   slug: string;
   title: string;
   issueNumber: number;
-  date: string;
+  subtitle: string;
   previewImages?: string[];
 }
 
@@ -20,7 +20,7 @@ export default function NewsletterIssueTile({
   slug,
   title,
   issueNumber,
-  date,
+  subtitle,
   previewImages,
 }: NewsletterIssueTileProps) {
   return (
@@ -32,9 +32,7 @@ export default function NewsletterIssueTile({
       >
         <Text featured={featured}>
           <h3>{title}</h3>
-          <p>
-            Issue #{issueNumber} · {date}
-          </p>
+          <p>{subtitle}</p>
         </Text>
         {featured && (
           <Images>

--- a/src/components/NewsletterIssuesList/NewsletterIssuesList.tsx
+++ b/src/components/NewsletterIssuesList/NewsletterIssuesList.tsx
@@ -14,6 +14,10 @@ export default async function NewsletterIssuesList({
   const locale = await getLocale();
   const newsletterIssues = await getAllNewsletterIssues(locale);
 
+  if (newsletterIssues.length === 0) {
+    return null;
+  }
+
   // Only show an empty issue slot if the number of issues is even
   // ...meaning the list of *past issues* is odd, and needs a spare tile
   const needsEmptyIssueSlot = newsletterIssues.length % 2 === 0;

--- a/src/components/NewsletterIssuesList/NewsletterIssuesList.tsx
+++ b/src/components/NewsletterIssuesList/NewsletterIssuesList.tsx
@@ -3,7 +3,7 @@ import NewsletterIssueTile from "@/components/NewsletterIssueTile";
 import StyledList from "@/components/StyledList";
 import PastIssuesList from "@/components/PastIssuesList";
 import EmptyIssueSlot from "@/components/EmptyIssueSlot";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 export default async function NewsletterIssuesList({
   showPastIssues = true,
@@ -11,7 +11,8 @@ export default async function NewsletterIssuesList({
   showPastIssues?: boolean;
 }) {
   const t = await getTranslations("Newsletter");
-  const newsletterIssues = await getAllNewsletterIssues();
+  const locale = await getLocale();
+  const newsletterIssues = await getAllNewsletterIssues(locale);
 
   // Only show an empty issue slot if the number of issues is even
   // ...meaning the list of *past issues* is odd, and needs a spare tile
@@ -31,7 +32,10 @@ export default async function NewsletterIssuesList({
               newsletterIssues[0].metadata.title
             }
             issueNumber={newsletterIssues[0].customMetadata.issueNumber}
-            date={newsletterIssues[0].formattedDate}
+            subtitle={t("issueTile", {
+              number: newsletterIssues[0].customMetadata.issueNumber,
+              date: newsletterIssues[0].formattedDate,
+            })}
             previewImages={newsletterIssues[0].customMetadata.previewImages}
           />
         </section>
@@ -59,7 +63,10 @@ export default async function NewsletterIssuesList({
                       slug={slug}
                       title={verboseTitle ?? title}
                       issueNumber={issueNumber}
-                      date={formattedDate}
+                      subtitle={t("issueTile", {
+                        number: issueNumber,
+                        date: formattedDate,
+                      })}
                       previewImages={previewImages}
                     />
                   )

--- a/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
+++ b/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
@@ -12,8 +12,10 @@ import InputHint from "@/components/InputHint";
 import {
   updateFirstNameAction,
   updateNewsletterPreferenceAction,
+  updatePreferredLocaleAction,
   sendEmailChangeEmailAction,
 } from "@/app/actions";
+import { localeLabels, locales, type Locale } from "@/i18n/config";
 
 import { styled } from "@pigment-css/react";
 import { validateFirstName, FIELD_CONFIGS } from "@/lib/formValidation";
@@ -113,6 +115,7 @@ type ProfileAccountSettingsProps = {
   profile: {
     first_name?: string;
     is_newsletter_subscribed?: boolean;
+    preferred_locale?: Locale | null;
   };
 };
 
@@ -125,10 +128,14 @@ function ProfileAccountSettings({
   const firstName = useEditableField();
   const email = useEditableField();
   const newsletterPreference = useEditableField();
+  const preferredLocale = useEditableField();
 
   const [tempFirstName, setTempFirstName] = useState(profile?.first_name);
   const [tempNewsletterPreference, setTempNewsletterPreference] = useState(
     profile?.is_newsletter_subscribed
+  );
+  const [tempPreferredLocale, setTempPreferredLocale] = useState<Locale>(
+    profile?.preferred_locale ?? "en"
   );
 
   // const handlePasswordUpdate = async (formData) => {
@@ -161,6 +168,7 @@ function ProfileAccountSettings({
 
     email.setIsUpdating(true);
     email.setError(null);
+    formData.set("locale", tempPreferredLocale);
 
     try {
       const result = await sendEmailChangeEmailAction(formData);
@@ -253,6 +261,30 @@ function ProfileAccountSettings({
   const handleNewsletterPreferenceCancel = () => {
     setTempNewsletterPreference(profile?.is_newsletter_subscribed);
     newsletterPreference.reset();
+  };
+
+  const handlePreferredLocaleUpdate = async (formData: FormData) => {
+    preferredLocale.setIsUpdating(true);
+    preferredLocale.setError(null);
+
+    try {
+      const result = await updatePreferredLocaleAction(formData);
+      if (result?.error) {
+        preferredLocale.setError(result.error);
+      } else {
+        preferredLocale.setIsEditing(false);
+      }
+    } catch (error) {
+      console.error("Error updating preferred locale:", error);
+      preferredLocale.setError(t("Errors.genericLater"));
+    } finally {
+      preferredLocale.setIsUpdating(false);
+    }
+  };
+
+  const handlePreferredLocaleCancel = () => {
+    setTempPreferredLocale(profile?.preferred_locale ?? "en");
+    preferredLocale.reset();
   };
 
   return (
@@ -421,6 +453,65 @@ function ProfileAccountSettings({
             <Button
               variant="secondary"
               onClick={() => newsletterPreference.setIsEditing(true)}
+            >
+              {t("Actions.edit")}
+            </Button>
+          </>
+        )}
+      </ListItem>
+
+      <ListItem editing={preferredLocale.isEditing}>
+        {preferredLocale.isEditing ? (
+          <Form nested={true} action={handlePreferredLocaleUpdate}>
+            <Field>
+              <Label>{t("Common.language")}</Label>
+              <Select
+                name="preferred_locale"
+                value={tempPreferredLocale}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                  setTempPreferredLocale(event.target.value as Locale)
+                }
+                required={true}
+              >
+                {locales.map((locale) => (
+                  <option key={locale} value={locale}>
+                    {localeLabels[locale]}
+                  </option>
+                ))}
+              </Select>
+              <InputHint variant={preferredLocale.error ? "error" : "default"}>
+                {preferredLocale.error
+                  ? preferredLocale.error
+                  : t("Profile.account.languageHint")}
+              </InputHint>
+            </Field>
+
+            <ButtonGroup>
+              <SubmitButton
+                disabled={preferredLocale.isUpdating}
+                loading={preferredLocale.isUpdating}
+                pendingText={t("Status.updating")}
+              >
+                {t("Actions.update")}
+              </SubmitButton>
+              <Button
+                variant="secondary"
+                onClick={handlePreferredLocaleCancel}
+                disabled={preferredLocale.isUpdating}
+              >
+                {t("Actions.cancel")}
+              </Button>
+            </ButtonGroup>
+          </Form>
+        ) : (
+          <>
+            <ListItemReadField>
+              <Label>{t("Common.language")}</Label>
+              <p>{localeLabels[tempPreferredLocale]}</p>
+            </ListItemReadField>
+            <Button
+              variant="secondary"
+              onClick={() => preferredLocale.setIsEditing(true)}
             >
               {t("Actions.edit")}
             </Button>

--- a/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
+++ b/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
@@ -15,7 +15,12 @@ import {
   updatePreferredLocaleAction,
   sendEmailChangeEmailAction,
 } from "@/app/actions";
-import { localeLabels, locales, type Locale } from "@/i18n/config";
+import {
+  defaultLocale,
+  localeLabels,
+  locales,
+  type Locale,
+} from "@/i18n/config";
 
 import { styled } from "@pigment-css/react";
 import { validateFirstName, FIELD_CONFIGS } from "@/lib/formValidation";
@@ -135,7 +140,7 @@ function ProfileAccountSettings({
     profile?.is_newsletter_subscribed
   );
   const [tempPreferredLocale, setTempPreferredLocale] = useState<Locale>(
-    profile?.preferred_locale ?? "en"
+    profile?.preferred_locale ?? defaultLocale
   );
 
   // const handlePasswordUpdate = async (formData) => {
@@ -283,7 +288,7 @@ function ProfileAccountSettings({
   };
 
   const handlePreferredLocaleCancel = () => {
-    setTempPreferredLocale(profile?.preferred_locale ?? "en");
+    setTempPreferredLocale(profile?.preferred_locale ?? defaultLocale);
     preferredLocale.reset();
   };
 

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -7,7 +7,9 @@ const SilentContainer = styled("div")(({ theme }) => ({
   position: "relative",
 }));
 
-const StyledSelect = styled(HeadlessSelect)(({ theme }) => ({
+const StyledSelect = styled(HeadlessSelect, {
+  shouldForwardProp: (prop) => prop !== "variant",
+})(({ theme }) => ({
   width: "100%",
   appearance: "none", // Reset browser-specific styles
   color: theme.colors.text.ui.primary,

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -24,7 +24,7 @@ const StyledSelect = styled(HeadlessSelect)(({ theme }) => ({
 
   fontSize: "1rem",
   minHeight: "3.5rem",
-  padding: "0.375rem 0.75rem",
+  padding: "0.375rem 2.5rem 0.375rem 0.75rem",
 
   outline: "none", // Reset browser-specific outline
   "&:focus, &[data-active]": {
@@ -34,13 +34,26 @@ const StyledSelect = styled(HeadlessSelect)(({ theme }) => ({
   "& *": {
     color: "black", // Apparently needed for Windows? See code example in https://headlessui.com/react/select
   },
+
+  variants: [
+    {
+      props: { variant: "compact" },
+      style: {
+        fontSize: "0.9375rem",
+        minHeight: "2.5rem",
+        padding: "0.25rem 2rem 0.25rem 0.625rem",
+      },
+    },
+  ],
 }));
 
-export default function Select({ children, ...props }) {
+export default function Select({ children, variant = "default", ...props }) {
   return (
     <SilentContainer>
-      <StyledSelect {...props}>{children}</StyledSelect>
-      <DropdownIcon />
+      <StyledSelect variant={variant} {...props}>
+        {children}
+      </StyledSelect>
+      <DropdownIcon variant={variant} />
     </SilentContainer>
   );
 }

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -9,7 +9,7 @@ import { hasSupabaseAuthCookie } from "@/utils/supabase/authCookies";
 
 const currentYear = new Date().getFullYear();
 
-export default async function LegalFooter() {
+export default async function SiteFooter() {
   const t = await getTranslations();
   const cookieStore = await cookies();
   const hasSignedInSession = hasSupabaseAuthCookie(cookieStore.getAll());

--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -1,0 +1,2 @@
+export * from "./SiteFooter";
+export { default } from "./SiteFooter";

--- a/src/components/TranslationNotice/TranslationNotice.tsx
+++ b/src/components/TranslationNotice/TranslationNotice.tsx
@@ -1,0 +1,42 @@
+import { styled } from "@pigment-css/react";
+
+type TranslationNoticeProps = {
+  title: string;
+  body: string;
+};
+
+export default function TranslationNotice({
+  title,
+  body,
+}: TranslationNoticeProps) {
+  return (
+    <Container>
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </Container>
+  );
+}
+
+const Container = styled("aside")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  backgroundColor: theme.colors.background.sunk,
+  padding: "1rem 1.25rem",
+  margin: "0 0 2rem",
+  borderRadius: theme.corners.base,
+  border: `1px solid ${theme.colors.border.base}`,
+
+  "& h3": {
+    margin: 0,
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: theme.colors.text.ui.secondary,
+  },
+
+  "& p": {
+    margin: 0,
+    color: theme.colors.text.ui.quaternary,
+    textWrap: "balance",
+  },
+}));

--- a/src/components/TranslationNotice/index.ts
+++ b/src/components/TranslationNotice/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TranslationNotice";

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -19,11 +19,6 @@ export const siteConfig = {
     general: "dGVhbUBwZWVscy5hcHA=",
     newsletter: "bmV3c2xldHRlckBwZWVscy5hcHA=",
   },
-  newsletter: {
-    description:
-      // TODO: Store in translations files instead
-      "Occasional updates on how Peels is supporting community composting around the world.",
-  },
   meta: {
     explainer:
       "a community platform for connecting folks with food scraps to those who compost",

--- a/src/content/legal/colophon.mdx
+++ b/src/content/legal/colophon.mdx
@@ -30,7 +30,7 @@ Peels is built on the open source React framework <StrongLink href="http://proto
 ### Translations
 
 {/* prettier-ignore */}
-<StrongLink href="https://next-intl.dev/" target="_blank">next-intl</StrongLink> extends Next.js to make language translations straightforward. <StrongLink href="http://crowdin.com" target="_blank">Crowdin</StrongLink> provides a handy web interface for volunteer translators to contribute their expertise.
+<StrongLink href="https://next-intl.dev/" target="_blank">next-intl</StrongLink> extends Next.js to make language translations straightforward. Peels keeps its translation catalogues in-repo so contributors can update product copy and locale files together.
 
 ### Components
 

--- a/src/content/legal/de/privacy.mdx
+++ b/src/content/legal/de/privacy.mdx
@@ -1,0 +1,109 @@
+import { siteConfig } from "@/config/site";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Datenschutz",
+  description:
+    "Diese Datenschutzerklärung erläutert, wie wir deine personenbezogenen Daten erfassen, verwenden und speichern und welche Rechte du in Bezug auf diese Daten hast.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Datenschutzerklärung",
+  updatedDate: "2025-05-11T09:00:00+10:00",
+};
+
+Peels verpflichtet sich zum Schutz deiner Privatsphäre. Diese Datenschutzerklärung erläutert, wie wir deine personenbezogenen Daten erfassen, verwenden und speichern und welche Rechte du in Bezug auf diese Daten hast. Durch die Nutzung von Peels stimmst du den in dieser Datenschutzerklärung beschriebenen Praktiken zu.
+
+## 1. Welche Daten wir erfassen
+
+Wenn du Peels nutzt, erfassen wir die folgenden Arten von Informationen:
+
+### 1.1 Personenbezogene Daten
+
+Wir erfassen personenbezogene Daten, also Informationen, die dich als Person identifizieren können. Dazu gehören:
+
+#### Für alle Nutzerinnen und Nutzer
+
+- Vorname (oder Spitzname).
+- E-Mail-Adresse.
+- Nachrichten, die du sendest und empfängst.
+- Profilfoto (optional).
+
+#### Für Gastgeberinnen und Gastgeber
+
+- Angaben zum Eintrag (z. B. Name des Eintrags, Beschreibung und Kartenkoordinaten).
+- Fotos zum Eintrag (optional).
+- Externe Links (optional).
+
+### 1.2 Cookies und Authentifizierungsdaten
+
+Peels verwendet notwendige Cookies, um die Authentifizierung zu verwalten und den Sitzungsstatus aufrechtzuerhalten. Diese Cookies werden in deinem Browser gespeichert und nicht zu Tracking- oder Werbezwecken verwendet.
+
+### 1.3 Technische Informationen und Nutzungsdaten
+
+Wir erfassen außerdem begrenzte Informationen, die dich nicht direkt identifizieren, um die Sicherheit, Funktionalität und Zuverlässigkeit der Plattform zu gewährleisten. Dazu gehören:
+
+- Browsertyp und Browserversion.
+- Betriebssystem.
+- Zugriffszeitpunkte.
+- Grundlegende Nutzungsmuster (z. B. Aktionen innerhalb der App).
+
+Diese technischen Informationen helfen uns, die Sicherheit und Stabilität der Plattform aufrechtzuerhalten, können aber nicht genutzt werden, um dich persönlich zu identifizieren.
+
+## 2. Wie wir deine Daten verwenden
+
+Wir verwenden deine personenbezogenen Daten, um:
+
+- die Peels-Plattform bereitzustellen und zu verbessern,
+- Verbindungen zwischen Nutzerinnen und Nutzern zu ermöglichen,
+- dich über wichtige Aktualisierungen oder Änderungen des Dienstes zu informieren (z. B. Änderungen der Bedingungen),
+- die Sicherheit und Funktionalität der Plattform sicherzustellen.
+
+Mit deiner ausdrücklichen Einwilligung (Opt-in) können wir deine E-Mail-Adresse außerdem verwenden, um gelegentliche Newsletter über Peels zu versenden. Du kannst dich jederzeit über den Link in den E-Mails oder in deinen Profileinstellungen abmelden.
+
+Wir können anonymisierte und aggregierte Daten (z. B. Statistiken über Kompostierungsaktivitäten) mit lokalen Behörden, gemeinnützigen Organisationen oder ähnlichen Einrichtungen teilen, um Nachhaltigkeit zu fördern und die Abfallbildung zu verbessern. Diese Daten werden dich niemals persönlich identifizieren.
+
+## 3. Wo deine Daten gespeichert werden
+
+Peels nutzt die folgenden Drittanbieter, um deine Daten zu speichern und zu verarbeiten:
+
+- **Supabase**: Hoster unserer Datenbank und Dateispeicherung mit Servern in Sydney, Australien.
+- **Vercel**: Hoster der Peels-Plattforminfrastruktur und des Domain-Managements mit Servern in den USA.
+- **MapTiler**: Anbieter von Geolokalisierungs- und Kartendiensten für die Peels-Plattform.
+- **Resend**: Anbieter für transaktionale E-Mails wie Benachrichtigungen und Nachrichten zwischen Nutzerinnen und Nutzern.
+
+Daten können aufgrund der von uns genutzten Dienste in Länder außerhalb deines Standorts übertragen oder dort verarbeitet werden (z. B. in den USA). Wir stellen sicher, dass solche Übermittlungen den geltenden Datenschutzgesetzen entsprechen und dass diese Anbieter branchenübliche Standards für Datenschutz und Sicherheit erfüllen.
+
+## 4. Deine Rechte
+
+Du hast in Bezug auf deine personenbezogenen Daten die folgenden Rechte:
+
+1. **Auskunft**: eine Kopie der personenbezogenen Daten anfordern, die wir über dich gespeichert haben.
+2. **Berichtigung**: die Korrektur unrichtiger oder unvollständiger Daten verlangen.
+3. **Löschung**: die Löschung deiner personenbezogenen Daten verlangen, vorbehaltlich unserer gesetzlichen Verpflichtungen.
+4. **Einschränkung**: verlangen, dass wir die Verarbeitung deiner personenbezogenen Daten in bestimmten Situationen einschränken.
+5. **Datenübertragbarkeit**: deine Daten in einem portablen Format anfordern.
+6. **Widerspruch**: der Verarbeitung deiner personenbezogenen Daten in bestimmten Situationen widersprechen.
+
+Die meisten dieser Rechte kannst du direkt über deine Profileinstellungen ausüben, wo du eine vollständige Kopie deiner personenbezogenen Daten herunterladen, deine Informationen aktualisieren oder dein Konto löschen kannst. Bitte <EncodedEmailLink address={siteConfig.encodedEmail.support}>kontaktiere uns</EncodedEmailLink> für weitere Anfragen oder wenn du Unterstützung benötigst. Für bestimmte Anfragen kann eine Identitätsprüfung erforderlich sein.
+
+## 5. Wie lange wir deine Daten speichern
+
+Wir bewahren deine personenbezogenen Daten nur so lange auf, wie es für die Bereitstellung der Plattform erforderlich ist oder gesetzlich vorgeschrieben ist. Zum Beispiel:
+
+- Nachrichten und Einträge werden gespeichert, bis sie von der nutzenden Person gelöscht werden oder das Konto beendet wird.
+- Notwendige Cookies laufen mit dem Ende deiner Sitzung oder entsprechend den funktionalen Anforderungen ab.
+
+Gelöschte Daten werden innerhalb eines angemessenen Zeitraums aus unseren Systemen entfernt, sofern ihre Aufbewahrung nicht aus rechtlichen oder sicherheitsrelevanten Gründen erforderlich ist.
+
+## 6. Sicherheit deiner Daten
+
+Wir treffen angemessene technische und organisatorische Maßnahmen, um deine Daten vor unbefugtem Zugriff, Verlust oder Missbrauch zu schützen. Kein System ist jedoch vollkommen sicher, und wir können die absolute Sicherheit deiner Daten nicht garantieren.
+
+## 7. Änderungen an dieser Erklärung
+
+Wir können diese Datenschutzerklärung von Zeit zu Zeit aktualisieren, um Änderungen an unseren Diensten oder rechtlichen Anforderungen Rechnung zu tragen. Wenn wesentliche Änderungen vorgenommen werden, informieren wir dich über die Plattform oder per E-Mail. Deine fortgesetzte Nutzung von Peels nach solchen Änderungen gilt als Zustimmung zur aktualisierten Erklärung.
+
+## 8. Kontakt
+
+Bitte <EncodedEmailLink address={siteConfig.encodedEmail.support}>kontaktiere uns</EncodedEmailLink>, wenn du Fragen oder Bedenken zu dieser Datenschutzerklärung hast oder deine Rechte ausüben möchtest.

--- a/src/content/legal/de/terms.mdx
+++ b/src/content/legal/de/terms.mdx
@@ -1,0 +1,119 @@
+import { siteConfig } from "@/config/site";
+import StrongLink from "@/components/StrongLink";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Bedingungen",
+  description:
+    "Durch den Zugriff auf Peels oder dessen Nutzung stimmst du diesen Nutzungsbedingungen zu.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Nutzungsbedingungen",
+  updatedDate: "2025-01-19T09:00:00+10:00",
+};
+
+Durch den Zugriff auf Peels oder dessen Nutzung stimmst du diesen Nutzungsbedingungen („Bedingungen“) zu. Wenn du nicht zustimmst, stelle die Nutzung von Peels bitte sofort ein. Diese Bedingungen bilden eine rechtliche Vereinbarung zwischen dir und Peels („wir“, „uns“, „unser“) und regeln deine Nutzung unserer Plattform, Dienste und Inhalte.
+
+## 1. Wer Peels nutzen kann
+
+Um Peels zu nutzen, musst du:
+
+- mindestens 18 Jahre alt sein,
+- die volle rechtliche Fähigkeit haben, diese Vereinbarung einzugehen.
+
+Durch die Nutzung von Peels erklärst und garantierst du, dass du diese Voraussetzungen erfüllst.
+
+## 2. Zweck von Peels
+
+Peels ist eine Plattform, die Menschen mit Lebensmittelresten („Spenderinnen und Spender“) mit Personen oder Orten verbindet, die diese für Kompostierung oder andere Nachhaltigkeitsprojekte nutzen können („Gastgeberinnen und Gastgeber“). Wir stellen die Verbindung her und sind nicht verantwortlich für Interaktionen, Vereinbarungen oder Streitigkeiten zwischen Nutzerinnen und Nutzern.
+
+## 3. Deine Verantwortlichkeiten
+
+Durch die Nutzung von Peels erklärst du dich damit einverstanden:
+
+- die Plattform nur für ihren vorgesehenen Zweck zu nutzen: Menschen für den Austausch von Lebensmittelresten zu verbinden,
+- beim Einrichten deines Profils oder Erstellen von Einträgen genaue und wahrheitsgemäße Angaben zu machen,
+- auf Nachrichten innerhalb eines angemessenen Zeitraums zu reagieren. Konten, die sich innerhalb eines angemessenen Zeitraums nicht beteiligen, können gesperrt oder gekündigt werden,
+- sicherzustellen, dass an Gastgeberinnen und Gastgeber abgegebene Lebensmittelreste frei von schädlichen oder ungeeigneten Materialien sind (z. B. Plastik, nicht organische Abfälle oder gefährliche Stoffe) und den angegebenen Anforderungen und Richtlinien entsprechen,
+- kein Privatgrundstück ohne ausdrückliche Zustimmung der Eigentümerin oder des Eigentümers zu betreten, selbst wenn ein Gastgeber-Eintrag von der Straße aus sichtbar ist,
+- alle veröffentlichten Anweisungen und Richtlinien für Abgabestellen zu befolgen,
+- keine automatisierten Systeme oder Bots zu verwenden, die unsere Server überlasten oder den Betrieb der Plattform stören könnten. Dazu zählt jede Software, die mehr Anfragen an unsere Server sendet, als eine Person durch normale Nutzung der Plattform vernünftigerweise erzeugen könnte.
+
+Du erklärst dich damit einverstanden, nicht:
+
+- sexuell explizite, illegale, beleidigende oder unangemessene Inhalte hochzuladen oder zu teilen,
+- Peels für Aktivitäten zu nutzen, die nichts mit seinem Zweck zu tun haben,
+- Daten von Peels (z. B. Einträge, Nutzerprofile oder andere Plattforminhalte) ohne unsere schriftliche Genehmigung für kommerzielle Zwecke zu verwenden,
+- andere Nutzerinnen und Nutzer zu belästigen, zu bedrohen oder zu schädigen oder sich missbräuchlich zu verhalten,
+- bei der Nutzung der Plattform gegen geltende Gesetze oder Vorschriften zu verstoßen.
+
+## 4. Gemeinschaftsrichtlinien
+
+Wir möchten eine respektvolle und inklusive Gemeinschaft fördern. Bitte begegne anderen mit Freundlichkeit und beteilige dich konstruktiv. Verstöße gegen diese Richtlinien können zu Verwarnungen, Sperrungen oder der Kündigung deines Kontos führen.
+
+## 5. Von Nutzerinnen und Nutzern erzeugte Inhalte
+
+Peels hostet in begrenztem Umfang von Nutzerinnen und Nutzern erzeugte Inhalte, darunter:
+
+- Namen, Spitznamen oder andere Kennzeichnungen,
+- Profilfotos oder Avatare,
+- Nachrichteninhalte zwischen Nutzerinnen und Nutzern,
+- Einträge einschließlich Beschreibungen und Koordinaten.
+
+Durch das Hochladen dieser Inhalte gewährst du uns eine nicht exklusive, weltweite und lizenzfreie Lizenz, diese für den Betrieb und die Verbesserung der Plattform zu verwenden. Das Eigentum an deinen Inhalten verbleibt bei dir.
+
+## 6. Haftungsbeschränkung
+
+Peels ist eine Plattform zur Vermittlung von Kontakten und übernimmt keine Gewähr für die Qualität, Sicherheit oder Rechtmäßigkeit von Lebensmittelresten, Einträgen oder Interaktionen zwischen Nutzerinnen und Nutzern. Wir haften nicht für:
+
+- Streitigkeiten, Schäden oder Verluste, die aus Interaktionen zwischen Nutzerinnen und Nutzern entstehen,
+- Schäden, die durch über die Plattform ausgetauschte Lebensmittelreste verursacht werden,
+- die Richtigkeit von Informationen, die von Nutzerinnen und Nutzern bereitgestellt werden.
+
+Durch die Nutzung von Peels verzichtest du auf jedes Recht, gegen uns rechtlich vorzugehen, soweit es um Streitigkeiten mit anderen Nutzerinnen und Nutzern oder Schäden aus deiner Nutzung der Plattform geht.
+
+## Deine Datenschutzrechte
+
+Du hast in Bezug auf deine personenbezogenen Daten die folgenden Rechte:
+
+1. **Recht auf Auskunft**: Du kannst eine Kopie der personenbezogenen Daten anfordern, die wir über dich gespeichert haben.
+2. **Recht auf Berichtigung**: Du kannst verlangen, dass wir unrichtige oder unvollständige Informationen korrigieren.
+3. **Recht auf Löschung**: Du kannst verlangen, dass wir deine Daten löschen, vorbehaltlich unserer gesetzlichen Verpflichtungen.
+4. **Recht auf Einschränkung der Verarbeitung**: Du kannst verlangen, dass wir die Verarbeitung deiner personenbezogenen Daten in bestimmten Umständen einschränken.
+5. **Recht auf Datenübertragbarkeit**: Du kannst deine Daten in einem portablen Format anfordern.
+6. **Recht auf Widerspruch**: Du kannst unserer Nutzung deiner personenbezogenen Daten in bestimmten Situationen widersprechen, auch für Direktmarketing.
+
+Die meisten dieser Rechte kannst du direkt über deine Profileinstellungen ausüben, wo du eine vollständige Kopie deiner personenbezogenen Daten herunterladen, deine Informationen aktualisieren oder dein Konto löschen kannst. Bitte <EncodedEmailLink address={siteConfig.encodedEmail.support}>kontaktiere uns</EncodedEmailLink> für weitere Anfragen oder Unterstützung. Für bestimmte Anfragen kann eine Identitätsprüfung erforderlich sein.
+
+Daten können aufgrund der von uns genutzten Dienste in Länder außerhalb deines Standorts übertragen oder dort verarbeitet werden (z. B. in den USA). Wir stellen sicher, dass solche Übermittlungen den geltenden Datenschutzgesetzen entsprechen.
+
+Weitere Informationen darüber, wie wir deine personenbezogenen Daten verarbeiten, findest du in unserer <StrongLink href="/privacy">Datenschutzerklärung</StrongLink>.
+
+## 7. Keine Gewährleistungen
+
+Peels wird „wie besehen“ und „wie verfügbar“ bereitgestellt, ohne Gewährleistungen irgendeiner Art. Wir garantieren nicht, dass die Plattform fehlerfrei, unterbrechungsfrei oder sicher ist.
+
+## 8. Änderungen an diesen Bedingungen
+
+Wir können diese Bedingungen von Zeit zu Zeit aktualisieren, um Änderungen an unseren Diensten, rechtlichen Anforderungen oder anderen wichtigen Faktoren Rechnung zu tragen. Wenn wesentliche Änderungen vorgenommen werden, informieren wir dich über die Plattform oder per E-Mail. Deine fortgesetzte Nutzung von Peels nach solchen Änderungen gilt als Annahme der aktualisierten Bedingungen.
+
+## 9. Beschwerden und Meldung von Problemen
+
+Wenn du auf ein Problem stößt oder einen Verstoß gegen diese Bedingungen melden möchtest, <EncodedEmailLink address={siteConfig.encodedEmail.support}>kontaktiere uns</EncodedEmailLink>. Wir werden Probleme innerhalb eines angemessenen Zeitraums untersuchen und bearbeiten, sind aber nicht verpflichtet, Streitigkeiten zwischen Nutzerinnen und Nutzern zu schlichten.
+
+## 10. Sperrung und Kündigung von Konten
+
+Wir behalten uns das Recht vor, Konten zu sperren oder zu kündigen, die:
+
+- gegen diese Bedingungen oder die Gemeinschaftsrichtlinien verstoßen,
+- nicht innerhalb eines angemessenen Zeitraums auf Nachrichten reagieren,
+- die Plattform für andere Zwecke als die vorgesehenen nutzen.
+
+## 11. Anwendbares Recht
+
+Diese Bedingungen unterliegen dem Recht Australiens. Durch die Nutzung von Peels erklärst du dich im Falle einer rechtlichen Streitigkeit mit der Zuständigkeit australischer Gerichte einverstanden.
+
+## 12. Kontakt
+
+Bitte <EncodedEmailLink address={siteConfig.encodedEmail.support}>kontaktiere uns</EncodedEmailLink>, wenn du Fragen zu diesen Bedingungen hast.

--- a/src/content/legal/es/privacy.mdx
+++ b/src/content/legal/es/privacy.mdx
@@ -106,8 +106,5 @@ Podemos actualizar esta política de privacidad periódicamente para reflejar ca
 
 ## 8. Contacto
 
-<EncodedEmailLink address={siteConfig.encodedEmail.support}>
-  Contáctanos
-</EncodedEmailLink>
-si tienes preguntas o inquietudes sobre esta política de privacidad, o si deseas
-ejercer tus derechos.
+{/* prettier-ignore */}
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>Contáctanos</EncodedEmailLink> si tienes preguntas o inquietudes sobre esta política de privacidad, o si deseas ejercer tus derechos.

--- a/src/content/legal/es/privacy.mdx
+++ b/src/content/legal/es/privacy.mdx
@@ -1,0 +1,113 @@
+import { siteConfig } from "@/config/site";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Privacidad",
+  description:
+    "Esta política de privacidad explica cómo recopilamos, usamos y almacenamos tu información personal, así como tus derechos sobre ella.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Política de privacidad",
+  updatedDate: "2025-05-11T09:00:00+10:00",
+};
+
+Peels se compromete a proteger tu privacidad. Esta política de privacidad explica cómo recopilamos, usamos y almacenamos tu información personal, así como tus derechos sobre ella. Al usar Peels, aceptas las prácticas descritas en esta política de privacidad.
+
+## 1. Qué datos recopilamos
+
+Cuando usas Peels, recopilamos los siguientes tipos de información:
+
+### 1.1 Información personal
+
+Recopilamos información personal (o información que permite identificarte como individuo). Esto incluye:
+
+#### Para todas las personas usuarias
+
+- Nombre de pila (o apodo).
+- Dirección de correo electrónico.
+- Mensajes que envías y recibes.
+- Foto de perfil (opcional).
+
+#### Para las personas anfitrionas
+
+- Información del anuncio (por ejemplo, nombre del anuncio, descripción y coordenadas del mapa).
+- Fotos del anuncio (opcional).
+- Enlaces externos (opcional).
+
+### 1.2 Cookies y datos de autenticación
+
+Peels utiliza cookies esenciales para gestionar la autenticación de las personas usuarias y mantener el estado de la sesión. Estas cookies se almacenan en tu navegador y no se usan con fines de seguimiento ni publicidad.
+
+### 1.3 Información técnica y de uso
+
+También recopilamos información limitada que no te identifica directamente para ayudar a mantener la seguridad, la funcionalidad y la fiabilidad de la plataforma. Esto incluye:
+
+- Tipo y versión del navegador.
+- Sistema operativo.
+- Registros de acceso.
+- Patrones básicos de uso (por ejemplo, acciones realizadas dentro de la aplicación).
+
+Esta información técnica nos ayuda a mantener la seguridad y la estabilidad de la plataforma, pero no puede utilizarse para identificarte personalmente.
+
+## 2. Cómo usamos tus datos
+
+Usamos tu información personal para:
+
+- Proporcionar y mejorar la plataforma Peels.
+- Facilitar conexiones entre personas usuarias.
+- Notificarte sobre actualizaciones importantes o cambios del servicio (por ejemplo, actualizaciones de los términos).
+- Garantizar la seguridad y el funcionamiento de la plataforma.
+
+Con tu consentimiento explícito (opt-in), también podemos usar tu dirección de correo para enviarte boletines ocasionales sobre Peels. Puedes darte de baja en cualquier momento a través del enlace incluido en los correos o desde la configuración de tu perfil.
+
+Podemos compartir datos anonimizados y agregados (por ejemplo, estadísticas sobre la actividad de compostaje) con gobiernos locales, organizaciones sin ánimo de lucro u otras entidades similares para promover la sostenibilidad y mejorar la educación sobre residuos. Estos datos nunca te identificarán personalmente.
+
+## 3. Dónde se almacenan tus datos
+
+Peels utiliza los siguientes servicios de terceros para almacenar y procesar tus datos:
+
+- **Supabase**: aloja nuestra base de datos y el almacenamiento de archivos, con servidores ubicados en Sídney, Australia.
+- **Vercel**: aloja la infraestructura de la plataforma Peels y la gestión del dominio, con servidores ubicados en Estados Unidos.
+- **MapTiler**: proporciona servicios de geolocalización y mapas para la plataforma Peels.
+- **Resend**: gestiona los correos transaccionales, como notificaciones y mensajes entre personas usuarias.
+
+Los datos pueden transferirse o procesarse en países fuera de tu ubicación (por ejemplo, Estados Unidos) debido a los servicios que utilizamos. Nos aseguramos de que esas transferencias cumplan con la legislación aplicable en materia de protección de datos y de que estos proveedores cumplan con los estándares del sector en seguridad y protección.
+
+## 4. Tus derechos
+
+Tienes los siguientes derechos con respecto a tus datos personales:
+
+1. **Acceso**: solicitar una copia de los datos personales que tenemos sobre ti.
+2. **Rectificación**: solicitar correcciones de datos inexactos o incompletos.
+3. **Supresión**: solicitar la eliminación de tus datos personales, sujeta a nuestras obligaciones legales.
+4. **Restricción**: solicitar que limitemos el tratamiento de tus datos personales en determinadas situaciones.
+5. **Portabilidad**: solicitar tus datos en un formato portable.
+6. **Oposición**: oponerte a la forma en que tratamos tus datos personales en determinadas situaciones.
+
+La mayoría de estos derechos pueden ejercerse directamente desde la configuración de tu perfil, donde puedes descargar una copia completa de tus datos personales, actualizar tu información o eliminar tu cuenta. <EncodedEmailLink address={siteConfig.encodedEmail.support}>Contáctanos</EncodedEmailLink> para cualquier otra solicitud o si necesitas ayuda. En determinados casos puede requerirse la verificación de tu identidad.
+
+## 5. Cuánto tiempo conservamos tus datos
+
+Conservamos tu información personal solo durante el tiempo necesario para prestar la plataforma o cuando así lo exija la ley. Por ejemplo:
+
+- Los mensajes y anuncios se conservan hasta que la persona usuaria los elimina o se cierra su cuenta.
+- Las cookies esenciales caducan al finalizar la sesión o según lo requiera el funcionamiento.
+
+Los datos eliminados se retiran de nuestros sistemas en un plazo razonable, salvo que deban conservarse por motivos legales o de seguridad.
+
+## 6. Seguridad de tus datos
+
+Adoptamos medidas técnicas y organizativas razonables para proteger tus datos frente a accesos no autorizados, pérdidas o usos indebidos. Sin embargo, ningún sistema es totalmente seguro y no podemos garantizar una seguridad absoluta.
+
+## 7. Cambios en esta política
+
+Podemos actualizar esta política de privacidad periódicamente para reflejar cambios en nuestros servicios o en los requisitos legales. Si se producen cambios importantes, te lo notificaremos a través de la plataforma o por correo electrónico. El uso continuado de Peels después de esos cambios constituye tu aceptación de la política actualizada.
+
+## 8. Contacto
+
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>
+  Contáctanos
+</EncodedEmailLink>
+si tienes preguntas o inquietudes sobre esta política de privacidad, o si deseas
+ejercer tus derechos.

--- a/src/content/legal/es/terms.mdx
+++ b/src/content/legal/es/terms.mdx
@@ -115,7 +115,5 @@ Estos Términos se rigen por las leyes de Australia. Al usar Peels, aceptas some
 
 ## 12. Contacto
 
-<EncodedEmailLink address={siteConfig.encodedEmail.support}>
-  Contáctanos
-</EncodedEmailLink>
-si tienes preguntas sobre estos Términos.
+{/* prettier-ignore */}
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>Contáctanos</EncodedEmailLink> si tienes preguntas sobre estos Términos.

--- a/src/content/legal/es/terms.mdx
+++ b/src/content/legal/es/terms.mdx
@@ -1,0 +1,121 @@
+import { siteConfig } from "@/config/site";
+import StrongLink from "@/components/StrongLink";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Términos",
+  description: "Al acceder o usar Peels, aceptas estos términos de uso.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Términos de uso",
+  updatedDate: "2025-01-19T09:00:00+10:00",
+};
+
+Al acceder o usar Peels, aceptas estos términos de uso («Términos»). Si no estás de acuerdo, deja de usar Peels de inmediato. Estos Términos constituyen un acuerdo legal entre tú y Peels («nosotros», «nuestro», «nuestra») y rigen tu uso de nuestra plataforma, servicios y contenido.
+
+## 1. Quién puede usar Peels
+
+Para usar Peels, debes:
+
+- Tener al menos 18 años.
+- Tener plena capacidad legal para celebrar este acuerdo.
+
+Al usar Peels, declaras y garantizas que cumples estos requisitos de elegibilidad.
+
+## 2. Finalidad de Peels
+
+Peels es una plataforma diseñada para conectar a personas que tienen restos de comida para donar («Donantes») con personas o lugares que pueden utilizarlos para compostaje u otros proyectos de sostenibilidad («Anfitriones»). Actuamos como intermediarios y no somos responsables de las interacciones, acuerdos o disputas entre personas usuarias.
+
+## 3. Tus responsabilidades
+
+Al usar Peels, aceptas:
+
+- Utilizar la plataforma únicamente para su finalidad prevista: conectar a personas para el intercambio de restos de comida.
+- Proporcionar información exacta y veraz al configurar tu perfil o crear anuncios.
+- Responder a los mensajes en un plazo razonable. Las cuentas que no participen dentro de un plazo razonable pueden ser suspendidas o canceladas.
+- Asegurarte de que los restos de comida facilitados a las personas anfitrionas estén libres de materiales nocivos o inapropiados (por ejemplo, plásticos, residuos no orgánicos o materiales peligrosos) y se ajusten a los requisitos y directrices de la persona anfitriona.
+- No entrar en ninguna propiedad privada sin el consentimiento explícito de la persona propietaria, aunque el anuncio de una persona anfitriona sea visible desde la calle.
+- Seguir todas las instrucciones y directrices publicadas para los puntos de entrega.
+- No utilizar sistemas automatizados o bots que puedan saturar nuestros servidores o alterar el funcionamiento de la plataforma. Esto incluye cualquier software que envíe más solicitudes a nuestros servidores de las que una persona podría generar razonablemente mediante el uso normal de la plataforma.
+
+Aceptas no:
+
+- Subir o compartir contenido sexualmente explícito, ilegal, ofensivo o inapropiado.
+- Usar Peels para actividades ajenas a su finalidad.
+- Utilizar los datos de Peels (por ejemplo anuncios, perfiles u otro contenido de la plataforma) con fines comerciales sin nuestro permiso por escrito.
+- Acosar, amenazar o dañar a otras personas ni participar en conductas abusivas.
+- Infringir las leyes o normativas aplicables mientras utilizas la plataforma.
+
+## 4. Normas de la comunidad
+
+Queremos fomentar una comunidad respetuosa e inclusiva. Trata a las demás personas con amabilidad y participa de forma constructiva. La vulneración de estas normas puede dar lugar a advertencias, suspensión o cancelación de tu cuenta.
+
+## 5. Contenido generado por las personas usuarias
+
+Peels aloja una cantidad limitada de contenido generado por personas usuarias, entre ello:
+
+- Nombres, apodos u otros identificadores.
+- Fotos de perfil o avatares.
+- Contenido de mensajes entre personas usuarias.
+- Anuncios, incluidas descripciones y coordenadas.
+
+Al subir este contenido, nos concedes una licencia no exclusiva, mundial y libre de regalías para utilizarlo con el fin de operar y mejorar la plataforma. La propiedad del contenido sigue siendo tuya.
+
+## 6. Limitación de responsabilidad
+
+Peels es una plataforma para facilitar conexiones y no garantiza la calidad, seguridad o legalidad de los restos de comida, los anuncios o las interacciones entre personas usuarias. No somos responsables de:
+
+- Cualquier disputa, daño o pérdida derivados de interacciones entre personas usuarias.
+- Cualquier daño causado por restos de comida intercambiados a través de la plataforma.
+- La exactitud de la información facilitada por las personas usuarias.
+
+Al usar Peels, renuncias a cualquier derecho a emprender acciones legales contra nosotros por disputas con otras personas usuarias o por daños derivados del uso de la plataforma.
+
+## Tus derechos de protección de datos
+
+Tienes los siguientes derechos con respecto a tus datos personales:
+
+1. **Derecho de acceso**: puedes solicitar una copia de los datos personales que tenemos sobre ti.
+2. **Derecho de rectificación**: puedes solicitar que corrijamos información inexacta o incompleta.
+3. **Derecho de supresión**: puedes solicitar que eliminemos tus datos, sujeto a nuestras obligaciones legales.
+4. **Derecho a limitar el tratamiento**: puedes solicitar que limitemos el tratamiento de tus datos personales en determinadas circunstancias.
+5. **Derecho a la portabilidad de los datos**: puedes solicitar tus datos en un formato portable.
+6. **Derecho de oposición**: puedes oponerte al uso de tus datos personales en determinadas situaciones, incluido el marketing directo.
+
+La mayoría de estos derechos pueden ejercerse directamente desde la configuración de tu perfil, donde puedes descargar una copia completa de tus datos personales, actualizar tu información o eliminar tu cuenta. <EncodedEmailLink address={siteConfig.encodedEmail.support}>Contáctanos</EncodedEmailLink> para cualquier otra solicitud o ayuda. En determinados casos puede requerirse la verificación de tu identidad.
+
+Los datos pueden transferirse o procesarse en países fuera de tu ubicación (por ejemplo, Estados Unidos) debido a los servicios que utilizamos. Nos aseguramos de que dichas transferencias cumplan con la legislación aplicable en materia de protección de datos.
+
+Para obtener más información sobre cómo tratamos tus datos personales, consulta nuestra <StrongLink href="/privacy">política de privacidad</StrongLink>.
+
+## 7. Sin garantías
+
+Peels se proporciona «tal cual» y «según disponibilidad», sin garantías de ningún tipo. No garantizamos que la plataforma esté libre de errores, que funcione sin interrupciones o que sea segura.
+
+## 8. Cambios en estos términos
+
+Podemos actualizar estos Términos periódicamente para reflejar cambios en nuestros servicios, requisitos legales u otros factores importantes. Si se producen cambios significativos, te lo notificaremos a través de la plataforma o por correo electrónico. El uso continuado de Peels después de esos cambios constituye tu aceptación de los Términos actualizados.
+
+## 9. Quejas y notificación de problemas
+
+Si encuentras un problema o necesitas informar de una infracción de estos Términos, <EncodedEmailLink address={siteConfig.encodedEmail.support}>contáctanos</EncodedEmailLink>. Investigaremos y abordaremos los problemas en un plazo razonable, pero no estamos obligados a mediar disputas entre personas usuarias.
+
+## 10. Suspensión y cancelación de cuenta
+
+Nos reservamos el derecho de suspender o cancelar cuentas que:
+
+- Infrinjan estos Términos o las normas de la comunidad.
+- No respondan a los mensajes en un plazo razonable.
+- Utilicen la plataforma con fines ajenos a su finalidad prevista.
+
+## 11. Ley aplicable
+
+Estos Términos se rigen por las leyes de Australia. Al usar Peels, aceptas someterte a la jurisdicción de los tribunales australianos en caso de disputa legal.
+
+## 12. Contacto
+
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>
+  Contáctanos
+</EncodedEmailLink>
+si tienes preguntas sobre estos Términos.

--- a/src/content/legal/fr/privacy.mdx
+++ b/src/content/legal/fr/privacy.mdx
@@ -1,0 +1,109 @@
+import { siteConfig } from "@/config/site";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Confidentialité",
+  description:
+    "Cette politique de confidentialité explique comment nous collectons, utilisons et stockons vos données personnelles, ainsi que vos droits à leur sujet.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Politique de confidentialité",
+  updatedDate: "2025-05-11T09:00:00+10:00",
+};
+
+Peels s’engage à protéger votre vie privée. Cette politique de confidentialité explique comment nous collectons, utilisons et stockons vos données personnelles, ainsi que vos droits à leur sujet. En utilisant Peels, vous acceptez les pratiques décrites dans cette politique de confidentialité.
+
+## 1. Quelles données nous collectons
+
+Lorsque vous utilisez Peels, nous collectons les types d’informations suivants :
+
+### 1.1 Données personnelles
+
+Nous collectons des données personnelles (ou informations permettant de vous identifier), c’est-à-dire toute donnée qui peut vous identifier en tant qu’individu. Cela comprend :
+
+#### Pour l’ensemble des utilisateurs et utilisatrices
+
+- Prénom (ou pseudonyme).
+- Adresse e-mail.
+- Messages envoyés et reçus.
+- Photo de profil (facultative).
+
+#### Pour les personnes hôtes
+
+- Informations d’annonce (par exemple le nom de l’annonce, sa description ou ses coordonnées sur la carte).
+- Photos de l’annonce (facultatives).
+- Liens externes (facultatifs).
+
+### 1.2 Cookies et données d’authentification
+
+Peels utilise des cookies essentiels pour gérer l’authentification des membres et maintenir l’état de connexion. Ces cookies sont stockés dans votre navigateur et ne sont pas utilisés à des fins de suivi ou de publicité.
+
+### 1.3 Informations techniques et d’usage
+
+Nous collectons aussi des informations limitées qui ne permettent pas de vous identifier directement, afin de maintenir la sécurité, la fonctionnalité et la fiabilité de la plateforme. Cela comprend :
+
+- Le type et la version du navigateur.
+- Le système d’exploitation.
+- Les horodatages d’accès.
+- Des schémas d’usage basiques (par exemple les actions effectuées dans l’application).
+
+Ces informations techniques nous aident à préserver la sécurité et la stabilité de la plateforme, mais ne peuvent pas être utilisées pour vous identifier personnellement.
+
+## 2. Comment nous utilisons vos données
+
+Nous utilisons vos données personnelles pour :
+
+- Fournir et améliorer la plateforme Peels.
+- Faciliter les mises en relation entre personnes utilisatrices.
+- Vous informer des mises à jour importantes ou des changements de service (par exemple des mises à jour des conditions).
+- Garantir la sécurité et le bon fonctionnement de la plateforme.
+
+Avec votre consentement explicite (opt-in), nous pouvons également utiliser votre adresse e-mail pour vous envoyer des infolettres occasionnelles à propos de Peels. Vous pouvez vous désabonner à tout moment via le lien présent dans les e-mails ou dans vos paramètres de profil.
+
+Nous pouvons partager des données anonymisées et agrégées (par exemple des statistiques sur l’activité de compostage) avec des collectivités locales, des organismes à but non lucratif ou des organisations similaires afin de promouvoir la durabilité et d’améliorer l’éducation autour des déchets. Ces données ne vous identifieront jamais personnellement.
+
+## 3. Où vos données sont stockées
+
+Peels utilise les services tiers suivants pour stocker et traiter vos données :
+
+- **Supabase** : hébergement de notre base de données et de notre stockage de fichiers, avec des serveurs situés à Sydney, en Australie.
+- **Vercel** : hébergement de l’infrastructure de Peels et gestion du domaine, avec des serveurs situés aux États-Unis.
+- **MapTiler** : services de géolocalisation et de cartographie pour la plateforme Peels.
+- **Resend** : gestion des e-mails transactionnels, tels que les notifications et les messages entre membres.
+
+Les données peuvent être transférées ou traitées dans des pays situés hors de votre lieu de résidence (par exemple aux États-Unis) en raison des services que nous utilisons. Nous veillons à ce que ces transferts respectent les lois applicables en matière de protection des données, et à ce que ces prestataires répondent aux standards du secteur en matière de sécurité et de protection.
+
+## 4. Vos droits
+
+Vous disposez des droits suivants concernant vos données personnelles :
+
+1. **Accès** : demander une copie des données personnelles que nous détenons à votre sujet.
+2. **Rectification** : demander la correction de données inexactes ou incomplètes.
+3. **Effacement** : demander la suppression de vos données personnelles, sous réserve de nos obligations légales.
+4. **Restriction** : demander que nous limitions le traitement de vos données personnelles dans certaines situations.
+5. **Portabilité** : demander vos données dans un format portable.
+6. **Opposition** : vous opposer à la manière dont nous traitons vos données personnelles dans certaines situations.
+
+La plupart de ces droits peuvent être exercés directement depuis vos paramètres de profil, où vous pouvez télécharger une copie complète de vos données personnelles, mettre à jour vos informations ou supprimer votre compte. Veuillez <EncodedEmailLink address={siteConfig.encodedEmail.support}>nous contacter</EncodedEmailLink> pour toute autre demande ou si vous avez besoin d’aide. Une vérification d’identité peut être requise pour certaines demandes.
+
+## 5. Combien de temps nous conservons vos données
+
+Nous conservons vos données personnelles uniquement aussi longtemps que nécessaire pour fournir la plateforme ou lorsque la loi l’exige. Par exemple :
+
+- Les messages et les annonces sont conservés jusqu’à leur suppression par la personne utilisatrice ou jusqu’à la fermeture de son compte.
+- Les cookies essentiels expirent à la fin de votre session ou selon les besoins de fonctionnement.
+
+Les données supprimées sont retirées de nos systèmes dans un délai raisonnable, sauf si leur conservation est nécessaire pour des raisons légales ou de sécurité.
+
+## 6. Sécurité de vos données
+
+Nous prenons des mesures techniques et organisationnelles raisonnables pour protéger vos données contre l’accès non autorisé, la perte ou l’usage abusif. Aucun système n’étant totalement sûr, nous ne pouvons toutefois pas garantir une sécurité absolue.
+
+## 7. Modifications de cette politique
+
+Nous pouvons mettre à jour cette politique de confidentialité de temps à autre afin de refléter des changements dans nos services ou dans les exigences légales. En cas de modification importante, nous vous en informerons via la plateforme ou par e-mail. L’usage continu de Peels après ces changements vaut acceptation de la politique mise à jour.
+
+## 8. Contact
+
+Veuillez <EncodedEmailLink address={siteConfig.encodedEmail.support}>nous contacter</EncodedEmailLink> si vous avez des questions ou des préoccupations concernant cette politique de confidentialité, ou si vous souhaitez exercer vos droits.

--- a/src/content/legal/fr/terms.mdx
+++ b/src/content/legal/fr/terms.mdx
@@ -1,0 +1,119 @@
+import { siteConfig } from "@/config/site";
+import StrongLink from "@/components/StrongLink";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Conditions",
+  description:
+    "En accédant à Peels ou en l’utilisant, vous acceptez les présentes conditions d’utilisation.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Conditions d’utilisation",
+  updatedDate: "2025-01-19T09:00:00+10:00",
+};
+
+En accédant à Peels ou en l’utilisant, vous acceptez les présentes conditions d’utilisation (« Conditions »). Si vous n’êtes pas d’accord, veuillez cesser immédiatement d’utiliser Peels. Ces Conditions constituent un accord juridique entre vous et Peels (« nous », « notre », « nos ») et régissent votre utilisation de notre plateforme, de nos services et de notre contenu.
+
+## 1. Qui peut utiliser Peels
+
+Pour utiliser Peels, vous devez :
+
+- Avoir au moins 18 ans.
+- Avoir la pleine capacité juridique pour conclure cet accord.
+
+En utilisant Peels, vous déclarez et garantissez que vous remplissez ces conditions d’éligibilité.
+
+## 2. Objet de Peels
+
+Peels est une plateforme conçue pour mettre en relation des personnes qui ont des restes alimentaires à donner (« Donneurs ») avec des personnes ou lieux pouvant les utiliser pour le compostage ou d’autres projets liés à la durabilité (« Hôtes »). Nous jouons un rôle de mise en relation et ne sommes pas responsables des interactions, accords ou litiges entre personnes utilisatrices.
+
+## 3. Vos responsabilités
+
+En utilisant Peels, vous acceptez de :
+
+- Utiliser la plateforme uniquement pour son objectif prévu : mettre en relation des personnes autour de l’échange de restes alimentaires.
+- Fournir des informations exactes et sincères lors de la création de votre profil ou de vos annonces.
+- Répondre aux messages dans un délai raisonnable. Les comptes qui ne participent pas dans un délai raisonnable peuvent être suspendus ou supprimés.
+- Veiller à ce que les restes alimentaires fournis aux hôtes soient exempts de matériaux nocifs ou inappropriés (par exemple plastique, déchets non organiques ou substances dangereuses) et respectent les exigences et consignes indiquées par l’hôte.
+- Ne pas pénétrer sur une propriété privée sans le consentement explicite de la personne propriétaire, même si une annonce d’hôte est visible depuis la rue.
+- Respecter toutes les instructions et consignes affichées pour les lieux de dépôt.
+- Ne pas utiliser de systèmes automatisés ou de robots susceptibles de surcharger nos serveurs ou de perturber le fonctionnement de la plateforme. Cela inclut tout logiciel qui enverrait davantage de requêtes qu’une personne ne pourrait raisonnablement en générer dans le cadre d’un usage normal.
+
+Vous acceptez de ne pas :
+
+- Téléverser ou partager du contenu sexuellement explicite, illégal, offensant ou inapproprié.
+- Utiliser Peels pour des activités sans lien avec son objectif.
+- Utiliser les données de Peels (par exemple les annonces, profils membres ou autres contenus de la plateforme) à des fins commerciales sans notre autorisation écrite.
+- Harceler, menacer ou nuire à d’autres personnes, ni adopter un comportement abusif.
+- Enfreindre des lois ou réglementations applicables lors de l’utilisation de la plateforme.
+
+## 4. Principes communautaires
+
+Nous souhaitons favoriser une communauté respectueuse et inclusive. Merci de traiter les autres avec bienveillance et de contribuer de manière constructive. Toute violation de ces principes peut entraîner des avertissements, une suspension ou la suppression du compte.
+
+## 5. Contenus générés par les utilisateurs et utilisatrices
+
+Peels héberge une quantité limitée de contenus générés par les personnes utilisatrices, notamment :
+
+- Des noms, pseudonymes ou autres identifiants.
+- Des photos de profil ou avatars.
+- Le contenu des messages entre membres.
+- Des annonces, y compris leurs descriptions et coordonnées.
+
+En téléversant ce contenu, vous nous accordez une licence non exclusive, mondiale et gratuite pour l’utiliser dans le cadre du fonctionnement et de l’amélioration de la plateforme. Vous restez propriétaire de votre contenu.
+
+## 6. Limitation de responsabilité
+
+Peels est une plateforme de mise en relation et ne garantit ni la qualité, ni la sécurité, ni la légalité des restes alimentaires, des annonces ou des interactions entre personnes utilisatrices. Nous ne sommes pas responsables :
+
+- Des litiges, dommages ou pertes résultant des interactions entre personnes utilisatrices.
+- De tout dommage causé par les restes alimentaires échangés via la plateforme.
+- De l’exactitude des informations fournies par les personnes utilisatrices.
+
+En utilisant Peels, vous renoncez à toute action en justice contre nous concernant des litiges avec d’autres personnes utilisatrices ou des dommages résultant de votre utilisation de la plateforme.
+
+## Vos droits en matière de protection des données
+
+Vous disposez des droits suivants concernant vos données personnelles :
+
+1. **Droit d’accès** : vous pouvez demander une copie des données personnelles que nous détenons à votre sujet.
+2. **Droit de rectification** : vous pouvez demander que nous corrigions toute information inexacte ou incomplète.
+3. **Droit à l’effacement** : vous pouvez demander la suppression de vos données, sous réserve de nos obligations légales.
+4. **Droit à la limitation du traitement** : vous pouvez demander que nous limitions le traitement de vos données personnelles dans certaines circonstances.
+5. **Droit à la portabilité des données** : vous pouvez demander que vos données vous soient fournies dans un format portable.
+6. **Droit d’opposition** : vous pouvez vous opposer à l’utilisation de vos données personnelles dans certaines situations, y compris à des fins de marketing direct.
+
+La plupart de ces droits peuvent être exercés directement dans vos paramètres de profil, où vous pouvez télécharger une copie complète de vos données personnelles, mettre à jour vos informations ou supprimer votre compte. Veuillez <EncodedEmailLink address={siteConfig.encodedEmail.support}>nous contacter</EncodedEmailLink> pour toute autre demande ou assistance. Une vérification d’identité peut être exigée pour certaines demandes.
+
+Les données peuvent être transférées ou traitées dans des pays situés hors de votre lieu de résidence (par exemple aux États-Unis) en raison des services que nous utilisons. Nous veillons à ce que ces transferts respectent les lois applicables en matière de protection des données.
+
+Pour plus d’informations sur la manière dont nous traitons vos données personnelles, veuillez consulter notre <StrongLink href="/privacy">politique de confidentialité</StrongLink>.
+
+## 7. Absence de garanties
+
+Peels est fourni « en l’état » et « selon disponibilité », sans garantie d’aucune sorte. Nous ne garantissons pas que la plateforme sera exempte d’erreurs, ininterrompue ou sécurisée.
+
+## 8. Modifications de ces conditions
+
+Nous pouvons mettre à jour ces Conditions de temps à autre afin de refléter des changements dans nos services, les exigences légales ou d’autres facteurs importants. En cas de modification importante, nous vous en informerons via la plateforme ou par e-mail. L’utilisation continue de Peels après ces changements vaut acceptation des conditions mises à jour.
+
+## 9. Plaintes et signalement de problèmes
+
+Si vous rencontrez un problème ou souhaitez signaler une violation des présentes Conditions, veuillez <EncodedEmailLink address={siteConfig.encodedEmail.support}>nous contacter</EncodedEmailLink>. Nous enquêterons et traiterons les problèmes dans un délai raisonnable, sans être tenus de servir de médiateur dans les litiges entre personnes utilisatrices.
+
+## 10. Suspension et résiliation du compte
+
+Nous nous réservons le droit de suspendre ou de supprimer les comptes qui :
+
+- Enfreignent les présentes Conditions ou les principes communautaires.
+- Ne répondent pas aux messages dans un délai raisonnable.
+- Utilisent la plateforme à des fins autres que celles prévues.
+
+## 11. Droit applicable
+
+Les présentes Conditions sont régies par le droit australien. En utilisant Peels, vous acceptez de vous soumettre à la compétence des juridictions australiennes en cas de litige juridique.
+
+## 12. Contact
+
+Veuillez <EncodedEmailLink address={siteConfig.encodedEmail.support}>nous contacter</EncodedEmailLink> si vous avez des questions sur ces Conditions.

--- a/src/content/legal/pt-BR/privacy.mdx
+++ b/src/content/legal/pt-BR/privacy.mdx
@@ -1,0 +1,113 @@
+import { siteConfig } from "@/config/site";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Privacidade",
+  description:
+    "Esta política de privacidade explica como coletamos, usamos e armazenamos os seus dados pessoais, bem como os seus direitos em relação a eles.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Política de privacidade",
+  updatedDate: "2025-05-11T09:00:00+10:00",
+};
+
+O Peels está comprometido em proteger a sua privacidade. Esta política de privacidade explica como coletamos, usamos e armazenamos os seus dados pessoais, bem como os seus direitos em relação a eles. Ao usar o Peels, você concorda com as práticas descritas nesta política de privacidade.
+
+## 1. Quais dados coletamos
+
+Quando você usa o Peels, coletamos os seguintes tipos de informação:
+
+### 1.1 Dados pessoais
+
+Coletamos dados pessoais (ou informações que permitem identificar você como indivíduo). Isso inclui:
+
+#### Para todas as pessoas usuárias
+
+- Primeiro nome (ou apelido).
+- Endereço de e-mail.
+- Mensagens que você envia e recebe.
+- Foto de perfil (opcional).
+
+#### Para pessoas anfitriãs
+
+- Informações do anúncio (por exemplo nome do anúncio, descrição e coordenadas no mapa).
+- Fotos do anúncio (opcional).
+- Links externos (opcional).
+
+### 1.2 Cookies e dados de autenticação
+
+O Peels usa cookies essenciais para gerir a autenticação das pessoas usuárias e manter o estado da sessão. Esses cookies ficam armazenados no seu navegador e não são usados para rastreamento nem para publicidade.
+
+### 1.3 Informações técnicas e de uso
+
+Também coletamos informações limitadas que não identificam você diretamente para ajudar a manter a segurança, a funcionalidade e a confiabilidade da plataforma. Isso inclui:
+
+- Tipo e versão do navegador.
+- Sistema operacional.
+- Registros de acesso.
+- Padrões básicos de uso (por exemplo ações realizadas dentro do aplicativo).
+
+Essas informações técnicas ajudam a manter a segurança e a estabilidade da plataforma, mas não podem ser usadas para identificar você pessoalmente.
+
+## 2. Como usamos os seus dados
+
+Usamos os seus dados pessoais para:
+
+- Fornecer e melhorar a plataforma Peels.
+- Facilitar conexões entre pessoas usuárias.
+- Avisar sobre atualizações importantes ou mudanças no serviço (por exemplo atualizações dos termos).
+- Garantir a segurança e o funcionamento da plataforma.
+
+Com o seu consentimento explícito (opt-in), também podemos usar o seu endereço de e-mail para enviar boletins ocasionais sobre o Peels. Você pode cancelar a inscrição a qualquer momento pelo link nos e-mails ou nas configurações do seu perfil.
+
+Podemos compartilhar dados anonimizados e agregados (por exemplo estatísticas sobre atividades de compostagem) com governos locais, organizações sem fins lucrativos ou grupos semelhantes para promover a sustentabilidade e melhorar a educação sobre resíduos. Esses dados nunca identificarão você pessoalmente.
+
+## 3. Onde os seus dados são armazenados
+
+O Peels usa os seguintes serviços de terceiros para armazenar e processar os seus dados:
+
+- **Supabase**: hospeda o nosso banco de dados e o armazenamento de arquivos, com servidores localizados em Sydney, Austrália.
+- **Vercel**: hospeda a infraestrutura da plataforma Peels e a gestão do domínio, com servidores localizados nos Estados Unidos.
+- **MapTiler**: fornece serviços de geolocalização e mapas para a plataforma Peels.
+- **Resend**: cuida dos e-mails transacionais, como notificações e mensagens entre pessoas usuárias.
+
+Os dados podem ser transferidos ou processados em países fora da sua localização (por exemplo os Estados Unidos) por causa dos serviços que usamos. Garantimos que essas transferências estejam em conformidade com as leis aplicáveis de proteção de dados e que esses fornecedores atendam aos padrões do setor em matéria de proteção e segurança.
+
+## 4. Seus direitos
+
+Você tem os seguintes direitos em relação aos seus dados pessoais:
+
+1. **Acesso**: solicitar uma cópia dos dados pessoais que mantemos sobre você.
+2. **Retificação**: solicitar a correção de dados incorretos ou incompletos.
+3. **Eliminação**: solicitar a exclusão dos seus dados pessoais, sujeito às nossas obrigações legais.
+4. **Restrição**: solicitar que limitemos o tratamento dos seus dados pessoais em determinadas situações.
+5. **Portabilidade**: solicitar os seus dados em um formato portátil.
+6. **Oposição**: opor-se à forma como processamos os seus dados pessoais em determinadas situações.
+
+A maior parte desses direitos pode ser exercida diretamente nas configurações do seu perfil, onde você pode baixar uma cópia completa dos seus dados pessoais, atualizar as suas informações ou excluir a sua conta. <EncodedEmailLink address={siteConfig.encodedEmail.support}>Entre em contato conosco</EncodedEmailLink> para outros pedidos ou caso precise de ajuda. A verificação de identidade pode ser exigida em determinados casos.
+
+## 5. Por quanto tempo mantemos os seus dados
+
+Mantemos os seus dados pessoais apenas pelo tempo necessário para fornecer a plataforma ou conforme exigido por lei. Por exemplo:
+
+- Mensagens e anúncios são mantidos até serem excluídos pela pessoa usuária ou até o encerramento da conta.
+- Cookies essenciais expiram quando a sessão termina ou conforme necessário para o funcionamento.
+
+Os dados excluídos são removidos dos nossos sistemas dentro de um prazo razoável, salvo quando a retenção for necessária por motivos legais ou de segurança.
+
+## 6. Segurança dos seus dados
+
+Adotamos medidas técnicas e organizacionais razoáveis para proteger os seus dados contra acesso não autorizado, perda ou uso indevido. Ainda assim, nenhum sistema é totalmente seguro e não podemos garantir segurança absoluta.
+
+## 7. Alterações nesta política
+
+Podemos atualizar esta política de privacidade de tempos em tempos para refletir mudanças nos nossos serviços ou nas exigências legais. Se houver alterações significativas, avisaremos você pela plataforma ou por e-mail. O uso contínuo do Peels após essas alterações constitui a sua aceitação da política atualizada.
+
+## 8. Contato
+
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>
+  Entre em contato conosco
+</EncodedEmailLink>
+se você tiver dúvidas ou preocupações sobre esta política de privacidade, ou se
+quiser exercer os seus direitos.

--- a/src/content/legal/pt-BR/privacy.mdx
+++ b/src/content/legal/pt-BR/privacy.mdx
@@ -106,8 +106,5 @@ Podemos atualizar esta política de privacidade de tempos em tempos para refleti
 
 ## 8. Contato
 
-<EncodedEmailLink address={siteConfig.encodedEmail.support}>
-  Entre em contato conosco
-</EncodedEmailLink>
-se você tiver dúvidas ou preocupações sobre esta política de privacidade, ou se
-quiser exercer os seus direitos.
+{/* prettier-ignore */}
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>Entre em contato conosco</EncodedEmailLink> se você tiver dúvidas ou preocupações sobre esta política de privacidade, ou se quiser exercer os seus direitos.

--- a/src/content/legal/pt-BR/terms.mdx
+++ b/src/content/legal/pt-BR/terms.mdx
@@ -116,7 +116,5 @@ Estes Termos são regidos pelas leis da Austrália. Ao usar o Peels, você conco
 
 ## 12. Contato
 
-<EncodedEmailLink address={siteConfig.encodedEmail.support}>
-  Entre em contato conosco
-</EncodedEmailLink>
-se você tiver qualquer dúvida sobre estes Termos.
+{/* prettier-ignore */}
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>Entre em contato conosco</EncodedEmailLink> se você tiver qualquer dúvida sobre estes Termos.

--- a/src/content/legal/pt-BR/terms.mdx
+++ b/src/content/legal/pt-BR/terms.mdx
@@ -1,0 +1,122 @@
+import { siteConfig } from "@/config/site";
+import StrongLink from "@/components/StrongLink";
+import EncodedEmailLink from "@/components/EncodedEmailLink";
+
+export const metadata = {
+  title: "Termos",
+  description:
+    "Ao acessar ou usar o Peels, você concorda com estes termos de uso.",
+};
+
+export const customMetadata = {
+  verboseTitle: "Termos de uso",
+  updatedDate: "2025-01-19T09:00:00+10:00",
+};
+
+Ao acessar ou usar o Peels, você concorda com estes termos de uso (“Termos”). Se você não concordar, interrompa imediatamente o uso do Peels. Estes Termos constituem um acordo legal entre você e o Peels (“nós”, “nosso”, “nossa”) e regem o seu uso da nossa plataforma, serviços e conteúdo.
+
+## 1. Quem pode usar o Peels
+
+Para usar o Peels, você deve:
+
+- Ter pelo menos 18 anos.
+- Ter plena capacidade legal para celebrar este acordo.
+
+Ao usar o Peels, você declara e garante que cumpre esses requisitos de elegibilidade.
+
+## 2. Finalidade do Peels
+
+O Peels é uma plataforma criada para conectar pessoas que têm restos de comida para doar (“Doadores”) com pessoas ou locais que podem usá-los para compostagem ou outros projetos de sustentabilidade (“Anfitriões”). Atuamos como ponte entre as pessoas e não somos responsáveis por interações, acordos ou disputas entre pessoas usuárias.
+
+## 3. Suas responsabilidades
+
+Ao usar o Peels, você concorda em:
+
+- Usar a plataforma apenas para o seu propósito previsto: conectar pessoas para a troca de restos de comida.
+- Fornecer informações precisas e verdadeiras ao configurar o seu perfil ou criar anúncios.
+- Responder às mensagens em tempo razoável. Contas que não interajam dentro de um prazo razoável podem ser suspensas ou encerradas.
+- Garantir que quaisquer restos de comida fornecidos às pessoas anfitriãs estejam livres de materiais nocivos ou inadequados (por exemplo plástico, resíduos não orgânicos ou itens perigosos) e correspondam aos requisitos e orientações informados pela pessoa anfitriã.
+- Não entrar em propriedade privada sem consentimento explícito da pessoa proprietária, mesmo que um anúncio esteja visível da rua.
+- Seguir todas as instruções e orientações publicadas para os pontos de entrega.
+- Não utilizar sistemas automatizados ou bots que possam sobrecarregar os nossos servidores ou prejudicar o funcionamento da plataforma. Isso inclui qualquer software que envie mais solicitações aos nossos servidores do que uma pessoa poderia razoavelmente gerar por meio do uso normal da plataforma.
+
+Você concorda em não:
+
+- Enviar ou compartilhar conteúdo sexualmente explícito, ilegal, ofensivo ou inadequado.
+- Usar o Peels para atividades sem relação com a sua finalidade.
+- Usar dados do Peels (por exemplo anúncios, perfis de pessoas usuárias ou outro conteúdo da plataforma) para fins comerciais sem a nossa autorização por escrito.
+- Assediar, ameaçar ou prejudicar outras pessoas, nem se envolver em comportamento abusivo.
+- Violar leis ou regulamentos aplicáveis ao usar a plataforma.
+
+## 4. Diretrizes da comunidade
+
+Queremos promover uma comunidade respeitosa e inclusiva. Trate as outras pessoas com gentileza e participe de forma construtiva. Violações dessas diretrizes podem resultar em advertências, suspensão ou encerramento da conta.
+
+## 5. Conteúdo gerado por pessoas usuárias
+
+O Peels hospeda uma quantidade limitada de conteúdo gerado pelas pessoas usuárias, incluindo:
+
+- Nomes, apelidos ou outros identificadores.
+- Fotos de perfil ou avatares.
+- Conteúdo de mensagens entre pessoas usuárias.
+- Anúncios, incluindo descrições e coordenadas.
+
+Ao enviar esse conteúdo, você nos concede uma licença não exclusiva, mundial e sem royalties para usá-lo no funcionamento e na melhoria da plataforma. A propriedade do conteúdo continua sendo sua.
+
+## 6. Limitação de responsabilidade
+
+O Peels é uma plataforma para facilitar conexões e não garante a qualidade, a segurança ou a legalidade dos restos de comida, dos anúncios ou das interações entre pessoas usuárias. Não somos responsáveis por:
+
+- Quaisquer disputas, danos ou perdas decorrentes de interações entre pessoas usuárias.
+- Qualquer dano causado por restos de comida trocados por meio da plataforma.
+- A precisão das informações fornecidas por pessoas usuárias.
+
+Ao usar o Peels, você renuncia a qualquer direito de mover ação judicial contra nós por disputas com outras pessoas usuárias ou por danos resultantes do seu uso da plataforma.
+
+## Seus direitos de proteção de dados
+
+Você tem os seguintes direitos em relação aos seus dados pessoais:
+
+1. **Direito de acesso**: você pode solicitar uma cópia dos dados pessoais que mantemos sobre você.
+2. **Direito de retificação**: você pode solicitar a correção de informações incorretas ou incompletas.
+3. **Direito de eliminação**: você pode solicitar que excluamos os seus dados, sujeito às nossas obrigações legais.
+4. **Direito de restringir o tratamento**: você pode solicitar que limitemos o tratamento dos seus dados pessoais em determinadas circunstâncias.
+5. **Direito à portabilidade dos dados**: você pode solicitar os seus dados em formato portátil.
+6. **Direito de oposição**: você pode se opor ao uso dos seus dados pessoais em determinadas situações, inclusive para fins de marketing direto.
+
+A maior parte desses direitos pode ser exercida diretamente nas configurações do seu perfil, onde você pode baixar uma cópia completa dos seus dados pessoais, atualizar as suas informações ou excluir a sua conta. <EncodedEmailLink address={siteConfig.encodedEmail.support}>Entre em contato conosco</EncodedEmailLink> para outros pedidos ou assistência. A verificação de identidade pode ser exigida em alguns casos.
+
+Os dados podem ser transferidos ou processados em países fora da sua localização (por exemplo os Estados Unidos) devido aos serviços que utilizamos. Garantimos que essas transferências cumpram as leis aplicáveis de proteção de dados.
+
+Para mais informações sobre como tratamos os seus dados pessoais, consulte a nossa <StrongLink href="/privacy">política de privacidade</StrongLink>.
+
+## 7. Sem garantias
+
+O Peels é fornecido “no estado em que se encontra” e “conforme disponível”, sem garantias de qualquer tipo. Não garantimos que a plataforma será livre de erros, ininterrupta ou segura.
+
+## 8. Alterações destes termos
+
+Podemos atualizar estes Termos de tempos em tempos para refletir mudanças nos nossos serviços, requisitos legais ou outros fatores importantes. Se houver alterações significativas, notificaremos você pela plataforma ou por e-mail. O uso contínuo do Peels após essas alterações constitui a sua aceitação dos Termos atualizados.
+
+## 9. Reclamações e reporte de problemas
+
+Se você tiver um problema ou quiser relatar uma violação destes Termos, <EncodedEmailLink address={siteConfig.encodedEmail.support}>entre em contato conosco</EncodedEmailLink>. Investigaremos e trataremos os problemas dentro de um prazo razoável, mas não somos obrigados a mediar disputas entre pessoas usuárias.
+
+## 10. Suspensão e encerramento de conta
+
+Reservamo-nos o direito de suspender ou encerrar contas que:
+
+- Violem estes Termos ou as Diretrizes da Comunidade.
+- Não respondam às mensagens em tempo razoável.
+- Usem a plataforma para fins fora do seu uso pretendido.
+
+## 11. Lei aplicável
+
+Estes Termos são regidos pelas leis da Austrália. Ao usar o Peels, você concorda em se submeter à jurisdição dos tribunais australianos em caso de disputa legal.
+
+## 12. Contato
+
+<EncodedEmailLink address={siteConfig.encodedEmail.support}>
+  Entre em contato conosco
+</EncodedEmailLink>
+se você tiver qualquer dúvida sobre estes Termos.

--- a/src/content/newsletter/de/beginning-to-look-like-compost.mdx
+++ b/src/content/newsletter/de/beginning-to-look-like-compost.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../beginning-to-look-like-compost.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Es sieht langsam sehr nach Kompost aus",
+  description:
+    "Wir haben das Ende von 2025 erreicht und Peels wird bald ein Jahr alt. Hier ist ein kurzes Update.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 2,
+  verboseTitle: "Es sieht langsam sehr nach Kompost aus",
+  ogImage: "kaicycle.jpg",
+  previewImages: ["power-neighbourhood-house.jpg", "kaicycle.jpg"],
+  publishDate: "2025-12-23T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Diese Ausgabe ist derzeit nur auf Englisch verfügbar"
+  body="Wir arbeiten noch an Übersetzungen der Newsletter-Ausgaben. Bis dahin ist die vollständige Ausgabe unten die englische Version."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/de/celebrating-the-first-few-months.mdx
+++ b/src/content/newsletter/de/celebrating-the-first-few-months.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../celebrating-the-first-few-months.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Die ersten Monate feiern",
+  description:
+    "Die ersten Monate von Peels waren gross. Hier ist ein Update dazu, was passiert ist und worauf wir hinarbeiten.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 1,
+  verboseTitle: "Die ersten Monate von Peels feiern",
+  ogImage: "peels-map.jpg",
+  previewImages: ["peels-map.jpg", "kirrily.jpg"],
+  publishDate: "2025-06-03T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Diese Ausgabe ist derzeit nur auf Englisch verfügbar"
+  body="Wir arbeiten noch an Übersetzungen der Newsletter-Ausgaben. Bis dahin ist die vollständige Ausgabe unten die englische Version."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/es/beginning-to-look-like-compost.mdx
+++ b/src/content/newsletter/es/beginning-to-look-like-compost.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../beginning-to-look-like-compost.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Ya empieza a parecer compost",
+  description:
+    "Hemos llegado al final de 2025 y Peels está a punto de cumplir un año. Aquí tienes una breve actualización.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 2,
+  verboseTitle: "Ya empieza a parecer compost",
+  ogImage: "kaicycle.jpg",
+  previewImages: ["power-neighbourhood-house.jpg", "kaicycle.jpg"],
+  publishDate: "2025-12-23T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Este número solo está disponible en inglés por ahora"
+  body="Todavía estamos traduciendo los números del boletín. Por ahora, la edición completa que aparece abajo está en inglés."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/es/celebrating-the-first-few-months.mdx
+++ b/src/content/newsletter/es/celebrating-the-first-few-months.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../celebrating-the-first-few-months.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Celebrando los primeros meses",
+  description:
+    "Han sido unos primeros meses muy grandes para Peels. Aquí tienes una actualización sobre lo que ha pasado y hacia dónde vamos.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 1,
+  verboseTitle: "Celebrando los primeros meses de Peels",
+  ogImage: "peels-map.jpg",
+  previewImages: ["peels-map.jpg", "kirrily.jpg"],
+  publishDate: "2025-06-03T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Este número solo está disponible en inglés por ahora"
+  body="Todavía estamos traduciendo los números del boletín. Por ahora, la edición completa que aparece abajo está en inglés."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/fr/beginning-to-look-like-compost.mdx
+++ b/src/content/newsletter/fr/beginning-to-look-like-compost.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../beginning-to-look-like-compost.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Ça commence à ressembler à du compost",
+  description:
+    "Nous arrivons à la fin de 2025 et Peels va bientôt fêter sa première année. Voici une brève mise à jour.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 2,
+  verboseTitle: "Ça commence à ressembler à du compost",
+  ogImage: "kaicycle.jpg",
+  previewImages: ["power-neighbourhood-house.jpg", "kaicycle.jpg"],
+  publishDate: "2025-12-23T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Ce numéro n’est disponible qu’en anglais pour le moment"
+  body="Nous sommes encore en train de traduire les numéros de l’infolettre. Pour l’instant, la version complète ci-dessous est en anglais."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/fr/celebrating-the-first-few-months.mdx
+++ b/src/content/newsletter/fr/celebrating-the-first-few-months.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../celebrating-the-first-few-months.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Célébrer les premiers mois",
+  description:
+    "Les premiers mois de Peels ont été riches. Voici un point sur ce qui s’est passé et sur ce vers quoi nous avançons.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 1,
+  verboseTitle: "Célébrer les premiers mois de Peels",
+  ogImage: "peels-map.jpg",
+  previewImages: ["peels-map.jpg", "kirrily.jpg"],
+  publishDate: "2025-06-03T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Ce numéro n’est disponible qu’en anglais pour le moment"
+  body="Nous sommes encore en train de traduire les numéros de l’infolettre. Pour l’instant, la version complète ci-dessous est en anglais."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/pt-BR/beginning-to-look-like-compost.mdx
+++ b/src/content/newsletter/pt-BR/beginning-to-look-like-compost.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../beginning-to-look-like-compost.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Está começando a ficar com cara de composto",
+  description:
+    "Chegamos ao fim de 2025 e o Peels está prestes a completar um ano. Aqui vai uma atualização breve.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 2,
+  verboseTitle: "Está começando a ficar com cara de composto",
+  ogImage: "kaicycle.jpg",
+  previewImages: ["power-neighbourhood-house.jpg", "kaicycle.jpg"],
+  publishDate: "2025-12-23T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Esta edição está disponível apenas em inglês por enquanto"
+  body="Ainda estamos traduzindo as edições do boletim. Por enquanto, a edição completa abaixo está em inglês."
+/>
+
+<BaseIssue />

--- a/src/content/newsletter/pt-BR/celebrating-the-first-few-months.mdx
+++ b/src/content/newsletter/pt-BR/celebrating-the-first-few-months.mdx
@@ -1,0 +1,24 @@
+import BaseIssue from "../celebrating-the-first-few-months.mdx";
+import TranslationNotice from "@/components/TranslationNotice";
+
+export const metadata = {
+  title: "Celebrando os primeiros meses",
+  description:
+    "Os primeiros meses do Peels foram intensos. Aqui vai uma atualização sobre o que aconteceu e para onde estamos indo.",
+  authors: ["Danny White"],
+};
+
+export const customMetadata = {
+  issueNumber: 1,
+  verboseTitle: "Celebrando os primeiros meses do Peels",
+  ogImage: "peels-map.jpg",
+  previewImages: ["peels-map.jpg", "kirrily.jpg"],
+  publishDate: "2025-06-03T09:00:00+10:00",
+};
+
+<TranslationNotice
+  title="Esta edição está disponível apenas em inglês por enquanto"
+  body="Ainda estamos traduzindo as edições do boletim. Por enquanto, a edição completa abaixo está em inglês."
+/>
+
+<BaseIssue />

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -85,18 +85,21 @@ export function parseAcceptLanguageHeader(
       const qualityParam = params.find((param) =>
         param.trim().startsWith("q=")
       );
-      const quality = Number.parseFloat(
+      const parsedQuality = Number.parseFloat(
         qualityParam?.trim().replace("q=", "") ?? "1"
       );
+      const quality = Number.isFinite(parsedQuality)
+        ? Math.min(Math.max(parsedQuality, 0), 1)
+        : 0;
 
       return {
-        quality: Number.isFinite(quality) ? quality : 0,
+        quality,
         locale: normaliseLocale(languageTag),
       };
     })
     .filter(
       (entry): entry is { quality: number; locale: Locale } =>
-        entry.locale !== null
+        entry.locale !== null && entry.quality > 0
     )
     .sort((left, right) => right.quality - left.quality)
     .map((entry) => entry.locale);

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,7 +1,103 @@
 export type Locale = (typeof locales)[number];
 
 // Any new languages need to have their locale added here
-export const locales = ["en", "es", "de"] as const;
+export const locales = ["en", "es", "de", "pt-BR", "fr"] as const;
 
 // English as the default
 export const defaultLocale: Locale = "en";
+
+export const localeCookieName = "NEXT_LOCALE";
+
+export const localeLabels: Record<Locale, string> = {
+  en: "English",
+  es: "Español",
+  de: "Deutsch",
+  "pt-BR": "Português (Brasil)",
+  fr: "Français",
+};
+
+const localeAliasMap: Record<string, Locale> = {
+  en: "en",
+  "en-au": "en",
+  "en-gb": "en",
+  "en-us": "en",
+  es: "es",
+  "es-419": "es",
+  "es-ar": "es",
+  "es-cl": "es",
+  "es-co": "es",
+  "es-es": "es",
+  "es-mx": "es",
+  de: "de",
+  "de-at": "de",
+  "de-ch": "de",
+  "de-de": "de",
+  pt: "pt-BR",
+  "pt-br": "pt-BR",
+  "pt-pt": "pt-BR",
+  fr: "fr",
+  "fr-be": "fr",
+  "fr-ca": "fr",
+  "fr-fr": "fr",
+};
+
+export function isValidLocale(value: unknown): value is Locale {
+  return typeof value === "string" && locales.includes(value as Locale);
+}
+
+export function normaliseLocale(
+  value: string | null | undefined
+): Locale | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  if (isValidLocale(trimmedValue)) {
+    return trimmedValue;
+  }
+
+  const lowerCaseValue = trimmedValue.toLowerCase();
+  const directMatch = localeAliasMap[lowerCaseValue];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const [baseLanguage] = lowerCaseValue.split("-");
+  return localeAliasMap[baseLanguage] ?? null;
+}
+
+export function parseAcceptLanguageHeader(
+  headerValue: string | null
+): Locale[] {
+  if (!headerValue) {
+    return [];
+  }
+
+  return headerValue
+    .split(",")
+    .map((entry) => {
+      const [languageTag, ...params] = entry.trim().split(";");
+      const qualityParam = params.find((param) =>
+        param.trim().startsWith("q=")
+      );
+      const quality = Number.parseFloat(
+        qualityParam?.trim().replace("q=", "") ?? "1"
+      );
+
+      return {
+        quality: Number.isFinite(quality) ? quality : 0,
+        locale: normaliseLocale(languageTag),
+      };
+    })
+    .filter(
+      (entry): entry is { quality: number; locale: Locale } =>
+        entry.locale !== null
+    )
+    .sort((left, right) => right.quality - left.quality)
+    .map((entry) => entry.locale);
+}

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -38,6 +38,15 @@ export async function getUserLocale() {
   } = await supabase.auth.getUser();
 
   if (user?.id) {
+    const metadataLocale = normaliseLocale(
+      typeof user.user_metadata?.preferred_locale === "string"
+        ? user.user_metadata.preferred_locale
+        : null
+    );
+    if (metadataLocale) {
+      return metadataLocale;
+    }
+
     const { data: profile, error: profileError } = await supabase
       .from("profiles")
       .select("preferred_locale")
@@ -54,15 +63,6 @@ export async function getUserLocale() {
     const profileLocale = normaliseLocale(profile?.preferred_locale ?? null);
     if (profileLocale) {
       return profileLocale;
-    }
-
-    const metadataLocale = normaliseLocale(
-      typeof user.user_metadata?.preferred_locale === "string"
-        ? user.user_metadata.preferred_locale
-        : null
-    );
-    if (metadataLocale) {
-      return metadataLocale;
     }
   }
 

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -1,34 +1,75 @@
 "use server";
 
 import { cookies, headers } from "next/headers";
-import { defaultLocale, type Locale, locales } from "@/i18n/config";
+import { createClient } from "@/utils/supabase/server";
+import {
+  defaultLocale,
+  type Locale,
+  isValidLocale,
+  localeCookieName,
+  normaliseLocale,
+  parseAcceptLanguageHeader,
+} from "@/i18n/config";
 
-// In this example the locale is read from a cookie. You could alternatively
-// also read it from a database, backend service, or any other source.
-const COOKIE_NAME = "NEXT_LOCALE";
+function isMissingPreferredLocaleColumn(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  return (
+    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
+  );
+}
 
 export async function getUserLocale() {
-  const headersList = await headers();
-  const acceptLanguage = headersList.get("accept-language");
-  // console.log("[locale.ts] preferred-locale:", { acceptLanguage });
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  // Try to get locale from cookie first
-  const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
+  if (user?.id) {
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("preferred_locale")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError && !isMissingPreferredLocaleColumn(profileError)) {
+      console.error(
+        "Error loading preferred locale from profile:",
+        profileError
+      );
+    }
+
+    const profileLocale = normaliseLocale(profile?.preferred_locale ?? null);
+    if (profileLocale) {
+      return profileLocale;
+    }
+
+    const metadataLocale = normaliseLocale(
+      typeof user.user_metadata?.preferred_locale === "string"
+        ? user.user_metadata.preferred_locale
+        : null
+    );
+    if (metadataLocale) {
+      return metadataLocale;
+    }
+  }
+
+  const cookieStore = await cookies();
+  const cookieLocale = normaliseLocale(
+    cookieStore.get(localeCookieName)?.value ?? null
+  );
   if (cookieLocale) {
     return cookieLocale;
   }
 
-  // If no cookie, try to use browser preference
-  if (acceptLanguage) {
-    // Parse value. E.g. from:
-    // en-AU,en;q=0.9
-    // To:
-    // en
-    const firstLanguage = acceptLanguage.split(",")[0].split("-")[0] as Locale;
-    if (locales.includes(firstLanguage)) {
-      return firstLanguage;
-    }
-    // crowdin.yml reflects this two_letters_code preference
+  const headersList = await headers();
+  const acceptedLocales = parseAcceptLanguageHeader(
+    headersList.get("accept-language")
+  );
+
+  if (acceptedLocales.length > 0) {
+    return acceptedLocales[0];
   }
 
   // Always return defaultLocale if no other locale is found
@@ -38,6 +79,13 @@ export async function getUserLocale() {
 // Used in an explicit component, like a language picker:
 // https://next-intl.dev/examples#app-router-without-i18n-routing
 export async function setUserLocale(locale: Locale) {
-  console.log("Setting locale cookie:", locale);
-  (await cookies()).set(COOKIE_NAME, locale);
+  if (!isValidLocale(locale)) {
+    return;
+  }
+
+  (await cookies()).set(localeCookieName, locale, {
+    maxAge: 60 * 60 * 24 * 365,
+    path: "/",
+    sameSite: "lax",
+  });
 }

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -2,6 +2,7 @@
 
 import { cookies, headers } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
+import { isMissingPreferredLocaleColumn } from "@/utils/postgrest";
 import {
   defaultLocale,
   type Locale,
@@ -10,15 +11,6 @@ import {
   normaliseLocale,
   parseAcceptLanguageHeader,
 } from "@/i18n/config";
-
-function isMissingPreferredLocaleColumn(error: {
-  code?: string | null;
-  message?: string | null;
-}) {
-  return (
-    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
-  );
-}
 
 export async function getUserLocale() {
   const supabase = await createClient();

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -84,5 +84,6 @@ export async function setUserLocale(locale: Locale) {
     maxAge: 60 * 60 * 24 * 365,
     path: "/",
     sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
   });
 }

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -3,6 +3,7 @@
 import { cookies, headers } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
 import { isMissingPreferredLocaleColumn } from "@/utils/postgrest";
+import { hasSupabaseAuthCookie } from "@/utils/supabase/authCookies";
 import {
   defaultLocale,
   type Locale,
@@ -13,6 +14,24 @@ import {
 } from "@/i18n/config";
 
 export async function getUserLocale() {
+  const cookieStore = await cookies();
+  const cookieLocale = normaliseLocale(
+    cookieStore.get(localeCookieName)?.value ?? null
+  );
+
+  if (cookieLocale) {
+    return cookieLocale;
+  }
+
+  const headersList = await headers();
+  const acceptedLocales = parseAcceptLanguageHeader(
+    headersList.get("accept-language")
+  );
+
+  if (!hasSupabaseAuthCookie(cookieStore.getAll())) {
+    return acceptedLocales[0] ?? defaultLocale;
+  }
+
   const supabase = await createClient();
   const {
     data: { user },
@@ -47,24 +66,10 @@ export async function getUserLocale() {
     }
   }
 
-  const cookieStore = await cookies();
-  const cookieLocale = normaliseLocale(
-    cookieStore.get(localeCookieName)?.value ?? null
-  );
-  if (cookieLocale) {
-    return cookieLocale;
-  }
-
-  const headersList = await headers();
-  const acceptedLocales = parseAcceptLanguageHeader(
-    headersList.get("accept-language")
-  );
-
   if (acceptedLocales.length > 0) {
     return acceptedLocales[0];
   }
 
-  // Always return defaultLocale if no other locale is found
   return defaultLocale;
 }
 

--- a/src/lib/content/handlers/legal.ts
+++ b/src/lib/content/handlers/legal.ts
@@ -3,15 +3,24 @@ import { cache } from "react";
 import type { LegalPageData } from "../types";
 import {
   formatContentData,
+  importLocalizedContentModule,
+  resolveContentLocale,
   validateBaseCustomMetadata,
   validateBaseMetadata,
 } from "../utils";
 
 export const getLegalPageMetadata = cache(async function getLegalPageMetadata(
-  slug: string
+  slug: string,
+  locale: string | null | undefined = null
 ): Promise<LegalPageData> {
   try {
-    const file = await import(`@/content/legal/${slug}.mdx`);
+    const resolvedLocale = resolveContentLocale(locale);
+    const content = await importLocalizedContentModule(
+      "legal",
+      slug,
+      resolvedLocale
+    );
+    const file = content.file;
 
     if (file?.metadata) {
       validateBaseMetadata(file.metadata, slug);
@@ -26,7 +35,10 @@ export const getLegalPageMetadata = cache(async function getLegalPageMetadata(
           slug,
           metadata: file.metadata,
           customMetadata: file.customMetadata,
+          locale: content.locale,
+          isFallback: content.isFallback,
         },
+        resolvedLocale,
         "updatedDate",
         false // updatedDate is optional for legal pages
       );
@@ -37,4 +49,12 @@ export const getLegalPageMetadata = cache(async function getLegalPageMetadata(
     console.error(error?.message);
     return notFound();
   }
+});
+
+export const getLegalPageModule = cache(async function getLegalPageModule(
+  slug: string,
+  locale: string | null | undefined = null
+) {
+  const resolvedLocale = resolveContentLocale(locale);
+  return importLocalizedContentModule("legal", slug, resolvedLocale);
 });

--- a/src/lib/content/handlers/newsletter.ts
+++ b/src/lib/content/handlers/newsletter.ts
@@ -1,19 +1,29 @@
 import { notFound } from "next/navigation";
 import { cache } from "react";
+import type { Locale } from "@/i18n/config";
 import type { NewsletterIssueData } from "../types";
 import {
   formatContentData,
   getAllContentSlugs,
+  importLocalizedContentModule,
+  resolveContentLocale,
   validateNewsletterCustomMetadata,
   validateNewsletterMetadata,
 } from "../utils";
 
 export const getNewsletterIssueMetadata = cache(
   async function getNewsletterIssueMetadata(
-    slug: string
+    slug: string,
+    locale: string | null | undefined = null
   ): Promise<NewsletterIssueData> {
     try {
-      const file = await import(`@/content/newsletter/${slug}.mdx`);
+      const resolvedLocale = resolveContentLocale(locale);
+      const content = await importLocalizedContentModule(
+        "newsletter",
+        slug,
+        resolvedLocale
+      );
+      const file = content.file;
 
       if (file?.metadata && file?.customMetadata) {
         validateNewsletterMetadata(file.metadata, slug);
@@ -24,7 +34,10 @@ export const getNewsletterIssueMetadata = cache(
             slug,
             metadata: file.metadata,
             customMetadata: file.customMetadata,
+            locale: content.locale,
+            isFallback: content.isFallback,
           },
+          resolvedLocale,
           "publishDate",
           true // publishDate is required for legal pages
         );
@@ -38,10 +51,23 @@ export const getNewsletterIssueMetadata = cache(
   }
 );
 
-export async function getAllNewsletterIssues(): Promise<NewsletterIssueData[]> {
+export const getNewsletterIssueModule = cache(
+  async function getNewsletterIssueModule(
+    slug: string,
+    locale: string | null | undefined = null
+  ) {
+    const resolvedLocale = resolveContentLocale(locale);
+    return importLocalizedContentModule("newsletter", slug, resolvedLocale);
+  }
+);
+
+export async function getAllNewsletterIssues(
+  locale: string | null | undefined = null
+): Promise<NewsletterIssueData[]> {
+  const resolvedLocale = resolveContentLocale(locale);
   const slugs = await getAllContentSlugs("newsletter");
   const issues = await Promise.all(
-    slugs.map((slug) => getNewsletterIssueMetadata(slug))
+    slugs.map((slug) => getNewsletterIssueMetadata(slug, resolvedLocale))
   );
 
   return issues.sort(

--- a/src/lib/content/handlers/newsletter.ts
+++ b/src/lib/content/handlers/newsletter.ts
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import type { Locale } from "@/i18n/config";
 import type { NewsletterIssueData } from "../types";
 import {
   formatContentData,

--- a/src/lib/content/handlers/newsletter.ts
+++ b/src/lib/content/handlers/newsletter.ts
@@ -39,7 +39,7 @@ export const getNewsletterIssueMetadata = cache(
           },
           resolvedLocale,
           "publishDate",
-          true // publishDate is required for legal pages
+          true // publishDate is required for newsletter issues
         );
       }
 

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -1,6 +1,7 @@
 // Shared types between all Markdown collections, like newsletter issues and legal pages
 // https://www.notion.so/peels/Markdown-Pages-20bb37e1678f806a9649c3c658ab6258?source=copy_link
 
+import type { Locale } from "@/i18n/config";
 import type { Metadata } from "next/types";
 
 // Base metadata that all content types share
@@ -31,6 +32,8 @@ export type NewsletterIssueData = {
   metadata: NewsletterMetadata;
   customMetadata: NewsletterCustomMetadata;
   formattedDate: string;
+  locale: Locale;
+  isFallback: boolean;
 };
 
 // Legal-specific types
@@ -44,4 +47,6 @@ export type LegalPageData = {
   metadata: BaseMetadata;
   customMetadata?: LegalCustomMetadata;
   formattedDate?: string;
+  locale: Locale;
+  isFallback: boolean;
 };

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -1,7 +1,7 @@
 // Shared utils between all Markdown collections, like newsletter issues and legal pages
 // https://www.notion.so/peels/Markdown-Pages-20bb37e1678f806a9649c3c658ab6258?source=copy_link
 
-import { readdir } from "fs/promises";
+import { access, readdir } from "fs/promises";
 import type { Dirent } from "fs";
 import { join } from "path";
 import { defaultLocale, type Locale, normaliseLocale } from "@/i18n/config";
@@ -27,13 +27,31 @@ export function formatContentDate(dateString: string, locale: Locale) {
   }).format(new Date(dateString));
 }
 
+async function doesContentFileExist(contentPath: string) {
+  try {
+    await access(contentPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function importLocalizedContentModule(
   contentType: "newsletter" | "legal",
   slug: string,
   locale: Locale
 ) {
   if (locale !== defaultLocale) {
-    try {
+    const localisedContentPath = join(
+      process.cwd(),
+      "src",
+      "content",
+      contentType,
+      locale,
+      `${slug}.mdx`
+    );
+
+    if (await doesContentFileExist(localisedContentPath)) {
       const file = await import(
         `@/content/${contentType}/${locale}/${slug}.mdx`
       );
@@ -42,8 +60,6 @@ export async function importLocalizedContentModule(
         locale,
         isFallback: false,
       };
-    } catch (_error) {
-      // Fall through to the default English content.
     }
   }
 

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -19,12 +19,26 @@ export function resolveContentLocale(
   return normaliseLocale(locale) ?? defaultLocale;
 }
 
+function parseContentCalendarDate(dateString: string) {
+  const isoDateMatch = dateString.match(/^(\d{4})-(\d{2})-(\d{2})/);
+
+  if (!isoDateMatch) {
+    return new Date(dateString);
+  }
+
+  const [, year, month, day] = isoDateMatch;
+  return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+}
+
 export function formatContentDate(dateString: string, locale: Locale) {
   return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "long",
     day: "numeric",
-  }).format(new Date(dateString));
+    // Treat authored content dates as stable calendar dates rather than
+    // shifting them with the runtime's local timezone.
+    timeZone: "UTC",
+  }).format(parseContentCalendarDate(dateString));
 }
 
 async function doesContentFileExist(contentPath: string) {

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -4,8 +4,7 @@
 import { readdir } from "fs/promises";
 import type { Dirent } from "fs";
 import { join } from "path";
-import { siteConfig } from "@/config/site";
-import { formatPublishDate } from "@/utils/dateUtils";
+import { defaultLocale, type Locale, normaliseLocale } from "@/i18n/config";
 
 // Common file utilities
 export const isMDXFile = (dirent: Dirent) =>
@@ -13,6 +12,48 @@ export const isMDXFile = (dirent: Dirent) =>
 
 export const getSlugFromFilename = (dirent: Dirent) =>
   dirent.name.substring(0, dirent.name.lastIndexOf("."));
+
+export function resolveContentLocale(
+  locale: string | null | undefined
+): Locale {
+  return normaliseLocale(locale) ?? defaultLocale;
+}
+
+export function formatContentDate(dateString: string, locale: Locale) {
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(dateString));
+}
+
+export async function importLocalizedContentModule(
+  contentType: "newsletter" | "legal",
+  slug: string,
+  locale: Locale
+) {
+  if (locale !== defaultLocale) {
+    try {
+      const file = await import(
+        `@/content/${contentType}/${locale}/${slug}.mdx`
+      );
+      return {
+        file,
+        locale,
+        isFallback: false,
+      };
+    } catch (_error) {
+      // Fall through to the default English content.
+    }
+  }
+
+  const file = await import(`@/content/${contentType}/${slug}.mdx`);
+  return {
+    file,
+    locale: defaultLocale,
+    isFallback: locale !== defaultLocale,
+  };
+}
 
 // Common content loading utilities
 export async function getAllContentSlugs(
@@ -86,6 +127,7 @@ export function formatContentData<
   },
 >(
   data: T,
+  locale: Locale,
   dateField: string = "publishDate",
   isDateRequired: boolean = true
 ): T & { formattedDate: string } {
@@ -103,7 +145,7 @@ export function formatContentData<
   // Add OpenGraph metadata
   const metadata = {
     ...data,
-    formattedDate: formatPublishDate(data.customMetadata[dateField]),
+    formattedDate: formatContentDate(data.customMetadata[dateField], locale),
     openGraph: {
       title: data.metadata.title,
       description: data.metadata.description,

--- a/src/utils/authRedirects.ts
+++ b/src/utils/authRedirects.ts
@@ -1,3 +1,5 @@
+import { defaultLocale, type Locale, normaliseLocale } from "@/i18n/config";
+
 export const SUPABASE_EMAIL_AUTH_TYPES = new Set([
   "signup",
   "invite",
@@ -54,3 +56,29 @@ export const appendSuccessParam = (path: string, successValue: string) => {
   url.searchParams.set("success", successValue);
   return `${url.pathname}${url.search}${url.hash}`;
 };
+
+export const getLocaleFromSearchParams = (
+  searchParams: URLSearchParams | Record<string, string | string[] | undefined>
+) => {
+  if (searchParams instanceof URLSearchParams) {
+    return normaliseLocale(searchParams.get("locale"));
+  }
+
+  const rawLocale = searchParams.locale;
+  if (Array.isArray(rawLocale)) {
+    return normaliseLocale(rawLocale[0]);
+  }
+
+  return normaliseLocale(rawLocale ?? null);
+};
+
+export const appendLocaleParam = (path: string, locale: Locale) => {
+  const normalisedPath = normaliseNextPath(path, "/profile");
+  const url = new URL(normalisedPath, "https://www.peels.app");
+  url.searchParams.set("locale", locale);
+  return `${url.pathname}${url.search}${url.hash}`;
+};
+
+export const resolveAuthLocale = (
+  requestedLocale: string | null | undefined
+): Locale => normaliseLocale(requestedLocale) ?? defaultLocale;

--- a/src/utils/postgrest.ts
+++ b/src/utils/postgrest.ts
@@ -1,0 +1,18 @@
+type PostgrestLikeError = {
+  code?: string | null;
+  message?: string | null;
+};
+
+export function isMissingPostgrestColumn(
+  error: PostgrestLikeError,
+  columnName: string
+) {
+  return (
+    error.code === "PGRST204" &&
+    new RegExp(columnName, "i").test(error.message ?? "")
+  );
+}
+
+export function isMissingPreferredLocaleColumn(error: PostgrestLikeError) {
+  return isMissingPostgrestColumn(error, "preferred_locale");
+}

--- a/src/utils/postgrest.ts
+++ b/src/utils/postgrest.ts
@@ -9,7 +9,7 @@ export function isMissingPostgrestColumn(
 ) {
   return (
     error.code === "PGRST204" &&
-    new RegExp(columnName, "i").test(error.message ?? "")
+    (error.message ?? "").toLowerCase().includes(columnName.toLowerCase())
   );
 }
 

--- a/src/utils/supabase/authCookies.ts
+++ b/src/utils/supabase/authCookies.ts
@@ -1,0 +1,6 @@
+type CookieLike = {
+  name: string;
+};
+
+export const hasSupabaseAuthCookie = (cookies: CookieLike[]) =>
+  cookies.some(({ name }) => name.includes("auth-token"));

--- a/supabase/functions/_shared/i18n.ts
+++ b/supabase/functions/_shared/i18n.ts
@@ -429,8 +429,10 @@ const chatEmailCopy = {
     ownerFooterBeforeLink: "Don’t want emails like this? ",
     ownerFooterLink: "Manage",
     ownerFooterAfterLink: " your listing to hide or remove it from Peels.",
-    initiatorFooter:
-      "You’re receiving this email because you originally reached out to {senderName} on Peels.",
+    initiatorFooterBeforeLink:
+      "You’re receiving this email because you originally reached out to {senderName} on ",
+    initiatorFooterLink: "Peels",
+    initiatorFooterAfterLink: ".",
     residentOf: "Resident of {listingAreaName}",
     body: "Hi {recipientName}, you’ve received a new message from {senderName}{listingContext}. Check it out on Peels:",
     button: "View message",
@@ -445,8 +447,10 @@ const chatEmailCopy = {
     ownerFooterBeforeLink: "¿No quieres recibir correos como este? ",
     ownerFooterLink: "Gestiona",
     ownerFooterAfterLink: " tu anuncio para ocultarlo o quitarlo de Peels.",
-    initiatorFooter:
-      "Recibes este correo porque contactaste antes con {senderName} en Peels.",
+    initiatorFooterBeforeLink:
+      "Recibes este correo porque contactaste antes con {senderName} en ",
+    initiatorFooterLink: "Peels",
+    initiatorFooterAfterLink: ".",
     residentOf: "Persona residente de {listingAreaName}",
     body: "Hola {recipientName}, has recibido un nuevo mensaje de {senderName}{listingContext}. Échale un vistazo en Peels:",
     button: "Ver mensaje",
@@ -462,8 +466,10 @@ const chatEmailCopy = {
     ownerFooterLink: "Verwalte",
     ownerFooterAfterLink:
       " deinen Eintrag, um ihn auf Peels auszublenden oder zu entfernen.",
-    initiatorFooter:
-      "Du erhältst diese E-Mail, weil du {senderName} ursprünglich über Peels kontaktiert hast.",
+    initiatorFooterBeforeLink:
+      "Du erhältst diese E-Mail, weil du {senderName} ursprünglich über ",
+    initiatorFooterLink: "Peels",
+    initiatorFooterAfterLink: " kontaktiert hast.",
     residentOf: "Person aus {listingAreaName}",
     body: "Hallo {recipientName}, du hast eine neue Nachricht von {senderName}{listingContext} erhalten. Schau sie dir auf Peels an:",
     button: "Nachricht ansehen",
@@ -479,8 +485,10 @@ const chatEmailCopy = {
     ownerFooterLink: "Gere",
     ownerFooterAfterLink:
       " o teu anúncio para o ocultares ou removeres do Peels.",
-    initiatorFooter:
-      "Recebeste este e-mail porque entraste em contacto com {senderName} no Peels.",
+    initiatorFooterBeforeLink:
+      "Recebeste este e-mail porque entraste em contacto com {senderName} no ",
+    initiatorFooterLink: "Peels",
+    initiatorFooterAfterLink: ".",
     residentOf: "Pessoa de {listingAreaName}",
     body: "Olá {recipientName}, recebeste uma nova mensagem de {senderName}{listingContext}. Vê tudo no Peels:",
     button: "Ver mensagem",
@@ -497,8 +505,10 @@ const chatEmailCopy = {
     ownerFooterLink: "Gérez",
     ownerFooterAfterLink:
       " votre annonce pour la masquer ou la supprimer de Peels.",
-    initiatorFooter:
-      "Vous recevez cet e-mail parce que vous avez contacté {senderName} via Peels.",
+    initiatorFooterBeforeLink:
+      "Vous recevez cet e-mail parce que vous avez contacté {senderName} via ",
+    initiatorFooterLink: "Peels",
+    initiatorFooterAfterLink: ".",
     residentOf: "Personne située à {listingAreaName}",
     body: "Bonjour {recipientName}, vous avez reçu un nouveau message de {senderName}{listingContext}. Consultez-le sur Peels :",
     button: "Voir le message",

--- a/supabase/functions/_shared/i18n.ts
+++ b/supabase/functions/_shared/i18n.ts
@@ -1,0 +1,511 @@
+export type SupportedLocale = "en" | "es" | "de" | "pt-BR" | "fr";
+
+export const defaultEmailLocale: SupportedLocale = "en";
+
+const localeAliasMap: Record<string, SupportedLocale> = {
+  en: "en",
+  "en-au": "en",
+  "en-gb": "en",
+  "en-us": "en",
+  es: "es",
+  "es-419": "es",
+  "es-ar": "es",
+  "es-cl": "es",
+  "es-co": "es",
+  "es-es": "es",
+  "es-mx": "es",
+  de: "de",
+  "de-at": "de",
+  "de-ch": "de",
+  "de-de": "de",
+  pt: "pt-BR",
+  "pt-br": "pt-BR",
+  "pt-pt": "pt-BR",
+  fr: "fr",
+  "fr-be": "fr",
+  "fr-ca": "fr",
+  "fr-fr": "fr",
+};
+
+export const resolveSupportedLocale = (
+  value: string | null | undefined
+): SupportedLocale | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const directMatch = localeAliasMap[trimmedValue];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const lowerCaseValue = trimmedValue.toLowerCase();
+  const normalisedMatch = localeAliasMap[lowerCaseValue];
+  if (normalisedMatch) {
+    return normalisedMatch;
+  }
+
+  const [baseLanguage] = lowerCaseValue.split("-");
+  return localeAliasMap[baseLanguage] ?? null;
+};
+
+export const getLocaleFromRedirectTo = (
+  redirectTo: string | null | undefined
+): SupportedLocale | null => {
+  if (!redirectTo) {
+    return null;
+  }
+
+  try {
+    const redirectUrl = new URL(redirectTo);
+    return resolveSupportedLocale(redirectUrl.searchParams.get("locale"));
+  } catch (_error) {
+    return null;
+  }
+};
+
+export const resolveEmailLocale = ({
+  redirectTo,
+  preferredLocale,
+}: {
+  redirectTo?: string | null;
+  preferredLocale?: string | null;
+}): SupportedLocale =>
+  getLocaleFromRedirectTo(redirectTo) ??
+  resolveSupportedLocale(preferredLocale) ??
+  defaultEmailLocale;
+
+const authEmailCopy = {
+  en: {
+    signOff: "Best",
+    team: "Peels team",
+    replyHelp: "Just hit ‘reply’ if you run into any issues or have questions.",
+    signup: {
+      subject: "Verify your Peels account",
+      preview:
+        "Let's get you composting, {firstName}! Here’s a link to verify your Peels account.",
+      heading: "Welcome to Peels",
+      footer:
+        "You’re receiving this email because you signed up for a Peels account.",
+      body: "We’re so glad you’re here, {firstName}! Follow this link to verify your account:",
+      button: "Verify your Peels account",
+    },
+    recovery: {
+      subject: "Reset your password on Peels",
+      preview:
+        "Sorry to hear you’re having trouble signing in to Peels. Here’s a link to reset your password.",
+      heading: "Reset your password",
+      footer:
+        "You’re receiving this email because someone—hopefully you—requested a password reset link for your Peels account.",
+      body: "Sorry to hear you’re having trouble signing in to Peels. Tap the below link to reset your password:",
+      button: "Reset password",
+    },
+    emailChange: {
+      subject: "Confirm your email change on Peels",
+      preview: "Here’s a link to change the email address you use on Peels.",
+      heading: "Confirm your email change",
+      footer:
+        "You’re receiving this email because you requested an email address change on Peels.",
+      body: "Follow this link to confirm your new email on Peels:",
+      button: "Change email address",
+      reminder: "As a reminder, you’re changing from {email} to {newEmail}.",
+    },
+    magicLink: {
+      subject: "Your magic link for Peels",
+      preview: "Here’s a link to instantly sign in to Peels.",
+      heading: "Your magic link",
+      footer:
+        "You’re receiving this email because you requested help signing in to Peels.",
+      body: "Follow this link to instantly sign in to Peels:",
+      button: "Sign in to Peels",
+    },
+    invite: {
+      subject: "You’ve been invited to Peels",
+      preview: "Lucky you! You’re invited to try out Peels.",
+      heading: "You’re invited",
+      footer:
+        "You’re receiving this email because someone at Peels invited you to join.",
+      body: "Someone at Peels has invited you to try it out. Follow this link to accept the invite:",
+      button: "Accept invite",
+    },
+    reauthentication: {
+      subject: "Confirm reauthentication on Peels",
+      genericSubject: "Your verification code for Peels",
+      preview: "Here’s your code for Peels.",
+      heading: "Your verification code",
+      footer:
+        "You’re receiving this email because you requested a verification code for Peels.",
+      body: "Enter the following code on Peels:",
+    },
+  },
+  es: {
+    signOff: "Un abrazo",
+    team: "Equipo de Peels",
+    replyHelp:
+      "Solo tienes que responder a este correo si tienes algún problema o pregunta.",
+    signup: {
+      subject: "Verifica tu cuenta de Peels",
+      preview:
+        "¡Vamos a ponerte a compostar, {firstName}! Aquí tienes un enlace para verificar tu cuenta de Peels.",
+      heading: "Bienvenido a Peels",
+      footer:
+        "Recibes este correo porque te has registrado para crear una cuenta en Peels.",
+      body: "Nos alegra mucho verte por aquí, {firstName}! Sigue este enlace para verificar tu cuenta:",
+      button: "Verificar tu cuenta de Peels",
+    },
+    recovery: {
+      subject: "Restablece tu contraseña de Peels",
+      preview:
+        "Sentimos que estés teniendo problemas para iniciar sesión en Peels. Aquí tienes un enlace para restablecer tu contraseña.",
+      heading: "Restablece tu contraseña",
+      footer:
+        "Recibes este correo porque alguien, esperamos que hayas sido tú, solicitó un enlace para restablecer la contraseña de tu cuenta de Peels.",
+      body: "Sentimos que estés teniendo problemas para iniciar sesión en Peels. Toca el siguiente enlace para restablecer tu contraseña:",
+      button: "Restablecer contraseña",
+    },
+    emailChange: {
+      subject: "Confirma tu cambio de correo en Peels",
+      preview:
+        "Aquí tienes un enlace para cambiar la dirección de correo que usas en Peels.",
+      heading: "Confirma tu cambio de correo",
+      footer:
+        "Recibes este correo porque solicitaste cambiar tu dirección de correo en Peels.",
+      body: "Sigue este enlace para confirmar tu nuevo correo en Peels:",
+      button: "Cambiar dirección de correo",
+      reminder: "Como recordatorio, estás cambiando de {email} a {newEmail}.",
+    },
+    magicLink: {
+      subject: "Tu enlace mágico para Peels",
+      preview:
+        "Aquí tienes un enlace para iniciar sesión en Peels al instante.",
+      heading: "Tu enlace mágico",
+      footer:
+        "Recibes este correo porque pediste ayuda para iniciar sesión en Peels.",
+      body: "Sigue este enlace para iniciar sesión en Peels al instante:",
+      button: "Iniciar sesión en Peels",
+    },
+    invite: {
+      subject: "Te han invitado a Peels",
+      preview: "¡Qué suerte! Te han invitado a probar Peels.",
+      heading: "Tienes una invitación",
+      footer: "Recibes este correo porque alguien de Peels te invitó a unirte.",
+      body: "Alguien de Peels te ha invitado a probarlo. Sigue este enlace para aceptar la invitación:",
+      button: "Aceptar invitación",
+    },
+    reauthentication: {
+      subject: "Confirma la reautenticación en Peels",
+      genericSubject: "Tu código de verificación para Peels",
+      preview: "Aquí tienes tu código para Peels.",
+      heading: "Tu código de verificación",
+      footer:
+        "Recibes este correo porque solicitaste un código de verificación para Peels.",
+      body: "Introduce el siguiente código en Peels:",
+    },
+  },
+  de: {
+    signOff: "Viele Grüsse",
+    team: "Peels-Team",
+    replyHelp:
+      "Antworte einfach auf diese E-Mail, wenn du auf Probleme stösst oder Fragen hast.",
+    signup: {
+      subject: "Bestätige dein Peels-Konto",
+      preview:
+        "Los geht’s mit dem Kompostieren, {firstName}! Hier ist dein Link, um dein Peels-Konto zu bestätigen.",
+      heading: "Willkommen bei Peels",
+      footer:
+        "Du erhältst diese E-Mail, weil du ein Peels-Konto erstellt hast.",
+      body: "Schön, dass du da bist, {firstName}! Folge diesem Link, um dein Konto zu bestätigen:",
+      button: "Peels-Konto bestätigen",
+    },
+    recovery: {
+      subject: "Setze dein Peels-Passwort zurück",
+      preview:
+        "Schade, dass du Probleme beim Anmelden bei Peels hast. Hier ist ein Link, um dein Passwort zurückzusetzen.",
+      heading: "Setze dein Passwort zurück",
+      footer:
+        "Du erhältst diese E-Mail, weil jemand – hoffentlich du – einen Link zum Zurücksetzen des Passworts für dein Peels-Konto angefordert hat.",
+      body: "Schade, dass du Probleme beim Anmelden bei Peels hast. Nutze den folgenden Link, um dein Passwort zurückzusetzen:",
+      button: "Passwort zurücksetzen",
+    },
+    emailChange: {
+      subject: "Bestätige deine E-Mail-Änderung bei Peels",
+      preview:
+        "Hier ist ein Link, um die E-Mail-Adresse zu ändern, die du bei Peels verwendest.",
+      heading: "Bestätige deine E-Mail-Änderung",
+      footer:
+        "Du erhältst diese E-Mail, weil du eine Änderung deiner E-Mail-Adresse bei Peels angefordert hast.",
+      body: "Folge diesem Link, um deine neue E-Mail-Adresse bei Peels zu bestätigen:",
+      button: "E-Mail-Adresse ändern",
+      reminder: "Zur Erinnerung: Du wechselst von {email} zu {newEmail}.",
+    },
+    magicLink: {
+      subject: "Dein Magic Link für Peels",
+      preview:
+        "Hier ist ein Link, mit dem du dich sofort bei Peels anmelden kannst.",
+      heading: "Dein Magic Link",
+      footer:
+        "Du erhältst diese E-Mail, weil du Hilfe beim Anmelden bei Peels angefordert hast.",
+      body: "Folge diesem Link, um dich sofort bei Peels anzumelden:",
+      button: "Bei Peels anmelden",
+    },
+    invite: {
+      subject: "Du wurdest zu Peels eingeladen",
+      preview: "Glück gehabt! Du wurdest eingeladen, Peels auszuprobieren.",
+      heading: "Du bist eingeladen",
+      footer:
+        "Du erhältst diese E-Mail, weil dich jemand von Peels zum Mitmachen eingeladen hat.",
+      body: "Jemand von Peels hat dich eingeladen, es auszuprobieren. Folge diesem Link, um die Einladung anzunehmen:",
+      button: "Einladung annehmen",
+    },
+    reauthentication: {
+      subject: "Bestätige die erneute Anmeldung bei Peels",
+      genericSubject: "Dein Bestätigungscode für Peels",
+      preview: "Hier ist dein Code für Peels.",
+      heading: "Dein Bestätigungscode",
+      footer:
+        "Du erhältst diese E-Mail, weil du einen Bestätigungscode für Peels angefordert hast.",
+      body: "Gib den folgenden Code bei Peels ein:",
+    },
+  },
+  "pt-BR": {
+    signOff: "Abraço",
+    team: "Equipa do Peels",
+    replyHelp:
+      "É só responder a este e-mail se tiveres algum problema ou pergunta.",
+    signup: {
+      subject: "Confirma a tua conta no Peels",
+      preview:
+        "Vamos colocar-te a compostar, {firstName}! Aqui está um link para confirmares a tua conta no Peels.",
+      heading: "Boas-vindas ao Peels",
+      footer: "Recebeste este e-mail porque criaste uma conta no Peels.",
+      body: "Que bom ter-te por aqui, {firstName}! Segue este link para confirmares a tua conta:",
+      button: "Confirmar a tua conta no Peels",
+    },
+    recovery: {
+      subject: "Redefine a tua palavra-passe no Peels",
+      preview:
+        "Lamentamos que estejas com dificuldades para entrar no Peels. Aqui está um link para redefinires a tua palavra-passe.",
+      heading: "Redefine a tua palavra-passe",
+      footer:
+        "Recebeste este e-mail porque alguém, esperamos que tenhas sido tu, pediu um link para redefinir a palavra-passe da tua conta no Peels.",
+      body: "Lamentamos que estejas com dificuldades para entrar no Peels. Toca no link abaixo para redefinires a tua palavra-passe:",
+      button: "Redefinir palavra-passe",
+    },
+    emailChange: {
+      subject: "Confirma a alteração do teu e-mail no Peels",
+      preview:
+        "Aqui está um link para alterares o endereço de e-mail que usas no Peels.",
+      heading: "Confirma a alteração do teu e-mail",
+      footer:
+        "Recebeste este e-mail porque pediste uma alteração de endereço de e-mail no Peels.",
+      body: "Segue este link para confirmares o teu novo e-mail no Peels:",
+      button: "Alterar endereço de e-mail",
+      reminder: "Só para relembrar: estás a mudar de {email} para {newEmail}.",
+    },
+    magicLink: {
+      subject: "O teu link mágico para o Peels",
+      preview: "Aqui está um link para entrares instantaneamente no Peels.",
+      heading: "O teu link mágico",
+      footer:
+        "Recebeste este e-mail porque pediste ajuda para entrar no Peels.",
+      body: "Segue este link para entrares instantaneamente no Peels:",
+      button: "Entrar no Peels",
+    },
+    invite: {
+      subject: "Foste convidado para o Peels",
+      preview: "Que sorte! Foste convidado para experimentar o Peels.",
+      heading: "Tens um convite",
+      footer:
+        "Recebeste este e-mail porque alguém do Peels te convidou para participar.",
+      body: "Alguém do Peels convidou-te para experimentar a plataforma. Segue este link para aceitares o convite:",
+      button: "Aceitar convite",
+    },
+    reauthentication: {
+      subject: "Confirma a reautenticação no Peels",
+      genericSubject: "O teu código de verificação para o Peels",
+      preview: "Aqui está o teu código para o Peels.",
+      heading: "O teu código de verificação",
+      footer:
+        "Recebeste este e-mail porque pediste um código de verificação para o Peels.",
+      body: "Introduz o código abaixo no Peels:",
+    },
+  },
+  fr: {
+    signOff: "Bien à vous",
+    team: "Équipe Peels",
+    replyHelp:
+      "Répondez simplement à cet e-mail si vous rencontrez un souci ou si vous avez des questions.",
+    signup: {
+      subject: "Vérifiez votre compte Peels",
+      preview:
+        "On vous aide à vous lancer dans le compostage, {firstName} ! Voici un lien pour vérifier votre compte Peels.",
+      heading: "Bienvenue sur Peels",
+      footer:
+        "Vous recevez cet e-mail parce que vous avez créé un compte Peels.",
+      body: "Nous sommes ravis de vous compter parmi nous, {firstName} ! Suivez ce lien pour vérifier votre compte :",
+      button: "Vérifier votre compte Peels",
+    },
+    recovery: {
+      subject: "Réinitialisez votre mot de passe Peels",
+      preview:
+        "Désolé d’apprendre que vous avez du mal à vous connecter à Peels. Voici un lien pour réinitialiser votre mot de passe.",
+      heading: "Réinitialisez votre mot de passe",
+      footer:
+        "Vous recevez cet e-mail parce que quelqu’un, espérons-le vous, a demandé un lien de réinitialisation du mot de passe pour votre compte Peels.",
+      body: "Désolé d’apprendre que vous avez du mal à vous connecter à Peels. Appuyez sur le lien ci-dessous pour réinitialiser votre mot de passe :",
+      button: "Réinitialiser le mot de passe",
+    },
+    emailChange: {
+      subject: "Confirmez votre changement d’e-mail sur Peels",
+      preview:
+        "Voici un lien pour changer l’adresse e-mail que vous utilisez sur Peels.",
+      heading: "Confirmez votre changement d’e-mail",
+      footer:
+        "Vous recevez cet e-mail parce que vous avez demandé un changement d’adresse e-mail sur Peels.",
+      body: "Suivez ce lien pour confirmer votre nouvelle adresse e-mail sur Peels :",
+      button: "Changer d’adresse e-mail",
+      reminder: "Pour rappel, vous passez de {email} à {newEmail}.",
+    },
+    magicLink: {
+      subject: "Votre lien magique pour Peels",
+      preview: "Voici un lien pour vous connecter instantanément à Peels.",
+      heading: "Votre lien magique",
+      footer:
+        "Vous recevez cet e-mail parce que vous avez demandé de l’aide pour vous connecter à Peels.",
+      body: "Suivez ce lien pour vous connecter instantanément à Peels :",
+      button: "Se connecter à Peels",
+    },
+    invite: {
+      subject: "Vous êtes invité sur Peels",
+      preview: "Quelle chance ! Vous êtes invité à découvrir Peels.",
+      heading: "Vous êtes invité",
+      footer:
+        "Vous recevez cet e-mail parce qu’une personne de Peels vous a invité à rejoindre la plateforme.",
+      body: "Une personne de Peels vous a invité à découvrir la plateforme. Suivez ce lien pour accepter l’invitation :",
+      button: "Accepter l’invitation",
+    },
+    reauthentication: {
+      subject: "Confirmez la réauthentification sur Peels",
+      genericSubject: "Votre code de vérification pour Peels",
+      preview: "Voici votre code pour Peels.",
+      heading: "Votre code de vérification",
+      footer:
+        "Vous recevez cet e-mail parce que vous avez demandé un code de vérification pour Peels.",
+      body: "Saisissez le code suivant sur Peels :",
+    },
+  },
+} as const satisfies Record<SupportedLocale, unknown>;
+
+type AuthEmailKind =
+  | "signup"
+  | "recovery"
+  | "emailChange"
+  | "magicLink"
+  | "invite"
+  | "reauthentication";
+
+export const getAuthEmailCopy = (
+  locale: SupportedLocale,
+  kind: AuthEmailKind
+) => authEmailCopy[locale][kind];
+
+export const getAuthEmailSharedCopy = (locale: SupportedLocale) => ({
+  signOff: authEmailCopy[locale].signOff,
+  team: authEmailCopy[locale].team,
+  replyHelp: authEmailCopy[locale].replyHelp,
+});
+
+const chatEmailCopy = {
+  en: {
+    subject: "{senderName} just messaged you",
+    preview:
+      "Hi {recipientName}, you’ve received a new message from {senderName}. Visit Peels to see what they wrote.",
+    heading: "New message on Peels",
+    ownerFooterBeforeLink: "Don’t want emails like this? ",
+    ownerFooterLink: "Manage",
+    ownerFooterAfterLink: " your listing to hide or remove it from Peels.",
+    initiatorFooter:
+      "You’re receiving this email because you originally reached out to {senderName} on Peels.",
+    residentOf: "Resident of {listingAreaName}",
+    body: "Hi {recipientName}, you’ve received a new message from {senderName}{listingContext}. Check it out on Peels:",
+    button: "View message",
+    signOff: "Best",
+    team: "Peels team",
+  },
+  es: {
+    subject: "{senderName} te ha enviado un mensaje",
+    preview:
+      "Hola {recipientName}, has recibido un nuevo mensaje de {senderName}. Visita Peels para ver lo que escribió.",
+    heading: "Nuevo mensaje en Peels",
+    ownerFooterBeforeLink: "¿No quieres recibir correos como este? ",
+    ownerFooterLink: "Gestiona",
+    ownerFooterAfterLink: " tu anuncio para ocultarlo o quitarlo de Peels.",
+    initiatorFooter:
+      "Recibes este correo porque contactaste antes con {senderName} en Peels.",
+    residentOf: "Persona residente de {listingAreaName}",
+    body: "Hola {recipientName}, has recibido un nuevo mensaje de {senderName}{listingContext}. Échale un vistazo en Peels:",
+    button: "Ver mensaje",
+    signOff: "Un abrazo",
+    team: "Equipo de Peels",
+  },
+  de: {
+    subject: "{senderName} hat dir gerade geschrieben",
+    preview:
+      "Hallo {recipientName}, du hast eine neue Nachricht von {senderName} erhalten. Besuche Peels, um sie zu lesen.",
+    heading: "Neue Nachricht auf Peels",
+    ownerFooterBeforeLink: "Du möchtest solche E-Mails nicht mehr? ",
+    ownerFooterLink: "Verwalte",
+    ownerFooterAfterLink:
+      " deinen Eintrag, um ihn auf Peels auszublenden oder zu entfernen.",
+    initiatorFooter:
+      "Du erhältst diese E-Mail, weil du {senderName} ursprünglich über Peels kontaktiert hast.",
+    residentOf: "Person aus {listingAreaName}",
+    body: "Hallo {recipientName}, du hast eine neue Nachricht von {senderName}{listingContext} erhalten. Schau sie dir auf Peels an:",
+    button: "Nachricht ansehen",
+    signOff: "Viele Grüsse",
+    team: "Peels-Team",
+  },
+  "pt-BR": {
+    subject: "{senderName} acabou de te enviar uma mensagem",
+    preview:
+      "Olá {recipientName}, recebeste uma nova mensagem de {senderName}. Vai ao Peels para ver o que foi escrito.",
+    heading: "Nova mensagem no Peels",
+    ownerFooterBeforeLink: "Não queres receber e-mails como este? ",
+    ownerFooterLink: "Gere",
+    ownerFooterAfterLink:
+      " o teu anúncio para o ocultares ou removeres do Peels.",
+    initiatorFooter:
+      "Recebeste este e-mail porque entraste em contacto com {senderName} no Peels.",
+    residentOf: "Pessoa de {listingAreaName}",
+    body: "Olá {recipientName}, recebeste uma nova mensagem de {senderName}{listingContext}. Vê tudo no Peels:",
+    button: "Ver mensagem",
+    signOff: "Abraço",
+    team: "Equipa do Peels",
+  },
+  fr: {
+    subject: "{senderName} vient de vous envoyer un message",
+    preview:
+      "Bonjour {recipientName}, vous avez reçu un nouveau message de {senderName}. Rendez-vous sur Peels pour le lire.",
+    heading: "Nouveau message sur Peels",
+    ownerFooterBeforeLink:
+      "Vous ne souhaitez plus recevoir ce type d’e-mails ? ",
+    ownerFooterLink: "Gérez",
+    ownerFooterAfterLink:
+      " votre annonce pour la masquer ou la supprimer de Peels.",
+    initiatorFooter:
+      "Vous recevez cet e-mail parce que vous avez contacté {senderName} via Peels.",
+    residentOf: "Personne située à {listingAreaName}",
+    body: "Bonjour {recipientName}, vous avez reçu un nouveau message de {senderName}{listingContext}. Consultez-le sur Peels :",
+    button: "Voir le message",
+    signOff: "Bien à vous",
+    team: "Équipe Peels",
+  },
+} as const satisfies Record<SupportedLocale, unknown>;
+
+export const getChatEmailCopy = (locale: SupportedLocale) =>
+  chatEmailCopy[locale];

--- a/supabase/functions/_shared/newsletter.ts
+++ b/supabase/functions/_shared/newsletter.ts
@@ -1,0 +1,244 @@
+import {
+  defaultEmailLocale,
+  resolveSupportedLocale,
+  type SupportedLocale,
+} from "./i18n.ts";
+
+type LocalisedIssueDetails = {
+  title: string;
+  description: string;
+};
+
+type NewsletterEmailCopy = {
+  subjectPrefix: string;
+  preview: string;
+  heading: string;
+  announcement: string;
+  cta: string;
+  ctaHint: string;
+  footerMemberPrefix: string;
+  footerMemberLink: string;
+  footerMemberSuffix: string;
+  footerExternalPrefix: string;
+  footerExternalLink: string;
+  footerExternalSuffix: string;
+  viewOnlinePrefix: string;
+  viewOnlineLink: string;
+  viewOnlineSuffix: string;
+  signOff: string;
+  team: string;
+};
+
+const legacyAudienceId = "34497242-6af7-4862-a2e7-356eca18176b";
+
+const currentIssue = {
+  slug: "beginning-to-look-like-compost",
+  issueNumber: 2,
+  locales: {
+    en: {
+      title: "It’s beginning to look a lot like compost",
+      description:
+        "We’ve made it to the end of 2025, and Peels is about to turn one. Here’s a brief update.",
+    },
+    es: {
+      title: "Empieza a parecerse mucho al compost",
+      description:
+        "Ya llegamos al final de 2025 y Peels está a punto de cumplir un año. Aquí va una breve actualización.",
+    },
+    de: {
+      title: "Es fängt an, sehr nach Kompost auszusehen",
+      description:
+        "Wir haben das Ende von 2025 erreicht, und Peels wird bald ein Jahr alt. Hier ist ein kurzes Update.",
+    },
+    "pt-BR": {
+      title: "Está começando a ficar com cara de composto",
+      description:
+        "Chegamos ao fim de 2025 e o Peels está prestes a completar um ano. Aqui vai uma atualização breve.",
+    },
+    fr: {
+      title: "Ça commence à ressembler à du compost",
+      description:
+        "Nous arrivons à la fin de 2025 et Peels va bientôt fêter sa première année. Voici une brève mise à jour.",
+    },
+  },
+} as const satisfies {
+  slug: string;
+  issueNumber: number;
+  locales: Record<SupportedLocale, LocalisedIssueDetails>;
+};
+
+const newsletterEmailCopy = {
+  en: {
+    subjectPrefix: "New Peels newsletter",
+    preview: "Issue #{issueNumber} of the Peels newsletter is now live.",
+    heading: "A new newsletter issue is here",
+    announcement: "Issue #{issueNumber} of the Peels newsletter is now live.",
+    cta: "Read this issue",
+    ctaHint:
+      "Open it on Peels to read the full update and share it with others.",
+    footerMemberPrefix:
+      "You’re receiving this email because you opted in to occasional newsletter updates from Peels. You can update your preferences ",
+    footerMemberLink: "here",
+    footerMemberSuffix: ".",
+    footerExternalPrefix:
+      "You’re receiving this email because you signed up to hear occasional updates from Peels. You can unsubscribe ",
+    footerExternalLink: "here",
+    footerExternalSuffix: ".",
+    viewOnlinePrefix: "You can also ",
+    viewOnlineLink: "read or share this issue online",
+    viewOnlineSuffix: ".",
+    signOff: "Best",
+    team: "Peels team",
+  },
+  es: {
+    subjectPrefix: "Nuevo boletín de Peels",
+    preview:
+      "Ya está disponible el número #{issueNumber} del boletín de Peels.",
+    heading: "Ya está aquí un nuevo número del boletín",
+    announcement:
+      "Ya está disponible el número #{issueNumber} del boletín de Peels.",
+    cta: "Leer este número",
+    ctaHint:
+      "Ábrelo en Peels para leer la actualización completa y compartirla con otras personas.",
+    footerMemberPrefix:
+      "Recibes este correo porque te suscribiste para recibir las novedades ocasionales de Peels. Puedes actualizar tus preferencias ",
+    footerMemberLink: "aquí",
+    footerMemberSuffix: ".",
+    footerExternalPrefix:
+      "Recibes este correo porque te apuntaste para recibir novedades ocasionales de Peels. Puedes darte de baja ",
+    footerExternalLink: "aquí",
+    footerExternalSuffix: ".",
+    viewOnlinePrefix: "También puedes ",
+    viewOnlineLink: "leer o compartir este número en línea",
+    viewOnlineSuffix: ".",
+    signOff: "Un abrazo",
+    team: "Equipo de Peels",
+  },
+  de: {
+    subjectPrefix: "Neuer Peels-Newsletter",
+    preview:
+      "Ausgabe #{issueNumber} des Peels-Newsletters ist jetzt verfügbar.",
+    heading: "Eine neue Newsletter-Ausgabe ist da",
+    announcement:
+      "Ausgabe #{issueNumber} des Peels-Newsletters ist jetzt verfügbar.",
+    cta: "Diese Ausgabe lesen",
+    ctaHint:
+      "Öffne sie auf Peels, um das vollständige Update zu lesen und mit anderen zu teilen.",
+    footerMemberPrefix:
+      "Du erhältst diese E-Mail, weil du dich für gelegentliche Newsletter-Updates von Peels angemeldet hast. Du kannst deine Einstellungen ",
+    footerMemberLink: "hier",
+    footerMemberSuffix: " anpassen.",
+    footerExternalPrefix:
+      "Du erhältst diese E-Mail, weil du dich für gelegentliche Updates von Peels angemeldet hast. Du kannst dich ",
+    footerExternalLink: "hier",
+    footerExternalSuffix: " abmelden.",
+    viewOnlinePrefix: "Du kannst diese Ausgabe auch online ",
+    viewOnlineLink: "lesen oder teilen",
+    viewOnlineSuffix: ".",
+    signOff: "Viele Grüsse",
+    team: "Peels-Team",
+  },
+  "pt-BR": {
+    subjectPrefix: "Novo boletim do Peels",
+    preview: "A edição #{issueNumber} do boletim do Peels já está no ar.",
+    heading: "Uma nova edição do boletim chegou",
+    announcement: "A edição #{issueNumber} do boletim do Peels já está no ar.",
+    cta: "Ler esta edição",
+    ctaHint:
+      "Abra no Peels para ler a atualização completa e compartilhar com outras pessoas.",
+    footerMemberPrefix:
+      "Você está recebendo este e-mail porque optou por receber atualizações ocasionais do boletim do Peels. Você pode atualizar as suas preferências ",
+    footerMemberLink: "aqui",
+    footerMemberSuffix: ".",
+    footerExternalPrefix:
+      "Você está recebendo este e-mail porque se inscreveu para receber atualizações ocasionais do Peels. Você pode cancelar a inscrição ",
+    footerExternalLink: "aqui",
+    footerExternalSuffix: ".",
+    viewOnlinePrefix: "Você também pode ",
+    viewOnlineLink: "ler ou compartilhar esta edição online",
+    viewOnlineSuffix: ".",
+    signOff: "Abraço",
+    team: "Equipe Peels",
+  },
+  fr: {
+    subjectPrefix: "Nouvelle infolettre Peels",
+    preview:
+      "Le numéro #{issueNumber} de l’infolettre Peels est maintenant disponible.",
+    heading: "Un nouveau numéro de l’infolettre est arrivé",
+    announcement:
+      "Le numéro #{issueNumber} de l’infolettre Peels est maintenant disponible.",
+    cta: "Lire ce numéro",
+    ctaHint:
+      "Ouvrez-le sur Peels pour lire la mise à jour complète et la partager autour de vous.",
+    footerMemberPrefix:
+      "Vous recevez cet e-mail parce que vous avez choisi de recevoir les nouvelles occasionnelles de Peels. Vous pouvez mettre à jour vos préférences ",
+    footerMemberLink: "ici",
+    footerMemberSuffix: ".",
+    footerExternalPrefix:
+      "Vous recevez cet e-mail parce que vous vous êtes inscrit pour recevoir des nouvelles occasionnelles de Peels. Vous pouvez vous désabonner ",
+    footerExternalLink: "ici",
+    footerExternalSuffix: ".",
+    viewOnlinePrefix: "Vous pouvez aussi ",
+    viewOnlineLink: "lire ou partager ce numéro en ligne",
+    viewOnlineSuffix: ".",
+    signOff: "Bien à vous",
+    team: "Équipe Peels",
+  },
+} as const satisfies Record<SupportedLocale, NewsletterEmailCopy>;
+
+const replaceIssueNumber = (text: string) =>
+  text.replace("{issueNumber}", String(currentIssue.issueNumber));
+
+export const getCurrentNewsletterIssue = (locale: SupportedLocale) => ({
+  ...currentIssue,
+  ...currentIssue.locales[locale],
+});
+
+export const getNewsletterEmailCopy = (locale: SupportedLocale) => {
+  const copy = newsletterEmailCopy[locale];
+
+  return {
+    ...copy,
+    preview: replaceIssueNumber(copy.preview),
+    announcement: replaceIssueNumber(copy.announcement),
+  };
+};
+
+export const getNewsletterEmailSubject = (locale: SupportedLocale) => {
+  const issue = getCurrentNewsletterIssue(locale);
+  const copy = getNewsletterEmailCopy(locale);
+
+  return `${copy.subjectPrefix}: ${issue.title}`;
+};
+
+export const getNewsletterIssueUrl = () =>
+  `https://www.peels.app/newsletter/${currentIssue.slug}`;
+
+export const getNewsletterAudienceConfigs = (): Array<{
+  locale: SupportedLocale;
+  audienceId: string;
+}> => {
+  const audienceIds: Partial<Record<SupportedLocale, string | null>> = {
+    en:
+      Deno.env.get("NEWSLETTER_AUDIENCE_ID_EN") ??
+      Deno.env.get("NEWSLETTER_AUDIENCE_ID") ??
+      legacyAudienceId,
+    es: Deno.env.get("NEWSLETTER_AUDIENCE_ID_ES"),
+    de: Deno.env.get("NEWSLETTER_AUDIENCE_ID_DE"),
+    "pt-BR": Deno.env.get("NEWSLETTER_AUDIENCE_ID_PT_BR"),
+    fr: Deno.env.get("NEWSLETTER_AUDIENCE_ID_FR"),
+  };
+
+  return (
+    Object.entries(audienceIds) as Array<[SupportedLocale, string | null]>
+  )
+    .filter(([, audienceId]) => Boolean(audienceId))
+    .map(([locale, audienceId]) => ({
+      locale,
+      audienceId: audienceId!,
+    }));
+};
+
+export const resolveNewsletterLocale = (
+  value: string | null | undefined
+): SupportedLocale => resolveSupportedLocale(value) ?? defaultEmailLocale;

--- a/supabase/functions/_shared/newsletter.ts
+++ b/supabase/functions/_shared/newsletter.ts
@@ -211,8 +211,17 @@ export const getNewsletterEmailSubject = (locale: SupportedLocale) => {
   return `${copy.subjectPrefix}: ${issue.title}`;
 };
 
-export const getNewsletterIssueUrl = () =>
-  `https://www.peels.app/newsletter/${currentIssue.slug}`;
+export const getNewsletterIssueUrl = (locale?: SupportedLocale) => {
+  const issueUrl = new URL(
+    `https://www.peels.app/newsletter/${currentIssue.slug}`
+  );
+
+  if (locale && locale !== defaultEmailLocale) {
+    issueUrl.searchParams.set("locale", locale);
+  }
+
+  return issueUrl.toString();
+};
 
 export const getNewsletterAudienceConfigs = (): Array<{
   locale: SupportedLocale;

--- a/supabase/functions/_shared/postgrest.ts
+++ b/supabase/functions/_shared/postgrest.ts
@@ -1,0 +1,9 @@
+export function isMissingPreferredLocaleColumn(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  return (
+    error.code === "PGRST204" &&
+    (error.message ?? "").toLowerCase().includes("preferred_locale")
+  );
+}

--- a/supabase/functions/_templates/build-auth-confirm-url.ts
+++ b/supabase/functions/_templates/build-auth-confirm-url.ts
@@ -32,11 +32,13 @@ const getDefaultNextPathByType = (type: AuthEmailType) =>
 export const buildAuthConfirmUrl = ({
   email,
   emailActionType,
+  locale,
   redirectTo,
   tokenHash,
 }: {
   email?: string;
   emailActionType: string;
+  locale?: string;
   redirectTo: string;
   tokenHash: string;
 }) => {
@@ -76,6 +78,9 @@ export const buildAuthConfirmUrl = ({
   confirmUrl.searchParams.set("token_hash", tokenHash);
   confirmUrl.searchParams.set("type", safeAction);
   confirmUrl.searchParams.set("next", nextPath);
+  if (locale) {
+    confirmUrl.searchParams.set("locale", locale);
+  }
   if (email) {
     confirmUrl.searchParams.set("email", email);
   }

--- a/supabase/functions/_templates/email-change-email.tsx
+++ b/supabase/functions/_templates/email-change-email.tsx
@@ -2,11 +2,17 @@ import EmailBody from "./components/EmailBody.tsx";
 import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
 import { buildAuthConfirmUrl } from "./build-auth-confirm-url.ts";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface EmailChangeEmailProps {
   email: string;
   newEmail: string;
+  locale: SupportedLocale;
   supabase_url: string;
   email_action_type: string;
   redirect_to: string;
@@ -19,41 +25,43 @@ interface EmailChangeEmailProps {
 export const EmailChangeEmail = ({
   email,
   newEmail,
+  locale,
   supabase_url,
   email_action_type,
   redirect_to,
   token_hash,
 }: EmailChangeEmailProps) => {
+  const copy = getAuthEmailCopy(locale, "emailChange");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   const confirmUrl = buildAuthConfirmUrl({
     emailActionType: email_action_type,
+    locale,
     redirectTo: redirect_to,
     tokenHash: token_hash,
   });
 
   return (
     <EmailBody
-      previewText="Here’s a link to change the email address you use on Peels."
-      headingText="Confirm your email change"
-      footerText="You’re receiving this email because you requested an email address change on Peels."
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
+      <EmailParagraph>{copy.body}</EmailParagraph>
+
+      <EmailButton href={confirmUrl}>{copy.button}</EmailButton>
+
       <EmailParagraph>
-        Follow this link to confirm your new email on Peels:
+        {copy.reminder
+          .replace("{email}", email)
+          .replace("{newEmail}", newEmail)}
       </EmailParagraph>
 
-      <EmailButton href={confirmUrl}>Change email address</EmailButton>
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        As a reminder, you’re changing from {email} to {newEmail}.
-      </EmailParagraph>
-
-      <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
-
-      <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/invite-email.tsx
+++ b/supabase/functions/_templates/invite-email.tsx
@@ -1,11 +1,16 @@
 import EmailBody from "./components/EmailBody.tsx";
 import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
-import EmailLink from "./components/EmailLink.tsx";
 import { buildAuthConfirmUrl } from "./build-auth-confirm-url.ts";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface InviteEmailProps {
+  locale: SupportedLocale;
   //   username: string;
   //   lang: string;
   //   token: string;
@@ -19,6 +24,7 @@ interface InviteEmailProps {
 // https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/_templates/sign-up.tsx
 
 export const InviteEmail = ({
+  locale,
   //   username,
   //   lang,
   //   token,
@@ -27,34 +33,31 @@ export const InviteEmail = ({
   redirect_to,
   token_hash,
 }: InviteEmailProps) => {
-  const siteUrl = "https://www.peels.app";
+  const copy = getAuthEmailCopy(locale, "invite");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   const confirmUrl = buildAuthConfirmUrl({
     emailActionType: email_action_type,
+    locale,
     redirectTo: redirect_to,
     tokenHash: token_hash,
   });
 
   return (
     <EmailBody
-      previewText="Lucky you! You’re invited to try out Peels."
-      headingText="You’re invited"
-      footerText="You’re receiving this email because someone at Peels invited you to join."
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
-      <EmailParagraph>
-        Someone at <EmailLink href={siteUrl}>Peels</EmailLink> has invited you
-        to try it out. Follow this link to accept the invite:
-      </EmailParagraph>
+      <EmailParagraph>{copy.body}</EmailParagraph>
 
-      <EmailButton href={confirmUrl}>Accept invite</EmailButton>
+      <EmailButton href={confirmUrl}>{copy.button}</EmailButton>
 
-      <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/magic-link-email.tsx
+++ b/supabase/functions/_templates/magic-link-email.tsx
@@ -2,9 +2,15 @@ import EmailBody from "./components/EmailBody.tsx";
 import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
 import { buildAuthConfirmUrl } from "./build-auth-confirm-url.ts";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface MagicLinkEmailProps {
+  locale: SupportedLocale;
   //   username: string;
   //   lang: string;
   //   token: string;
@@ -18,6 +24,7 @@ interface MagicLinkEmailProps {
 // https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/_templates/sign-up.tsx
 
 export const MagicLinkEmail = ({
+  locale,
   //   username,
   //   lang,
   //   token,
@@ -26,32 +33,31 @@ export const MagicLinkEmail = ({
   redirect_to,
   token_hash,
 }: MagicLinkEmailProps) => {
+  const copy = getAuthEmailCopy(locale, "magicLink");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   const confirmUrl = buildAuthConfirmUrl({
     emailActionType: email_action_type,
+    locale,
     redirectTo: redirect_to,
     tokenHash: token_hash,
   });
 
   return (
     <EmailBody
-      previewText="Here’s a link to instantly sign in to Peels."
-      headingText="Your magic link"
-      footerText="You’re receiving this email because you requested help signing in to Peels."
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
-      <EmailParagraph>
-        Follow this link to instantly sign in to Peels:
-      </EmailParagraph>
+      <EmailParagraph>{copy.body}</EmailParagraph>
 
-      <EmailButton href={confirmUrl}>Sign in to Peels</EmailButton>
+      <EmailButton href={confirmUrl}>{copy.button}</EmailButton>
 
-      <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/new-chat-message-email.tsx
+++ b/supabase/functions/_templates/new-chat-message-email.tsx
@@ -5,9 +5,11 @@ import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
 import EmailLink from "./components/EmailLink.tsx";
 import { assignments } from "../_shared/tokens.js";
+import { getChatEmailCopy, type SupportedLocale } from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface NewChatMessageEmailProps {
+  locale: SupportedLocale;
   senderName: string;
   recipientName: string;
   // messageContent: string;
@@ -24,6 +26,7 @@ interface NewChatMessageEmailProps {
 }
 
 export const NewChatMessageEmail = ({
+  locale,
   senderName,
   recipientName,
   // messageContent,
@@ -39,26 +42,37 @@ export const NewChatMessageEmail = ({
   ownerHasMultipleNonResidentialListings,
 }: NewChatMessageEmailProps) => {
   const siteUrl = "https://www.peels.app";
+  const copy = getChatEmailCopy(locale);
+  const listingContext =
+    ownerHasMultipleNonResidentialListings && listingName
+      ? locale === "es"
+        ? ` sobre tu ubicación ${listingName}`
+        : locale === "de"
+          ? ` zu deinem Standort ${listingName}`
+          : locale === "pt-BR"
+            ? ` sobre o teu local ${listingName}`
+            : locale === "fr"
+              ? ` au sujet de votre lieu ${listingName}`
+              : ` about your ${listingName} location`
+      : "";
   return (
     <EmailBody
       logoUnread={true}
-      previewText={`Hi ${recipientName}, you’ve received a new message from ${senderName}. Visit Peels to see what they wrote.`}
-      headingText="New message on Peels"
+      previewText={copy.preview
+        .replace("{recipientName}", recipientName)
+        .replace("{senderName}", senderName)}
+      headingText={copy.heading}
       footerText={
         recipientRole === "owner" ? (
           <>
-            Don’t want emails like this?{" "}
+            {copy.ownerFooterBeforeLink}
             <EmailLink href={`${siteUrl}/profile/listings/${listingSlug}`}>
-              Manage
-            </EmailLink>{" "}
-            your listing to hide or remove it from Peels.
+              {copy.ownerFooterLink}
+            </EmailLink>
+            {copy.ownerFooterAfterLink}
           </>
         ) : (
-          <>
-            You’re receiving this email because you originally reached out to{" "}
-            {senderName} on{" "}
-            <EmailLink href={`${siteUrl}/profile`}>Peels</EmailLink>.
-          </>
+          copy.initiatorFooter.replace("{senderName}", senderName)
         )
       }
     >
@@ -76,27 +90,28 @@ export const NewChatMessageEmail = ({
 
         {recipientRole === "initiator" && (
           <Text style={listingByline}>
-            {listingName ? listingName : `Resident of ${listingAreaName}`}
+            {listingName
+              ? listingName
+              : copy.residentOf.replace("{listingAreaName}", listingAreaName)}
           </Text>
         )}
       </Row>
 
       <EmailParagraph>
-        Hi {recipientName}, you’ve received a new message from {senderName}
-        {ownerHasMultipleNonResidentialListings && listingName
-          ? ` about your ${listingName} location`
-          : ""}
-        . Check it out on Peels:
+        {copy.body
+          .replace("{recipientName}", recipientName)
+          .replace("{senderName}", senderName)
+          .replace("{listingContext}", listingContext)}
       </EmailParagraph>
 
       <EmailButton href={`${siteUrl}/chats/${threadId}`}>
-        View message
+        {copy.button}
       </EmailButton>
 
       <EmailParagraph>
-        Best,
+        {copy.signOff},
         <br />
-        Peels team
+        {copy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/new-chat-message-email.tsx
+++ b/supabase/functions/_templates/new-chat-message-email.tsx
@@ -72,7 +72,13 @@ export const NewChatMessageEmail = ({
             {copy.ownerFooterAfterLink}
           </>
         ) : (
-          copy.initiatorFooter.replace("{senderName}", senderName)
+          <>
+            {copy.initiatorFooterBeforeLink.replace("{senderName}", senderName)}
+            <EmailLink href={`${siteUrl}/chats/${threadId}`}>
+              {copy.initiatorFooterLink}
+            </EmailLink>
+            {copy.initiatorFooterAfterLink}
+          </>
         )
       }
     >

--- a/supabase/functions/_templates/newsletter-issue-email.tsx
+++ b/supabase/functions/_templates/newsletter-issue-email.tsx
@@ -1,0 +1,87 @@
+import * as React from "npm:react";
+import EmailBody from "./components/EmailBody.tsx";
+import EmailButton from "./components/EmailButton.tsx";
+import EmailHr from "./components/EmailHr.tsx";
+import EmailLink from "./components/EmailLink.tsx";
+import EmailParagraph from "./components/EmailParagraph.tsx";
+import {
+  getCurrentNewsletterIssue,
+  getNewsletterEmailCopy,
+  getNewsletterIssueUrl,
+} from "../_shared/newsletter.ts";
+import type { SupportedLocale } from "../_shared/i18n.ts";
+
+interface NewsletterIssueEmailProps {
+  locale: SupportedLocale;
+  recipientName: string;
+  externalAudience: boolean;
+}
+
+const getGreeting = (locale: SupportedLocale, recipientName: string) => {
+  switch (locale) {
+    case "es":
+      return `Hola ${recipientName},`;
+    case "de":
+      return `Hallo ${recipientName},`;
+    case "pt-BR":
+      return `Olá ${recipientName},`;
+    case "fr":
+      return `Bonjour ${recipientName},`;
+    default:
+      return `Hi ${recipientName},`;
+  }
+};
+
+export const NewsletterIssueEmail = ({
+  locale,
+  recipientName = "there",
+  externalAudience,
+}: NewsletterIssueEmailProps) => {
+  const copy = getNewsletterEmailCopy(locale);
+  const issue = getCurrentNewsletterIssue(locale);
+  const issueUrl = getNewsletterIssueUrl();
+  const profileUrl = "https://www.peels.app/profile";
+
+  return (
+    <EmailBody
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={
+        <>
+          {externalAudience ? (
+            <>
+              {copy.footerExternalPrefix}
+              <EmailLink href="{{{RESEND_UNSUBSCRIBE_URL}}}">
+                {copy.footerExternalLink}
+              </EmailLink>
+              {copy.footerExternalSuffix}
+            </>
+          ) : (
+            <>
+              {copy.footerMemberPrefix}
+              <EmailLink href={profileUrl}>{copy.footerMemberLink}</EmailLink>
+              {copy.footerMemberSuffix}
+            </>
+          )}{" "}
+          {copy.viewOnlinePrefix}
+          <EmailLink href={issueUrl}>{copy.viewOnlineLink}</EmailLink>
+          {copy.viewOnlineSuffix}
+        </>
+      }
+    >
+      <EmailParagraph>{getGreeting(locale, recipientName)}</EmailParagraph>
+      <EmailParagraph>{copy.announcement}</EmailParagraph>
+      <EmailParagraph>
+        <strong>{issue.title}</strong>
+      </EmailParagraph>
+      <EmailParagraph>{issue.description}</EmailParagraph>
+      <EmailParagraph>{copy.ctaHint}</EmailParagraph>
+      <EmailButton href={issueUrl}>{copy.cta}</EmailButton>
+      <EmailHr />
+      <EmailParagraph>{copy.signOff}</EmailParagraph>
+      <EmailParagraph>{copy.team}</EmailParagraph>
+    </EmailBody>
+  );
+};
+
+export default NewsletterIssueEmail;

--- a/supabase/functions/_templates/newsletter-issue-email.tsx
+++ b/supabase/functions/_templates/newsletter-issue-email.tsx
@@ -39,7 +39,7 @@ export const NewsletterIssueEmail = ({
 }: NewsletterIssueEmailProps) => {
   const copy = getNewsletterEmailCopy(locale);
   const issue = getCurrentNewsletterIssue(locale);
-  const issueUrl = getNewsletterIssueUrl();
+  const issueUrl = getNewsletterIssueUrl(locale);
   const profileUrl = "https://www.peels.app/profile";
 
   return (

--- a/supabase/functions/_templates/reauthentication-email.tsx
+++ b/supabase/functions/_templates/reauthentication-email.tsx
@@ -1,10 +1,15 @@
 import { CodeInline } from "npm:@react-email/components";
 import EmailBody from "./components/EmailBody.tsx";
-import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface ReauthenticationEmailProps {
+  locale: SupportedLocale;
   //   username: string;
   //   lang: string;
   token: string;
@@ -18,6 +23,7 @@ interface ReauthenticationEmailProps {
 // https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/_templates/sign-up.tsx
 
 export const ReauthenticationEmail = ({
+  locale,
   //   username,
   //   lang,
   token,
@@ -26,26 +32,26 @@ export const ReauthenticationEmail = ({
   // redirect_to,
   // token_hash,
 }: ReauthenticationEmailProps) => {
+  const copy = getAuthEmailCopy(locale, "reauthentication");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   return (
     <EmailBody
-      previewText="Here’s your code for Peels."
-      headingText="Your reauthentication code"
-      footerText="You’re receiving this email because you requested help a reauthentication code for Peels."
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
-      <EmailParagraph>Enter the following code on Peels:</EmailParagraph>
+      <EmailParagraph>{copy.body}</EmailParagraph>
 
       <EmailParagraph>
         <CodeInline>{token}</CodeInline>
       </EmailParagraph>
 
-      <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/reset-password-email.tsx
+++ b/supabase/functions/_templates/reset-password-email.tsx
@@ -2,9 +2,15 @@ import EmailBody from "./components/EmailBody.tsx";
 import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
 import { buildAuthConfirmUrl } from "./build-auth-confirm-url.ts";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface ResetPasswordEmailProps {
+  locale: SupportedLocale;
   //   username: string;
   //   lang: string;
   //   token: string;
@@ -18,6 +24,7 @@ interface ResetPasswordEmailProps {
 // https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/_templates/sign-up.tsx
 
 export const ResetPasswordEmail = ({
+  locale,
   //   username,
   //   lang,
   //   token,
@@ -26,33 +33,31 @@ export const ResetPasswordEmail = ({
   redirect_to,
   token_hash,
 }: ResetPasswordEmailProps) => {
+  const copy = getAuthEmailCopy(locale, "recovery");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   const confirmUrl = buildAuthConfirmUrl({
     emailActionType: email_action_type,
+    locale,
     redirectTo: redirect_to,
     tokenHash: token_hash,
   });
 
   return (
     <EmailBody
-      previewText="Sorry to hear you’re having trouble signing in to Peels. Here’s a link to reset your password."
-      headingText="Reset your password"
-      footerText="You’re receiving this email because someone—hopefully you—requested a password reset link for your Peels account."
+      previewText={copy.preview}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
-      <EmailParagraph>
-        Sorry to hear you’re having trouble signing in to Peels. Tap the below
-        link to reset your password:
-      </EmailParagraph>
+      <EmailParagraph>{copy.body}</EmailParagraph>
 
-      <EmailButton href={confirmUrl}>Reset password</EmailButton>
+      <EmailButton href={confirmUrl}>{copy.button}</EmailButton>
 
-      <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/_templates/sign-up-email.tsx
+++ b/supabase/functions/_templates/sign-up-email.tsx
@@ -2,11 +2,17 @@ import EmailBody from "./components/EmailBody.tsx";
 import EmailButton from "./components/EmailButton.tsx";
 import EmailParagraph from "./components/EmailParagraph.tsx";
 import { buildAuthConfirmUrl } from "./build-auth-confirm-url.ts";
+import {
+  getAuthEmailCopy,
+  getAuthEmailSharedCopy,
+  type SupportedLocale,
+} from "../_shared/i18n.ts";
 import * as React from "npm:react";
 
 interface SignUpEmailProps {
   email: string;
   firstName: string;
+  locale: SupportedLocale;
   //   lang: string;
   //   token: string;
   supabase_url: string;
@@ -21,6 +27,7 @@ interface SignUpEmailProps {
 export const SignUpEmail = ({
   email,
   firstName,
+  locale,
   //   lang,
   //   token,
   supabase_url,
@@ -28,34 +35,34 @@ export const SignUpEmail = ({
   redirect_to,
   token_hash,
 }: SignUpEmailProps) => {
+  const copy = getAuthEmailCopy(locale, "signup");
+  const sharedCopy = getAuthEmailSharedCopy(locale);
   const confirmUrl = buildAuthConfirmUrl({
     email,
     emailActionType: email_action_type,
+    locale,
     redirectTo: redirect_to,
     tokenHash: token_hash,
   });
 
   return (
     <EmailBody
-      previewText={`Let's get you composting, ${firstName}! Here’s a link to verify your Peels account.`}
-      headingText="Welcome to Peels"
-      footerText="You’re receiving this email because you signed up for a Peels account."
+      previewText={copy.preview.replace("{firstName}", firstName)}
+      headingText={copy.heading}
+      footerText={copy.footer}
     >
       <EmailParagraph>
-        We’re so glad you’re here, {firstName}! Follow this link to verify your
-        account:
+        {copy.body.replace("{firstName}", firstName)}
       </EmailParagraph>
 
-      <EmailButton href={confirmUrl}>Verify your Peels account</EmailButton>
+      <EmailButton href={confirmUrl}>{copy.button}</EmailButton>
+
+      <EmailParagraph>{sharedCopy.replyHelp}</EmailParagraph>
 
       <EmailParagraph>
-        Just hit ‘reply’ if you run into any issues or have questions.
-      </EmailParagraph>
-
-      <EmailParagraph>
-        Best,
+        {sharedCopy.signOff},
         <br />
-        Peels team
+        {sharedCopy.team}
       </EmailParagraph>
     </EmailBody>
   );

--- a/supabase/functions/send-email-for-auth-action/index.ts
+++ b/supabase/functions/send-email-for-auth-action/index.ts
@@ -11,6 +11,7 @@ import { MagicLinkEmail } from "../_templates/magic-link-email.tsx";
 import { InviteEmail } from "../_templates/invite-email.tsx";
 import { ReauthenticationEmail } from "../_templates/reauthentication-email.tsx";
 import { renderAsync } from "npm:@react-email/components@0.0.22";
+import { getAuthEmailCopy, resolveEmailLocale } from "../_shared/i18n.ts";
 
 declare const EdgeRuntime: {
   waitUntil: (promise: Promise<unknown>) => void;
@@ -31,6 +32,7 @@ type HookPayload = {
     new_email?: string;
     user_metadata?: {
       first_name?: string;
+      preferred_locale?: string;
     };
   };
   email_data: {
@@ -144,6 +146,10 @@ const prepareEmail = async (
   const userEmail = hookPayload.user.email;
   const userNewEmail = hookPayload.user.new_email ?? "";
   const firstName = hookPayload.user.user_metadata?.first_name ?? "there";
+  const locale = resolveEmailLocale({
+    redirectTo,
+    preferredLocale: hookPayload.user.user_metadata?.preferred_locale,
+  });
 
   if (
     ["signup", "invite", "magiclink", "recovery", "email_change"].includes(
@@ -164,11 +170,13 @@ const prepareEmail = async (
   }
 
   if (emailActionType === "recovery") {
+    const copy = getAuthEmailCopy(locale, "recovery");
     return {
       to: userEmail,
-      subject: "Reset your password on Peels",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(ResetPasswordEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -177,6 +185,7 @@ const prepareEmail = async (
       ),
       text: await renderAsync(
         React.createElement(ResetPasswordEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -189,13 +198,15 @@ const prepareEmail = async (
   }
 
   if (emailActionType === "signup") {
+    const copy = getAuthEmailCopy(locale, "signup");
     return {
       to: userEmail,
-      subject: "Verify your Peels account",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(SignUpEmail, {
           email: userEmail,
           firstName,
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -206,6 +217,7 @@ const prepareEmail = async (
         React.createElement(SignUpEmail, {
           email: userEmail,
           firstName,
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -224,13 +236,15 @@ const prepareEmail = async (
       );
     }
 
+    const copy = getAuthEmailCopy(locale, "emailChange");
     return {
       to: userNewEmail,
-      subject: "Confirm your email change on Peels",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(EmailChangeEmail, {
           email: userEmail,
           newEmail: userNewEmail,
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -241,6 +255,7 @@ const prepareEmail = async (
         React.createElement(EmailChangeEmail, {
           email: userEmail,
           newEmail: userNewEmail,
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -253,11 +268,13 @@ const prepareEmail = async (
   }
 
   if (emailActionType === "magiclink") {
+    const copy = getAuthEmailCopy(locale, "magicLink");
     return {
       to: userEmail,
-      subject: "Your magic link for Peels",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(MagicLinkEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -266,6 +283,7 @@ const prepareEmail = async (
       ),
       text: await renderAsync(
         React.createElement(MagicLinkEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -278,11 +296,13 @@ const prepareEmail = async (
   }
 
   if (emailActionType === "invite") {
+    const copy = getAuthEmailCopy(locale, "invite");
     return {
       to: userEmail,
-      subject: "You’ve been invited to Peels",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(InviteEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -291,6 +311,7 @@ const prepareEmail = async (
       ),
       text: await renderAsync(
         React.createElement(InviteEmail, {
+          locale,
           supabase_url: supabaseUrl,
           token_hash: tokenHash,
           redirect_to: redirectTo,
@@ -303,16 +324,19 @@ const prepareEmail = async (
   }
 
   if (emailActionType === "reauthentication") {
+    const copy = getAuthEmailCopy(locale, "reauthentication");
     return {
       to: userEmail,
-      subject: "Confirm reauthentication on Peels",
+      subject: copy.subject,
       html: await renderAsync(
         React.createElement(ReauthenticationEmail, {
+          locale,
           token,
         })
       ),
       text: await renderAsync(
         React.createElement(ReauthenticationEmail, {
+          locale,
           token,
         }),
         { plainText: true }
@@ -322,16 +346,19 @@ const prepareEmail = async (
   }
 
   // "email" type is treated as generic email OTP verification.
+  const copy = getAuthEmailCopy(locale, "reauthentication");
   return {
     to: userEmail,
-    subject: "Your verification code for Peels",
+    subject: copy.genericSubject,
     html: await renderAsync(
       React.createElement(ReauthenticationEmail, {
+        locale,
         token,
       })
     ),
     text: await renderAsync(
       React.createElement(ReauthenticationEmail, {
+        locale,
         token,
       }),
       { plainText: true }

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "npm:resend";
 import { NewChatMessageEmail } from "../_templates/new-chat-message-email.tsx";
+import { getChatEmailCopy, resolveEmailLocale } from "../_shared/i18n.ts";
 // Temporarily required, see below PR comment
 import { render } from "npm:@react-email/render";
 
@@ -137,12 +138,24 @@ const handler = async (_request: Request): Promise<Response> => {
     const recipientEmail = recipientData?.user?.email;
     console.log("Recipient Email:", recipientEmail);
 
+    const { data: recipientProfile } = await supabase
+      .from("profiles")
+      .select("preferred_locale")
+      .eq("id", recipientId)
+      .single();
+
+    const locale = resolveEmailLocale({
+      preferredLocale: recipientProfile?.preferred_locale,
+    });
+    const copy = getChatEmailCopy(locale);
+
     // Prepare and send Resend email via React Email
     const { data, error } = await resend.emails.send({
       from: `Peels <${generalEmailAddress}>`,
       to: [recipientEmail],
-      subject: `${senderName} just messaged you`,
+      subject: copy.subject.replace("{senderName}", senderName),
       react: NewChatMessageEmail({
+        locale,
         senderName,
         recipientName,
         // messageContent: record.content,
@@ -162,6 +175,7 @@ const handler = async (_request: Request): Promise<Response> => {
       // https://github.com/resend/resend-node/pull/469#issue-2871291956
       text: await render(
         NewChatMessageEmail({
+          locale,
           senderName,
           recipientName,
           // messageContent: record.content,

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -11,6 +11,13 @@ const generalEmailAddress = Deno.env.get("GENERAL_EMAIL_ADDRESS");
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 const resend = new Resend(RESEND_API_KEY);
 
+const isMissingPreferredLocaleColumn = (error: {
+  code?: string | null;
+  message?: string | null;
+}) =>
+  error.code === "PGRST204" &&
+  (error.message ?? "").toLowerCase().includes("preferred_locale");
+
 const handler = async (_request: Request): Promise<Response> => {
   try {
     // Prepare data
@@ -142,11 +149,22 @@ const handler = async (_request: Request): Promise<Response> => {
       throw new Error(`No email found for recipient ${recipientId}`);
     }
 
-    const { data: recipientProfile } = await supabase
-      .from("profiles")
-      .select("preferred_locale")
-      .eq("id", recipientId)
-      .single();
+    const { data: recipientProfile, error: recipientProfileError } =
+      await supabase
+        .from("profiles")
+        .select("preferred_locale")
+        .eq("id", recipientId)
+        .single();
+
+    if (
+      recipientProfileError &&
+      !isMissingPreferredLocaleColumn(recipientProfileError)
+    ) {
+      console.error(
+        "Error loading recipient preferred locale:",
+        recipientProfileError
+      );
+    }
 
     const locale = resolveEmailLocale({
       preferredLocale: recipientProfile?.preferred_locale,

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -138,6 +138,10 @@ const handler = async (_request: Request): Promise<Response> => {
     const recipientEmail = recipientData?.user?.email;
     console.log("Recipient Email:", recipientEmail);
 
+    if (!recipientEmail) {
+      throw new Error(`No email found for recipient ${recipientId}`);
+    }
+
     const { data: recipientProfile } = await supabase
       .from("profiles")
       .select("preferred_locale")

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "npm:resend";
 import { NewChatMessageEmail } from "../_templates/new-chat-message-email.tsx";
 import { getChatEmailCopy, resolveEmailLocale } from "../_shared/i18n.ts";
+import { isMissingPreferredLocaleColumn } from "../_shared/postgrest.ts";
 // Temporarily required, see below PR comment
 import { render } from "npm:@react-email/render";
 
@@ -10,13 +11,6 @@ import { render } from "npm:@react-email/render";
 const generalEmailAddress = Deno.env.get("GENERAL_EMAIL_ADDRESS");
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 const resend = new Resend(RESEND_API_KEY);
-
-const isMissingPreferredLocaleColumn = (error: {
-  code?: string | null;
-  message?: string | null;
-}) =>
-  error.code === "PGRST204" &&
-  (error.message ?? "").toLowerCase().includes("preferred_locale");
 
 const handler = async (_request: Request): Promise<Response> => {
   try {

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -26,10 +26,6 @@ const handler = async (_request: Request): Promise<Response> => {
 
     const audienceConfigs = getNewsletterAudienceConfigs();
 
-    if (audienceConfigs.length === 0) {
-      throw new Error("No newsletter audiences configured");
-    }
-
     const broadcasts = [];
 
     for (const { locale, audienceId } of audienceConfigs) {

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -45,14 +45,7 @@ const handler = async (_request: Request): Promise<Response> => {
           from: `Danny from Peels <${newsletterEmailAddress}>`,
           subject: getNewsletterEmailSubject(locale),
           react: email,
-          text: await render(
-            NewsletterIssueEmail({
-              locale,
-              recipientName: "there",
-              externalAudience: true,
-            }),
-            { plainText: true }
-          ),
+          text: await render(email, { plainText: true }),
           headers: {
             "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -29,9 +29,14 @@ const handler = async (_request: Request): Promise<Response> => {
     const broadcasts = [];
 
     for (const { locale, audienceId } of audienceConfigs) {
-      const email = NewsletterIssueEmail({
+      const reactEmail = NewsletterIssueEmail({
         locale,
         recipientName: "{{{FIRST_NAME|there}}}",
+        externalAudience: true,
+      });
+      const textEmail = NewsletterIssueEmail({
+        locale,
+        recipientName: "there",
         externalAudience: true,
       });
 
@@ -40,8 +45,8 @@ const handler = async (_request: Request): Promise<Response> => {
           audienceId,
           from: `Danny from Peels <${newsletterEmailAddress}>`,
           subject: getNewsletterEmailSubject(locale),
-          react: email,
-          text: await render(email, { plainText: true }),
+          react: reactEmail,
+          text: await render(textEmail, { plainText: true }),
           headers: {
             "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -1,20 +1,18 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { Resend } from "npm:resend";
+import { NewsletterIssueEmail } from "../_templates/newsletter-issue-email.tsx";
+import {
+  getNewsletterAudienceConfigs,
+  getNewsletterEmailSubject,
+} from "../_shared/newsletter.ts";
 // Temporarily required for rendering a text version
 // The `react` email sending method does not yet supports text version
 // https://github.com/resend/resend-node/pull/469
 import { render } from "npm:@react-email/render";
 
-// Update this to the newsletter issue you want to send
-import { NewsletterIssueTwoEmail } from "../_templates/newsletter-issue-two-email.tsx";
-
-// Update this to the newsletter issue you want to send
-const subject = "A small year-end update";
-
 const newsletterEmailAddress = Deno.env.get("NEWSLETTER_EMAIL_ADDRESS");
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 const resend = new Resend(RESEND_API_KEY);
-const newsletterAudienceId = "34497242-6af7-4862-a2e7-356eca18176b";
 
 // This edge function handles the sending of newsletter issues to external folks
 // who don't have a Peels account, such as council or external waste educators
@@ -26,46 +24,67 @@ const handler = async (_request: Request): Promise<Response> => {
 
     console.log("Creating broadcast for Resend audience...");
 
-    const { data: broadcast, error: broadcastError } =
-      await resend.broadcasts.create({
-        audienceId: newsletterAudienceId,
-        from: `Danny from Peels <${newsletterEmailAddress}>`,
-        subject,
-        react: NewsletterIssueTwoEmail({
-          recipientName: "{{{FIRST_NAME|there}}}",
-          externalAudience: true,
-        }),
-        text: await render(
-          NewsletterIssueTwoEmail({
-            recipientName: "there",
-            externalAudience: true,
-          }),
-          { plainText: true }
-        ),
-        headers: {
-          "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
-          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-        },
-      });
+    const audienceConfigs = getNewsletterAudienceConfigs();
 
-    if (broadcastError) {
-      throw broadcastError;
+    if (audienceConfigs.length === 0) {
+      throw new Error("No newsletter audiences configured");
     }
 
-    console.log("Broadcast created, sending...");
+    const broadcasts = [];
 
-    const { data: _sendData, error: sendError } = await resend.broadcasts.send(
-      broadcast.id
-    );
+    for (const { locale, audienceId } of audienceConfigs) {
+      const email = NewsletterIssueEmail({
+        locale,
+        recipientName: "{{{FIRST_NAME|there}}}",
+        externalAudience: true,
+      });
 
-    if (sendError) {
-      throw sendError;
+      const { data: broadcast, error: broadcastError } =
+        await resend.broadcasts.create({
+          audienceId,
+          from: `Danny from Peels <${newsletterEmailAddress}>`,
+          subject: getNewsletterEmailSubject(locale),
+          react: email,
+          text: await render(
+            NewsletterIssueEmail({
+              locale,
+              recipientName: "there",
+              externalAudience: true,
+            }),
+            { plainText: true }
+          ),
+          headers: {
+            "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
+            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+          },
+        });
+
+      if (broadcastError) {
+        throw broadcastError;
+      }
+
+      console.log(`Broadcast created for locale ${locale}, sending...`);
+
+      const { data: sendData, error: sendError } = await resend.broadcasts.send(
+        broadcast.id
+      );
+
+      if (sendError) {
+        throw sendError;
+      }
+
+      broadcasts.push({
+        locale,
+        audienceId,
+        broadcastId: broadcast.id,
+        sendData,
+      });
     }
 
     return new Response(
       JSON.stringify({
         success: true,
-        broadcastId: broadcast.id,
+        broadcasts,
       }),
       {
         status: 200,

--- a/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
@@ -6,6 +6,7 @@ import {
   getNewsletterEmailSubject,
   resolveNewsletterLocale,
 } from "../_shared/newsletter.ts";
+import { isMissingPreferredLocaleColumn } from "../_shared/postgrest.ts";
 // Temporarily required for rendering a text version
 // The `react` email sending method does not yet supports text version
 // https://github.com/resend/resend-node/pull/469
@@ -19,15 +20,6 @@ const resend = new Resend(RESEND_API_KEY);
 // TEST MODE: Set to true to send emails to test address and skip database updates
 const TEST_MODE = false;
 const TEST_EMAIL = "test@example.com";
-
-function isMissingPreferredLocaleColumn(error: {
-  code?: string | null;
-  message?: string | null;
-}) {
-  return (
-    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
-  );
-}
 
 // This edge function handles the sending of newsletter issues to Peels users
 // who opted-in to the newsletter after sign-up or later on in their profile

--- a/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
@@ -1,16 +1,15 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "npm:resend";
+import { NewsletterIssueEmail } from "../_templates/newsletter-issue-email.tsx";
+import {
+  getNewsletterEmailSubject,
+  resolveNewsletterLocale,
+} from "../_shared/newsletter.ts";
 // Temporarily required for rendering a text version
 // The `react` email sending method does not yet supports text version
 // https://github.com/resend/resend-node/pull/469
 import { render } from "npm:@react-email/render";
-
-// Update this to the newsletter issue you want to send
-import { NewsletterIssueTwoEmail } from "../_templates/newsletter-issue-two-email.tsx";
-
-// Update this to the newsletter issue you want to send
-const subject = "A small year-end update";
 
 // Look up required API keys from Supabase secrets
 const newsletterEmailAddress = Deno.env.get("NEWSLETTER_EMAIL_ADDRESS");
@@ -20,6 +19,15 @@ const resend = new Resend(RESEND_API_KEY);
 // TEST MODE: Set to true to send emails to test address and skip database updates
 const TEST_MODE = false;
 const TEST_EMAIL = "test@example.com";
+
+function isMissingPreferredLocaleColumn(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  return (
+    error.code === "PGRST204" && /preferred_locale/i.test(error.message ?? "")
+  );
+}
 
 // This edge function handles the sending of newsletter issues to Peels users
 // who opted-in to the newsletter after sign-up or later on in their profile
@@ -41,22 +49,51 @@ const handler = async (_request: Request): Promise<Response> => {
     // First, get all profiles that are opted-in to the newsletter
     // And have not yet been emailed this issue
     // In TEST_MODE, only get 1 profile to send a single test email
-    const { data: profiles, error: profilesError } = await supabase
+    let profiles: Array<{
+      id: string;
+      first_name: string | null;
+      preferred_locale?: string | null;
+    }> | null = null;
+    let profilesError: {
+      message: string;
+    } | null = null;
+
+    const profilesWithLocaleResult = await supabase
       .from("profiles")
-      .select("id, first_name")
+      .select("id, first_name, preferred_locale")
       .eq("is_newsletter_subscribed", true)
       .eq("emailed_latest_issue", false)
-      .limit(TEST_MODE ? 1 : 30); // Limit to 1 in test mode, 30 in production
+      .limit(TEST_MODE ? 1 : 30);
+
+    if (
+      profilesWithLocaleResult.error &&
+      isMissingPreferredLocaleColumn(profilesWithLocaleResult.error)
+    ) {
+      const fallbackProfilesResult = await supabase
+        .from("profiles")
+        .select("id, first_name")
+        .eq("is_newsletter_subscribed", true)
+        .eq("emailed_latest_issue", false)
+        .limit(TEST_MODE ? 1 : 30);
+
+      profiles = fallbackProfilesResult.data;
+      profilesError = fallbackProfilesResult.error;
+    } else {
+      profiles = profilesWithLocaleResult.data;
+      profilesError = profilesWithLocaleResult.error;
+    }
 
     if (profilesError) {
       throw new Error(`Failed to fetch profiles: ${profilesError.message}`);
     }
 
-    console.log(`Found ${profiles.length} profiles to process`);
+    const profilesToProcess = profiles ?? [];
+
+    console.log(`Found ${profilesToProcess.length} profiles to process`);
 
     // Process each profile
     const results = [];
-    for (const profile of profiles) {
+    for (const profile of profilesToProcess) {
       try {
         // Get user email from auth
         const { data: userData, error: userError } =
@@ -88,6 +125,18 @@ const handler = async (_request: Request): Promise<Response> => {
 
         console.log(`Processing: ${profile.first_name} (${userEmail})`);
 
+        const locale = resolveNewsletterLocale(
+          profile.preferred_locale ??
+            (typeof userData?.user?.user_metadata?.preferred_locale === "string"
+              ? userData.user.user_metadata.preferred_locale
+              : null)
+        );
+        const email = NewsletterIssueEmail({
+          locale,
+          recipientName: profile.first_name || "there",
+          externalAudience: false,
+        });
+
         // Add delay to respect rate limit (at most 2 per second)
         await new Promise((resolve) => setTimeout(resolve, 750));
 
@@ -102,20 +151,11 @@ const handler = async (_request: Request): Promise<Response> => {
         const { data: _data, error } = await resend.emails.send({
           from: `Danny from Peels <${newsletterEmailAddress}>`,
           to: [recipientEmail],
-          subject,
-          react: NewsletterIssueTwoEmail({
-            recipientName: profile.first_name || "there",
-            externalAudience: false,
+          subject: getNewsletterEmailSubject(locale),
+          react: email,
+          text: await render(email, {
+            plainText: true,
           }),
-          text: await render(
-            NewsletterIssueTwoEmail({
-              recipientName: profile.first_name || "there",
-              externalAudience: false,
-            }),
-            {
-              plainText: true,
-            }
-          ),
           headers: {
             "List-Unsubscribe": "<https://www.peels.app/profile>",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click", // Required for deliverability, even if irrelevant

--- a/supabase/migrations/20260421123000_add_profile_preferred_locale.sql
+++ b/supabase/migrations/20260421123000_add_profile_preferred_locale.sql
@@ -1,0 +1,44 @@
+alter table public.profiles
+add column if not exists preferred_locale text;
+
+alter table public.profiles
+drop constraint if exists profiles_preferred_locale_check;
+
+alter table public.profiles
+add constraint profiles_preferred_locale_check
+check (
+  preferred_locale is null
+  or preferred_locale in ('en', 'es', 'de', 'pt-BR', 'fr')
+);
+
+create or replace function public.handle_new_user() returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.profiles (
+    id,
+    first_name,
+    is_newsletter_subscribed,
+    preferred_locale,
+    http_referrer,
+    utm_source,
+    utm_medium,
+    utm_campaign
+  )
+  values (
+    new.id,
+    (new.raw_user_meta_data->>'first_name')::text,
+    (new.raw_user_meta_data->>'is_newsletter_subscribed')::boolean,
+    (new.raw_user_meta_data->>'preferred_locale')::text,
+    (new.raw_user_meta_data->>'http_referrer')::text,
+    (new.raw_user_meta_data->>'utm_source')::text,
+    (new.raw_user_meta_data->>'utm_medium')::text,
+    (new.raw_user_meta_data->>'utm_campaign')::text
+  );
+
+  return new;
+end;
+$$;
+
+alter function public.handle_new_user() owner to postgres;

--- a/supabase/migrations/20260421123000_add_profile_preferred_locale.sql
+++ b/supabase/migrations/20260421123000_add_profile_preferred_locale.sql
@@ -30,7 +30,11 @@ begin
     new.id,
     (new.raw_user_meta_data->>'first_name')::text,
     (new.raw_user_meta_data->>'is_newsletter_subscribed')::boolean,
-    (new.raw_user_meta_data->>'preferred_locale')::text,
+    case
+      when (new.raw_user_meta_data->>'preferred_locale')::text in ('en', 'es', 'de', 'pt-BR', 'fr')
+        then (new.raw_user_meta_data->>'preferred_locale')::text
+      else null
+    end,
     (new.raw_user_meta_data->>'http_referrer')::text,
     (new.raw_user_meta_data->>'utm_source')::text,
     (new.raw_user_meta_data->>'utm_medium')::text,

--- a/supabase/migrations/20260421130000_lock_down_handle_new_user_search_path.sql
+++ b/supabase/migrations/20260421130000_lock_down_handle_new_user_search_path.sql
@@ -1,0 +1,36 @@
+create or replace function public.handle_new_user() returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.profiles (
+    id,
+    first_name,
+    is_newsletter_subscribed,
+    preferred_locale,
+    http_referrer,
+    utm_source,
+    utm_medium,
+    utm_campaign
+  )
+  values (
+    new.id,
+    (new.raw_user_meta_data->>'first_name')::text,
+    (new.raw_user_meta_data->>'is_newsletter_subscribed')::boolean,
+    case
+      when (new.raw_user_meta_data->>'preferred_locale')::text in ('en', 'es', 'de', 'pt-BR', 'fr')
+        then (new.raw_user_meta_data->>'preferred_locale')::text
+      else null
+    end,
+    (new.raw_user_meta_data->>'http_referrer')::text,
+    (new.raw_user_meta_data->>'utm_source')::text,
+    (new.raw_user_meta_data->>'utm_medium')::text,
+    (new.raw_user_meta_data->>'utm_campaign')::text
+  );
+
+  return new;
+end;
+$$;
+
+alter function public.handle_new_user() owner to postgres;


### PR DESCRIPTION
## Summary

- remove Crowdin and consolidate Peels i18n around in-repo `next-intl` message catalogues
- add locale handling for guests, signed-in members, auth redirects, profile preferences, and transactional emails
- localise newsletter and legal content loading, RSS metadata, newsletter issue emails, and contributor docs

## Testing

- `npm run i18n:check`
- `npm run check`
- `npm run build`

## Notes

- external newsletter broadcasts can now be split by locale with `NEWSLETTER_AUDIENCE_ID_EN`, `NEWSLETTER_AUDIENCE_ID_ES`, `NEWSLETTER_AUDIENCE_ID_DE`, `NEWSLETTER_AUDIENCE_ID_PT_BR`, and `NEWSLETTER_AUDIENCE_ID_FR`
- locale-specific newsletter issue files can be full translations or localised wrappers with an explicit English fallback notice
- fixes #5 