### PR TITLE
action-first form standardisation

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -30,7 +30,7 @@ async function signIn(
 }
 
 async function delayProfileActionRequests(page: Page, delayMs = 500) {
-  await page.route("**/profile", async (route) => {
+  await page.route(/\/profile(?:\/|\?|$)/, async (route) => {
     if (route.request().method() === "POST") {
       await page.waitForTimeout(delayMs);
     }
@@ -57,7 +57,7 @@ test("public-listing shows the seeded public listing and guest contact gate", as
 test("profile loads the seeded host account and listings", async ({ page }) => {
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
 
-  await expect(page.getByTestId("profile-first-name")).not.toHaveText("", {
+  await expect(page.getByTestId("profile-first-name")).toHaveText(/\S+/, {
     timeout: PROFILE_RENDER_TIMEOUT_MS,
   });
   await expect(page.getByTestId("profile-listings")).toContainText(

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -29,6 +29,16 @@ async function signIn(
   ]);
 }
 
+async function delayProfileActionRequests(page: Page, delayMs = 500) {
+  await page.route("**/profile", async (route) => {
+    if (route.request().method() === "POST") {
+      await page.waitForTimeout(delayMs);
+    }
+
+    await route.continue();
+  });
+}
+
 test("public-listing shows the seeded public listing and guest contact gate", async ({
   page,
 }) => {
@@ -55,6 +65,59 @@ test("profile loads the seeded host account and listings", async ({ page }) => {
   );
   await expect(page.getByTestId("profile-listings")).toContainText(
     "Inner West Cafe Compost Pickup"
+  );
+});
+
+test("sign-in form preserves redirect_to", async ({ page }) => {
+  await signIn(page, {
+    email: HOST_EMAIL,
+    redirectTo: "/profile",
+  });
+
+  await expect(page).toHaveURL(/\/profile$/);
+});
+
+test("profile account actions show pending feedback and update the read view", async ({
+  page,
+}) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+  await delayProfileActionRequests(page);
+
+  await page.getByTestId("profile-account-first-name-edit").click();
+  await page.getByTestId("profile-account-first-name-input").fill("Avery Test");
+
+  const firstNameSubmit = page.getByTestId("profile-account-first-name-submit");
+  const firstNameClick = firstNameSubmit.click();
+  await expect(firstNameSubmit).toHaveText("Updating...");
+  await firstNameClick;
+  await expect(page.getByTestId("profile-account-first-name-value")).toHaveText(
+    "Avery Test"
+  );
+
+  await page.getByTestId("profile-account-newsletter-edit").click();
+  await page
+    .getByTestId("profile-account-newsletter-input")
+    .selectOption("false");
+
+  const newsletterSubmit = page.getByTestId(
+    "profile-account-newsletter-submit"
+  );
+  const newsletterClick = newsletterSubmit.click();
+  await expect(newsletterSubmit).toHaveText("Updating...");
+  await newsletterClick;
+  await expect(page.getByTestId("profile-account-newsletter-value")).toHaveText(
+    "Not subscribed"
+  );
+
+  await page.getByTestId("profile-account-language-edit").click();
+  await page.getByTestId("profile-account-language-input").selectOption("de");
+
+  const languageSubmit = page.getByTestId("profile-account-language-submit");
+  const languageClick = languageSubmit.click();
+  await expect(languageSubmit).toHaveText("Updating...");
+  await languageClick;
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    "Deutsch"
   );
 });
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -57,7 +57,7 @@ test("public-listing shows the seeded public listing and guest contact gate", as
 test("profile loads the seeded host account and listings", async ({ page }) => {
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
 
-  await expect(page.getByTestId("profile-first-name")).toHaveText("Avery", {
+  await expect(page.getByTestId("profile-first-name")).not.toHaveText("", {
     timeout: PROFILE_RENDER_TIMEOUT_MS,
   });
   await expect(page.getByTestId("profile-listings")).toContainText(
@@ -84,41 +84,88 @@ test("profile account actions show pending feedback and update the read view", a
   await delayProfileActionRequests(page);
 
   await page.getByTestId("profile-account-first-name-edit").click();
-  await page.getByTestId("profile-account-first-name-input").fill("Avery Test");
+  const firstNameInput = page.getByTestId("profile-account-first-name-input");
+  const originalFirstName = await firstNameInput.inputValue();
+  const updatedFirstName =
+    originalFirstName === "Avery Test" ? "Avery Again" : "Avery Test";
+  await firstNameInput.fill(updatedFirstName);
 
   const firstNameSubmit = page.getByTestId("profile-account-first-name-submit");
   const firstNameClick = firstNameSubmit.click();
-  await expect(firstNameSubmit).toHaveText("Updating...");
+  await expect(firstNameSubmit).toBeDisabled();
+  await expect(firstNameSubmit).toHaveAttribute("aria-busy", "true");
   await firstNameClick;
   await expect(page.getByTestId("profile-account-first-name-value")).toHaveText(
-    "Avery Test"
+    updatedFirstName
   );
 
   await page.getByTestId("profile-account-newsletter-edit").click();
-  await page
-    .getByTestId("profile-account-newsletter-input")
-    .selectOption("false");
+  const newsletterInput = page.getByTestId("profile-account-newsletter-input");
+  const originalNewsletterPreference = await newsletterInput.inputValue();
+  const updatedNewsletterPreference =
+    originalNewsletterPreference === "true" ? "false" : "true";
+  await newsletterInput.selectOption(updatedNewsletterPreference);
 
   const newsletterSubmit = page.getByTestId(
     "profile-account-newsletter-submit"
   );
   const newsletterClick = newsletterSubmit.click();
-  await expect(newsletterSubmit).toHaveText("Updating...");
+  await expect(newsletterSubmit).toBeDisabled();
+  await expect(newsletterSubmit).toHaveAttribute("aria-busy", "true");
   await newsletterClick;
-  await expect(page.getByTestId("profile-account-newsletter-value")).toHaveText(
-    "Not subscribed"
-  );
+  await page.getByTestId("profile-account-newsletter-edit").click();
+  await expect(
+    page.getByTestId("profile-account-newsletter-input")
+  ).toHaveValue(updatedNewsletterPreference);
+  await page.getByRole("button", { name: /cancel|abbrechen/i }).click();
 
   await page.getByTestId("profile-account-language-edit").click();
-  await page.getByTestId("profile-account-language-input").selectOption("de");
+  const languageInput = page.getByTestId("profile-account-language-input");
+  const originalLanguage = await languageInput.inputValue();
+  const updatedLanguage = originalLanguage === "de" ? "en" : "de";
+  await languageInput.selectOption(updatedLanguage);
 
   const languageSubmit = page.getByTestId("profile-account-language-submit");
   const languageClick = languageSubmit.click();
-  await expect(languageSubmit).toHaveText("Updating...");
+  await expect(languageSubmit).toBeDisabled();
+  await expect(languageSubmit).toHaveAttribute("aria-busy", "true");
   await languageClick;
-  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    "Deutsch"
+  await page.getByTestId("profile-account-language-edit").click();
+  await expect(page.getByTestId("profile-account-language-input")).toHaveValue(
+    updatedLanguage
   );
+  await page.getByRole("button", { name: /cancel|abbrechen/i }).click();
+
+  await page.getByTestId("profile-account-first-name-edit").click();
+  await page
+    .getByTestId("profile-account-first-name-input")
+    .fill(originalFirstName);
+  await page.getByTestId("profile-account-first-name-submit").click();
+  await expect(page.getByTestId("profile-account-first-name-value")).toHaveText(
+    originalFirstName
+  );
+
+  await page.getByTestId("profile-account-newsletter-edit").click();
+  await page
+    .getByTestId("profile-account-newsletter-input")
+    .selectOption(originalNewsletterPreference);
+  await page.getByTestId("profile-account-newsletter-submit").click();
+  await page.getByTestId("profile-account-newsletter-edit").click();
+  await expect(
+    page.getByTestId("profile-account-newsletter-input")
+  ).toHaveValue(originalNewsletterPreference);
+  await page.getByRole("button", { name: /cancel|abbrechen/i }).click();
+
+  await page.getByTestId("profile-account-language-edit").click();
+  await page
+    .getByTestId("profile-account-language-input")
+    .selectOption(originalLanguage);
+  await page.getByTestId("profile-account-language-submit").click();
+  await page.getByTestId("profile-account-language-edit").click();
+  await expect(page.getByTestId("profile-account-language-input")).toHaveValue(
+    originalLanguage
+  );
+  await page.getByRole("button", { name: /cancel|abbrechen/i }).click();
 });
 
 test("chat loads the seeded thread and composer for a signed-in donor", async ({

--- a/src/app/(core)/(interact)/(centered)/profile/page.js
+++ b/src/app/(core)/(interact)/(centered)/profile/page.js
@@ -1,4 +1,12 @@
 import { createClient } from "@/utils/supabase/server";
+import {
+  deleteAccountAction,
+  sendEmailChangeEmailAction,
+  signOutAction,
+  updateFirstNameAction,
+  updateNewsletterPreferenceAction,
+  updatePreferredLocaleAction,
+} from "@/app/actions";
 import ProfileHeader from "@/components/ProfileHeader";
 import ProfileAccountSettings from "@/components/ProfileAccountSettings";
 import ProfileListings from "@/components/ProfileListings";
@@ -73,12 +81,20 @@ export default async function ProfilePage() {
             ...(profile ?? {}),
             preferred_locale: preferredLocale,
           }}
+          updateFirstNameAction={updateFirstNameAction}
+          sendEmailChangeEmailAction={sendEmailChangeEmailAction}
+          updateNewsletterPreferenceAction={updateNewsletterPreferenceAction}
+          updatePreferredLocaleAction={updatePreferredLocaleAction}
         />
       </Section>
 
       <Section>
         <h2>{t("actions")}</h2>
-        <ProfileActions listings={listings} />
+        <ProfileActions
+          listings={listings}
+          signOutAction={signOutAction}
+          deleteAccountAction={deleteAccountAction}
+        />
       </Section>
 
       <SiteFooter />

--- a/src/app/(forms)/forgot-password/page.tsx
+++ b/src/app/(forms)/forgot-password/page.tsx
@@ -35,7 +35,7 @@ export default async function ForgotPassword(props: {
         <h1>{t("Auth.forgotPassword.title")}</h1>
         <p>{t("Auth.forgotPassword.body")}</p>
       </FormHeader>
-      <Form>
+      <Form action={forgotPasswordAction}>
         <Field>
           <Label htmlFor="email">{t("Common.email")}</Label>
           <Input
@@ -49,10 +49,7 @@ export default async function ForgotPassword(props: {
         {searchParams.error && (
           <FormMessage message={{ error: searchParams.error }} />
         )}
-        <SubmitButton
-          formAction={forgotPasswordAction}
-          pendingText={t("Status.emailing")}
-        >
+        <SubmitButton pendingText={t("Status.emailing")}>
           {t("Actions.emailLink")}
         </SubmitButton>
       </Form>

--- a/src/app/(forms)/profile/reset-password/page.tsx
+++ b/src/app/(forms)/profile/reset-password/page.tsx
@@ -44,7 +44,7 @@ export default async function ResetPassword(props: {
         <h1>{t("Auth.resetPassword.title")}</h1>
         <p>{t("Auth.resetPassword.body")}</p>
       </FormHeader>
-      <Form>
+      <Form action={resetPasswordAction}>
         <Field>
           <Label htmlFor="password">
             {t("Auth.resetPassword.newPassword")}
@@ -73,10 +73,7 @@ export default async function ResetPassword(props: {
         {searchParams.error && (
           <FormMessage message={{ error: searchParams.error }} />
         )}
-        <SubmitButton
-          formAction={resetPasswordAction}
-          pendingText={t("Status.resetting")}
-        >
+        <SubmitButton pendingText={t("Status.resetting")}>
           {t("Actions.resetPassword")}
         </SubmitButton>
       </Form>

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -17,7 +17,8 @@ import {
 import { getUserLocale, setUserLocale } from "@/i18n/services/locale";
 import { resolveAuthLocale } from "@/utils/authRedirects";
 import { isMissingPreferredLocaleColumn } from "@/utils/postgrest";
-import { normaliseLocale } from "@/i18n/config";
+import { normaliseLocale, type Locale } from "@/i18n/config";
+import type { InlineActionResult } from "@/types/actionResult";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
@@ -42,6 +43,43 @@ function translateFirstNameFieldError(
     default:
       return t("generic");
   }
+}
+
+type UpdateFirstNameActionData = {
+  firstName: string;
+};
+
+type SendEmailChangeActionData = {
+  email: string;
+};
+
+type UpdateNewsletterPreferenceActionData = {
+  newsletterPreference: boolean;
+};
+
+type UpdatePreferredLocaleActionData = {
+  preferredLocale: Locale;
+};
+
+function getActionFormData<T>(
+  previousStateOrFormData: FormData | InlineActionResult<T>,
+  maybeFormData?: FormData
+) {
+  return previousStateOrFormData instanceof FormData
+    ? previousStateOrFormData
+    : (maybeFormData as FormData);
+}
+
+function actionError<T>(error: string): InlineActionResult<T> {
+  return { success: false, error };
+}
+
+function actionSuccess<T>(data?: T): InlineActionResult<T> {
+  if (data === undefined) {
+    return { success: true, error: null };
+  }
+
+  return { success: true, error: null, data };
 }
 
 export const signUpAction = async (formData: FormData, request?: Request) => {
@@ -211,7 +249,7 @@ export const signUpAction = async (formData: FormData, request?: Request) => {
   return redirect(redirectUrl.toString());
 };
 
-export const signInAction = async (formData: FormData, request: Request) => {
+export const signInAction = async (formData: FormData) => {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
   const redirectTo = formData.get("redirect_to") as string;
@@ -264,7 +302,20 @@ export const forgotPasswordAction = async (formData: FormData) => {
   );
 };
 
-export const updateFirstNameAction = async (formData: FormData) => {
+export async function updateFirstNameAction(
+  previousState: InlineActionResult<UpdateFirstNameActionData>,
+  formData: FormData
+): Promise<InlineActionResult<UpdateFirstNameActionData>>;
+export async function updateFirstNameAction(
+  formData: FormData
+): Promise<InlineActionResult<UpdateFirstNameActionData>>;
+export async function updateFirstNameAction(
+  previousStateOrFormData:
+    | FormData
+    | InlineActionResult<UpdateFirstNameActionData>,
+  maybeFormData?: FormData
+) {
+  const formData = getActionFormData(previousStateOrFormData, maybeFormData);
   const t = await getTranslations("Errors");
   const supabase = await createClient();
   const {
@@ -273,9 +324,9 @@ export const updateFirstNameAction = async (formData: FormData) => {
 
   const firstNameValidation = validateFirstName(formData.get("first_name"));
   if (!firstNameValidation.isValid) {
-    return {
-      error: translateFirstNameFieldError(t, firstNameValidation.error),
-    };
+    return actionError<UpdateFirstNameActionData>(
+      translateFirstNameFieldError(t, firstNameValidation.error)
+    );
   }
 
   const { error } = await supabase
@@ -288,24 +339,54 @@ export const updateFirstNameAction = async (formData: FormData) => {
   if (error) {
     console.error("Error updating first name:", error);
     if (error.code === "23514" || /first name/i.test(error.message ?? "")) {
-      return { error: t("firstNameNotAllowed") };
+      return actionError<UpdateFirstNameActionData>(t("firstNameNotAllowed"));
     }
-    return { error: t("updateFirstNameFailed") };
+    return actionError<UpdateFirstNameActionData>(t("updateFirstNameFailed"));
   }
 
-  return { success: true };
-};
+  revalidatePath("/profile");
 
-export const sendEmailChangeEmailAction = async (formData: FormData) => {
+  return actionSuccess<UpdateFirstNameActionData>({
+    firstName: firstNameValidation.value ?? "",
+  });
+}
+
+export async function sendEmailChangeEmailAction(
+  previousState: InlineActionResult<SendEmailChangeActionData>,
+  formData: FormData
+): Promise<InlineActionResult<SendEmailChangeActionData>>;
+export async function sendEmailChangeEmailAction(
+  formData: FormData
+): Promise<InlineActionResult<SendEmailChangeActionData>>;
+export async function sendEmailChangeEmailAction(
+  previousStateOrFormData:
+    | FormData
+    | InlineActionResult<SendEmailChangeActionData>,
+  maybeFormData?: FormData
+) {
+  const formData = getActionFormData(previousStateOrFormData, maybeFormData);
   const t = await getTranslations("Errors");
   const supabase = await createClient();
   const origin = (await headers()).get("origin");
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const nextEmail = formData.get("email")?.toString()?.trim();
   const locale = resolveAuthLocale(
     formData.get("locale")?.toString() ?? (await getUserLocale())
   );
+
+  if (!nextEmail) {
+    return actionError<SendEmailChangeActionData>(t("emailRequired"));
+  }
+
+  if (nextEmail === user?.email) {
+    return actionError<SendEmailChangeActionData>(t("alreadyYourEmail"));
+  }
+
   const { error } = await supabase.auth.updateUser(
     {
-      email: formData.get("email") as string,
+      email: nextEmail,
     },
     {
       emailRedirectTo: `${origin || getBaseUrl()}/auth/complete?next=/profile&locale=${locale}`,
@@ -314,15 +395,26 @@ export const sendEmailChangeEmailAction = async (formData: FormData) => {
 
   if (error) {
     console.error("Error sending email change email:", error);
-    return {
-      error: t("updateEmailFailed"),
-    };
+    return actionError<SendEmailChangeActionData>(t("updateEmailFailed"));
   }
 
-  return { success: true };
-};
+  return actionSuccess<SendEmailChangeActionData>({ email: nextEmail });
+}
 
-export const updateNewsletterPreferenceAction = async (formData: FormData) => {
+export async function updateNewsletterPreferenceAction(
+  previousState: InlineActionResult<UpdateNewsletterPreferenceActionData>,
+  formData: FormData
+): Promise<InlineActionResult<UpdateNewsletterPreferenceActionData>>;
+export async function updateNewsletterPreferenceAction(
+  formData: FormData
+): Promise<InlineActionResult<UpdateNewsletterPreferenceActionData>>;
+export async function updateNewsletterPreferenceAction(
+  previousStateOrFormData:
+    | FormData
+    | InlineActionResult<UpdateNewsletterPreferenceActionData>,
+  maybeFormData?: FormData
+) {
+  const formData = getActionFormData(previousStateOrFormData, maybeFormData);
   const t = await getTranslations("Errors");
   const supabase = await createClient();
   const {
@@ -340,11 +432,17 @@ export const updateNewsletterPreferenceAction = async (formData: FormData) => {
 
   if (error) {
     console.error("Error updating newsletter preference:", error);
-    return { error: t("updateNewsletterFailed") };
+    return actionError<UpdateNewsletterPreferenceActionData>(
+      t("updateNewsletterFailed")
+    );
   }
 
-  return { success: true };
-};
+  revalidatePath("/profile");
+
+  return actionSuccess<UpdateNewsletterPreferenceActionData>({
+    newsletterPreference,
+  });
+}
 
 export const setDisplayLocaleAction = async (formData: FormData) => {
   const nextLocale = normaliseLocale(formData.get("locale")?.toString());
@@ -359,7 +457,20 @@ export const setDisplayLocaleAction = async (formData: FormData) => {
   return { success: true };
 };
 
-export const updatePreferredLocaleAction = async (formData: FormData) => {
+export async function updatePreferredLocaleAction(
+  previousState: InlineActionResult<UpdatePreferredLocaleActionData>,
+  formData: FormData
+): Promise<InlineActionResult<UpdatePreferredLocaleActionData>>;
+export async function updatePreferredLocaleAction(
+  formData: FormData
+): Promise<InlineActionResult<UpdatePreferredLocaleActionData>>;
+export async function updatePreferredLocaleAction(
+  previousStateOrFormData:
+    | FormData
+    | InlineActionResult<UpdatePreferredLocaleActionData>,
+  maybeFormData?: FormData
+) {
+  const formData = getActionFormData(previousStateOrFormData, maybeFormData);
   const t = await getTranslations("Errors");
   const supabase = await createClient();
   const nextLocale = normaliseLocale(
@@ -370,7 +481,7 @@ export const updatePreferredLocaleAction = async (formData: FormData) => {
   } = await supabase.auth.getUser();
 
   if (!user?.id || !nextLocale) {
-    return { error: t("generic") };
+    return actionError<UpdatePreferredLocaleActionData>(t("generic"));
   }
 
   const { error: profileError } = await supabase
@@ -400,15 +511,17 @@ export const updatePreferredLocaleAction = async (formData: FormData) => {
   }
 
   if (!profileUpdated && !authUpdated) {
-    return { error: t("genericLater") };
+    return actionError<UpdatePreferredLocaleActionData>(t("genericLater"));
   }
 
   await setUserLocale(nextLocale);
   revalidatePath("/profile");
   revalidatePath("/", "layout");
 
-  return { success: true };
-};
+  return actionSuccess<UpdatePreferredLocaleActionData>({
+    preferredLocale: nextLocale,
+  });
+}
 
 // This action triggers the password reset email to be sent to the user, called from the ProfileAccountSettings component
 // See also the very similar forgotPasswordAction which this is based on

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -322,6 +322,10 @@ export async function updateFirstNameAction(
     data: { user },
   } = await supabase.auth.getUser();
 
+  if (!user?.id) {
+    return actionError<UpdateFirstNameActionData>(t("generic"));
+  }
+
   const firstNameValidation = validateFirstName(formData.get("first_name"));
   if (!firstNameValidation.isValid) {
     return actionError<UpdateFirstNameActionData>(
@@ -420,6 +424,10 @@ export async function updateNewsletterPreferenceAction(
   const {
     data: { user },
   } = await supabase.auth.getUser();
+
+  if (!user?.id) {
+    return actionError<UpdateNewsletterPreferenceActionData>(t("generic"));
+  }
 
   const newsletterPreference = formData.get("newsletter_preference") === "true";
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -153,8 +153,9 @@ const buttonStyles = ({ theme }: { theme: any }): any => ({
   justifyContent: "center", // Added to help with alignment
   textDecoration: "none",
   padding: `0 calc(${theme.spacing.unit} * 2)`,
+  transform: "translateY(0)",
   transition:
-    "background 100ms ease-in-out, color 75ms ease-in-out, box-shadow 100ms ease-in-out",
+    "background 100ms ease-in-out, color 75ms ease-in-out, box-shadow 100ms ease-in-out, transform 50ms ease-out",
 
   // Ellipsize text
   "& span": {
@@ -175,6 +176,9 @@ const buttonStyles = ({ theme }: { theme: any }): any => ({
     cursor: "default",
     background: theme.colors.button.disabled.background,
     color: theme.colors.button.disabled.text,
+  },
+  '&:active:not([disabled]):not([aria-disabled="true"])': {
+    transform: "translateY(1px)",
   },
 
   variants: [

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -117,7 +117,7 @@ function ButtonToDialog({
                 width="contained"
                 pendingText={resolvedConfirmLoadingText}
                 // tabIndex={undefined} // Doesn't work. See below.
-                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibilty)
+                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
               >
                 {confirmButtonText}
               </SubmitButton>
@@ -130,7 +130,7 @@ function ButtonToDialog({
                 loading={isSubmitting}
                 loadingText={resolvedConfirmLoadingText}
                 // tabIndex={undefined} // Doesn't work. See below.
-                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibilty)
+                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
               >
                 {confirmButtonText}
               </SubmitButton>

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -110,8 +110,20 @@ function ButtonToDialog({
           <Dialog.Description>{children}</Dialog.Description>
         </Text>
         <Buttons>
-          {(action || onSubmit) && (
-            <form action={action} onSubmit={handleSubmit}>
+          {action ? (
+            <form action={action}>
+              <SubmitButton
+                variant={variant !== "danger" ? "primary" : "danger"}
+                width="contained"
+                pendingText={resolvedConfirmLoadingText}
+                // tabIndex={undefined} // Doesn't work. See below.
+                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibilty)
+              >
+                {confirmButtonText}
+              </SubmitButton>
+            </form>
+          ) : onSubmit ? (
+            <form onSubmit={handleSubmit}>
               <SubmitButton
                 variant={variant !== "danger" ? "primary" : "danger"}
                 width="contained"
@@ -123,7 +135,7 @@ function ButtonToDialog({
                 {confirmButtonText}
               </SubmitButton>
             </form>
-          )}
+          ) : null}
           <Dialog.Close asChild>
             <Button variant="secondary" width="contained">
               {resolvedCancelButtonText}

--- a/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
+++ b/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
@@ -203,11 +203,7 @@ function FirstNameEditor({
   }, [onSaved, state.data?.firstName, state.success]);
 
   return (
-    <form
-      action={formAction}
-      style={nestedFormStyle}
-      data-testid="profile-account-first-name-form"
-    >
+    <form style={nestedFormStyle} data-testid="profile-account-first-name-form">
       <Field>
         <Label>{t("Profile.account.firstName")}</Label>
         <InputComponent
@@ -222,6 +218,7 @@ function FirstNameEditor({
 
       <ButtonGroup>
         <SubmitButton
+          formAction={formAction}
           pending={isPending}
           pendingText={t("Status.updating")}
           data-testid="profile-account-first-name-submit"
@@ -249,11 +246,7 @@ function EmailEditor({
   );
 
   return (
-    <form
-      action={formAction}
-      style={nestedFormStyle}
-      data-testid="profile-account-email-form"
-    >
+    <form style={nestedFormStyle} data-testid="profile-account-email-form">
       <input type="hidden" name="locale" value={currentLocale} />
       <Field>
         <Label>{t("Common.email")}</Label>
@@ -279,6 +272,7 @@ function EmailEditor({
       <ButtonGroup>
         {!state.success && (
           <SubmitButton
+            formAction={formAction}
             pending={isPending}
             pendingText={t("Status.sending")}
             data-testid="profile-account-email-submit"
@@ -314,11 +308,7 @@ function NewsletterPreferenceEditor({
   }, [onSaved, state.data?.newsletterPreference, state.success]);
 
   return (
-    <form
-      action={formAction}
-      style={nestedFormStyle}
-      data-testid="profile-account-newsletter-form"
-    >
+    <form style={nestedFormStyle} data-testid="profile-account-newsletter-form">
       <Field>
         <Label>{t("Common.newsletter")}</Label>
         <Select
@@ -345,6 +335,7 @@ function NewsletterPreferenceEditor({
 
       <ButtonGroup>
         <SubmitButton
+          formAction={formAction}
           pending={isPending}
           pendingText={t("Status.updating")}
           data-testid="profile-account-newsletter-submit"
@@ -379,11 +370,7 @@ function PreferredLocaleEditor({
   }, [onSaved, state.data?.preferredLocale, state.success]);
 
   return (
-    <form
-      action={formAction}
-      style={nestedFormStyle}
-      data-testid="profile-account-language-form"
-    >
+    <form style={nestedFormStyle} data-testid="profile-account-language-form">
       <Field>
         <Label>{t("Common.language")}</Label>
         <Select
@@ -409,6 +396,7 @@ function PreferredLocaleEditor({
 
       <ButtonGroup>
         <SubmitButton
+          formAction={formAction}
           pending={isPending}
           pendingText={t("Status.updating")}
           data-testid="profile-account-language-submit"

--- a/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
+++ b/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useState, useCallback } from "react";
+
+import { useActionState, useCallback, useEffect, useState } from "react";
 import Button from "@/components/Button";
-import Form from "@/components/Form";
 import Field from "@/components/Field";
 import Select from "@/components/Select";
 import Label from "@/components/Label";
@@ -10,37 +10,29 @@ import SubmitButton from "@/components/SubmitButton";
 import InputHint from "@/components/InputHint";
 
 import {
-  updateFirstNameAction,
-  updateNewsletterPreferenceAction,
-  updatePreferredLocaleAction,
-  sendEmailChangeEmailAction,
-} from "@/app/actions";
-import {
   defaultLocale,
   localeLabels,
   locales,
   type Locale,
 } from "@/i18n/config";
+import type { InlineActionResult } from "@/types/actionResult";
 
 import { styled } from "@pigment-css/react";
-import { validateFirstName, FIELD_CONFIGS } from "@/lib/formValidation";
+import { FIELD_CONFIGS } from "@/lib/formValidation";
 import { useTranslations } from "next-intl";
 
 const List = styled("ul")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
-  padding: ` 0 calc(${theme.spacing.unit} * 1.5) calc(${theme.spacing.unit} * 1.5)`, // Visually match parent padding
-  // gap: `calc(${theme.spacing.unit} * 1)`,
+  padding: ` 0 calc(${theme.spacing.unit} * 1.5) calc(${theme.spacing.unit} * 1.5)`,
 }));
 
 const ListItem = styled("li")<{ editing?: boolean }>(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
-
   borderStyle: "solid",
   borderColor: "transparent",
   transition: "border-color 25ms linear",
-  // Assume middle row by default
   borderWidth: "1px 0",
   padding: "1rem 0",
   margin: "-0.5px 0",
@@ -67,7 +59,7 @@ const ListItem = styled("li")<{ editing?: boolean }>(({ theme }) => ({
   ],
 }));
 
-const ListItemReadField = styled(Field)(({ theme }) => ({
+const ListItemReadField = styled(Field)(() => ({
   flex: 1,
 }));
 
@@ -83,32 +75,66 @@ const PasswordPreview = styled("p")(({ theme }) => ({
 }));
 
 const InputComponent = Input as React.ComponentType<any>;
+const nestedFormStyle = {
+  width: "100%",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+} as const;
 
-// New custom hook for managing edit states
+type FirstNameActionData = {
+  firstName: string;
+};
+
+type EmailActionData = {
+  email: string;
+};
+
+type NewsletterPreferenceActionData = {
+  newsletterPreference: boolean;
+};
+
+type PreferredLocaleActionData = {
+  preferredLocale: Locale;
+};
+
+type UpdateFirstNameFormAction = (
+  previousState: InlineActionResult<FirstNameActionData>,
+  formData: FormData
+) => Promise<InlineActionResult<FirstNameActionData>>;
+
+type SendEmailChangeFormAction = (
+  previousState: InlineActionResult<EmailActionData>,
+  formData: FormData
+) => Promise<InlineActionResult<EmailActionData>>;
+
+type UpdateNewsletterPreferenceFormAction = (
+  previousState: InlineActionResult<NewsletterPreferenceActionData>,
+  formData: FormData
+) => Promise<InlineActionResult<NewsletterPreferenceActionData>>;
+
+type UpdatePreferredLocaleFormAction = (
+  previousState: InlineActionResult<PreferredLocaleActionData>,
+  formData: FormData
+) => Promise<InlineActionResult<PreferredLocaleActionData>>;
+
+function getInitialInlineActionState<T>(): InlineActionResult<T> {
+  return {
+    success: false,
+    error: null,
+  };
+}
+
 function useEditableField(initialState = false) {
   const [isEditing, setIsEditing] = useState(initialState);
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [lastSentAt, setLastSentAt] = useState(0);
 
   const reset = useCallback(() => {
     setIsEditing(false);
-    setError(null);
-    setSuccess(false);
   }, []);
 
   return {
     isEditing,
     setIsEditing,
-    isUpdating,
-    setIsUpdating,
-    error,
-    setError,
-    success,
-    setSuccess,
-    lastSentAt,
-    setLastSentAt,
     reset,
   };
 }
@@ -122,14 +148,290 @@ type ProfileAccountSettingsProps = {
     is_newsletter_subscribed?: boolean;
     preferred_locale?: Locale | null;
   };
+  updateFirstNameAction: UpdateFirstNameFormAction;
+  sendEmailChangeEmailAction: SendEmailChangeFormAction;
+  updateNewsletterPreferenceAction: UpdateNewsletterPreferenceFormAction;
+  updatePreferredLocaleAction: UpdatePreferredLocaleFormAction;
 };
+
+type FirstNameEditorProps = {
+  currentFirstName?: string;
+  action: UpdateFirstNameFormAction;
+  onCancel: () => void;
+  onSaved: (firstName: string) => void;
+};
+
+type EmailEditorProps = {
+  action: SendEmailChangeFormAction;
+  currentEmail: string;
+  currentLocale: Locale;
+  onCancel: () => void;
+};
+
+type NewsletterPreferenceEditorProps = {
+  action: UpdateNewsletterPreferenceFormAction;
+  currentPreference: boolean;
+  onCancel: () => void;
+  onPreferenceChange: (newsletterPreference: boolean) => void;
+  onSaved: (newsletterPreference: boolean) => void;
+};
+
+type PreferredLocaleEditorProps = {
+  action: UpdatePreferredLocaleFormAction;
+  currentLocale: Locale;
+  onCancel: () => void;
+  onLocaleChange: (locale: Locale) => void;
+  onSaved: (locale: Locale) => void;
+};
+
+function FirstNameEditor({
+  action,
+  currentFirstName,
+  onCancel,
+  onSaved,
+}: FirstNameEditorProps) {
+  const t = useTranslations();
+  const [state, formAction, isPending] = useActionState(
+    action,
+    getInitialInlineActionState<FirstNameActionData>()
+  );
+
+  useEffect(() => {
+    if (state.success && state.data?.firstName !== undefined) {
+      onSaved(state.data.firstName);
+    }
+  }, [onSaved, state.data?.firstName, state.success]);
+
+  return (
+    <form
+      action={formAction}
+      style={nestedFormStyle}
+      data-testid="profile-account-first-name-form"
+    >
+      <Field>
+        <Label>{t("Profile.account.firstName")}</Label>
+        <InputComponent
+          name="first_name"
+          {...FIELD_CONFIGS.firstName}
+          defaultValue={currentFirstName}
+          error={state.error}
+          data-testid="profile-account-first-name-input"
+        />
+        {state.error && <InputHint variant="error">{state.error}</InputHint>}
+      </Field>
+
+      <ButtonGroup>
+        <SubmitButton
+          pending={isPending}
+          pendingText={t("Status.updating")}
+          data-testid="profile-account-first-name-submit"
+        >
+          {t("Actions.update")}
+        </SubmitButton>
+        <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+          {t("Actions.cancel")}
+        </Button>
+      </ButtonGroup>
+    </form>
+  );
+}
+
+function EmailEditor({
+  action,
+  currentEmail,
+  currentLocale,
+  onCancel,
+}: EmailEditorProps) {
+  const t = useTranslations();
+  const [state, formAction, isPending] = useActionState(
+    action,
+    getInitialInlineActionState<EmailActionData>()
+  );
+
+  return (
+    <form
+      action={formAction}
+      style={nestedFormStyle}
+      data-testid="profile-account-email-form"
+    >
+      <input type="hidden" name="locale" value={currentLocale} />
+      <Field>
+        <Label>{t("Common.email")}</Label>
+        <InputComponent
+          name="email"
+          defaultValue={currentEmail}
+          {...FIELD_CONFIGS.email}
+          error={state.error}
+          data-testid="profile-account-email-input"
+        />
+        <InputHint
+          variant={
+            state.error ? "error" : state.success ? "success" : "default"
+          }
+        >
+          {state.error
+            ? state.error
+            : state.success
+              ? t("Profile.account.emailSuccess")
+              : t("Profile.account.emailHint")}
+        </InputHint>
+      </Field>
+      <ButtonGroup>
+        {!state.success && (
+          <SubmitButton
+            pending={isPending}
+            pendingText={t("Status.sending")}
+            data-testid="profile-account-email-submit"
+          >
+            {t("Actions.sendLink")}
+          </SubmitButton>
+        )}
+        <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+          {state.success ? t("Actions.close") : t("Actions.cancel")}
+        </Button>
+      </ButtonGroup>
+    </form>
+  );
+}
+
+function NewsletterPreferenceEditor({
+  action,
+  currentPreference,
+  onCancel,
+  onPreferenceChange,
+  onSaved,
+}: NewsletterPreferenceEditorProps) {
+  const t = useTranslations();
+  const [state, formAction, isPending] = useActionState(
+    action,
+    getInitialInlineActionState<NewsletterPreferenceActionData>()
+  );
+
+  useEffect(() => {
+    if (state.success && state.data?.newsletterPreference !== undefined) {
+      onSaved(state.data.newsletterPreference);
+    }
+  }, [onSaved, state.data?.newsletterPreference, state.success]);
+
+  return (
+    <form
+      action={formAction}
+      style={nestedFormStyle}
+      data-testid="profile-account-newsletter-form"
+    >
+      <Field>
+        <Label>{t("Common.newsletter")}</Label>
+        <Select
+          name="newsletter_preference"
+          value={String(currentPreference)}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+            onPreferenceChange(event.target.value === "true")
+          }
+          disabled={isPending}
+          required={true}
+          data-testid="profile-account-newsletter-input"
+        >
+          <option value="false">{t("Common.notSubscribed")}</option>
+          <option value="true">{t("Common.subscribed")}</option>
+        </Select>
+        <InputHint variant={state.error ? "error" : "default"}>
+          {state.error
+            ? state.error
+            : currentPreference
+              ? t("Profile.account.newsletterSubscribedHint")
+              : t("Profile.account.newsletterNotSubscribedHint")}
+        </InputHint>
+      </Field>
+
+      <ButtonGroup>
+        <SubmitButton
+          pending={isPending}
+          pendingText={t("Status.updating")}
+          data-testid="profile-account-newsletter-submit"
+        >
+          {t("Actions.update")}
+        </SubmitButton>
+        <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+          {t("Actions.cancel")}
+        </Button>
+      </ButtonGroup>
+    </form>
+  );
+}
+
+function PreferredLocaleEditor({
+  action,
+  currentLocale,
+  onCancel,
+  onLocaleChange,
+  onSaved,
+}: PreferredLocaleEditorProps) {
+  const t = useTranslations();
+  const [state, formAction, isPending] = useActionState(
+    action,
+    getInitialInlineActionState<PreferredLocaleActionData>()
+  );
+
+  useEffect(() => {
+    if (state.success && state.data?.preferredLocale !== undefined) {
+      onSaved(state.data.preferredLocale);
+    }
+  }, [onSaved, state.data?.preferredLocale, state.success]);
+
+  return (
+    <form
+      action={formAction}
+      style={nestedFormStyle}
+      data-testid="profile-account-language-form"
+    >
+      <Field>
+        <Label>{t("Common.language")}</Label>
+        <Select
+          name="preferred_locale"
+          value={currentLocale}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+            onLocaleChange(event.target.value as Locale)
+          }
+          disabled={isPending}
+          required={true}
+          data-testid="profile-account-language-input"
+        >
+          {locales.map((locale) => (
+            <option key={locale} value={locale}>
+              {localeLabels[locale]}
+            </option>
+          ))}
+        </Select>
+        <InputHint variant={state.error ? "error" : "default"}>
+          {state.error ? state.error : t("Profile.account.languageHint")}
+        </InputHint>
+      </Field>
+
+      <ButtonGroup>
+        <SubmitButton
+          pending={isPending}
+          pendingText={t("Status.updating")}
+          data-testid="profile-account-language-submit"
+        >
+          {t("Actions.update")}
+        </SubmitButton>
+        <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+          {t("Actions.cancel")}
+        </Button>
+      </ButtonGroup>
+    </form>
+  );
+}
 
 function ProfileAccountSettings({
   user,
   profile,
+  updateFirstNameAction,
+  sendEmailChangeEmailAction,
+  updateNewsletterPreferenceAction,
+  updatePreferredLocaleAction,
 }: ProfileAccountSettingsProps) {
   const t = useTranslations();
-  // Use our custom hook for each editable field
   const firstName = useEditableField();
   const email = useEditableField();
   const newsletterPreference = useEditableField();
@@ -137,205 +439,76 @@ function ProfileAccountSettings({
 
   const [tempFirstName, setTempFirstName] = useState(profile?.first_name);
   const [tempNewsletterPreference, setTempNewsletterPreference] = useState(
-    profile?.is_newsletter_subscribed
+    profile?.is_newsletter_subscribed ?? false
   );
   const [tempPreferredLocale, setTempPreferredLocale] = useState<Locale>(
     profile?.preferred_locale ?? defaultLocale
   );
 
-  // const handlePasswordUpdate = async (formData) => {
-  //   password.setIsUpdating(true);
-  //   password.setError(null);
-  //   try {
-  //     const result = await sendPasswordResetEmailAction(formData);
-  //     if (result?.error) {
-  //       password.setError(result.error);
-  //     } else {
-  //       password.setSuccess(true);
-  //       password.setLastSentAt(Date.now());
-  //     }
-  //   } catch (error) {
-  //     console.error("Error updating password:", error);
-  //     password.setError("Sorry, something’s gone wrong. Please try again.");
-  //   } finally {
-  //     password.setIsUpdating(false);
-  //   }
-  // };
-
-  const handleEmailUpdate = async (formData: FormData) => {
-    const newEmail = formData.get("email")?.toString();
-
-    // Client-side validation for unchanged email
-    if (newEmail === user.email) {
-      email.setError(t("Errors.alreadyYourEmail"));
-      return;
-    }
-
-    email.setIsUpdating(true);
-    email.setError(null);
-    formData.set("locale", tempPreferredLocale);
-
-    try {
-      const result = await sendEmailChangeEmailAction(formData);
-      if (result?.error) {
-        email.setError(result.error);
-      } else {
-        email.setSuccess(true);
-      }
-    } catch (error) {
-      console.error("Error updating email:", error);
-      email.setError(t("Errors.genericLater"));
-    } finally {
-      email.setIsUpdating(false);
-    }
-  };
-
-  const handleFirstNameUpdate = async (formData: FormData) => {
-    const validation = validateFirstName(formData.get("first_name"));
-    if (!validation.isValid) {
-      switch (validation.error) {
-        case "empty":
-          firstName.setError(t("Errors.emptyName"));
-          break;
-        case "tooShort":
-          firstName.setError(t("Errors.firstNameTooShort"));
-          break;
-        case "tooLong":
-          firstName.setError(t("Errors.firstNameTooLong"));
-          break;
-        case "invalidChars":
-          firstName.setError(t("Errors.firstNameInvalidChars"));
-          break;
-        case "forbiddenContent":
-        case "reserved":
-          firstName.setError(t("Errors.firstNameNotAllowed"));
-          break;
-        default:
-          firstName.setError(t("Errors.generic"));
-      }
-      return;
-    }
-
-    firstName.setIsUpdating(true);
-    firstName.setError(null);
-
-    try {
-      const result = await updateFirstNameAction(formData);
-      if (result?.error) {
-        firstName.setError(result.error);
-      } else {
-        setTempFirstName(validation.value ?? "");
-        firstName.setIsEditing(false);
-      }
-    } catch (error) {
-      console.error("Error updating first name:", error);
-      firstName.setError(t("Errors.genericLater"));
-    } finally {
-      firstName.setIsUpdating(false);
-    }
-  };
-
-  const handleFirstNameCancel = () => {
+  const handleFirstNameCancel = useCallback(() => {
     firstName.reset();
-  };
+  }, [firstName.reset]);
 
-  const handleNewsletterPreferenceUpdate = async (formData: FormData) => {
-    const nextNewsletterPreference =
-      formData.get("newsletter_preference") === "true";
-    console.log("Updating newsletter preference to", nextNewsletterPreference);
+  const handleFirstNameSaved = useCallback(
+    (nextFirstName: string) => {
+      setTempFirstName(nextFirstName);
+      firstName.reset();
+    },
+    [firstName.reset]
+  );
 
-    newsletterPreference.setIsUpdating(true);
-    newsletterPreference.setError(null);
+  const handleEmailCancel = useCallback(() => {
+    email.reset();
+  }, [email.reset]);
 
-    try {
-      const result = await updateNewsletterPreferenceAction(formData);
-      if (result?.error) {
-        newsletterPreference.setError(result.error);
-      } else {
-        setTempNewsletterPreference(nextNewsletterPreference);
-        newsletterPreference.setIsEditing(false);
-      }
-    } catch (error) {
-      console.error("Error updating newsletter preference:", error);
-      newsletterPreference.setError(t("Errors.genericLater"));
-    } finally {
-      newsletterPreference.setIsUpdating(false);
-    }
-  };
-
-  const handleNewsletterPreferenceCancel = () => {
-    setTempNewsletterPreference(profile?.is_newsletter_subscribed);
+  const handleNewsletterPreferenceCancel = useCallback(() => {
+    setTempNewsletterPreference(profile?.is_newsletter_subscribed ?? false);
     newsletterPreference.reset();
-  };
+  }, [newsletterPreference.reset, profile?.is_newsletter_subscribed]);
 
-  const handlePreferredLocaleUpdate = async (formData: FormData) => {
-    preferredLocale.setIsUpdating(true);
-    preferredLocale.setError(null);
+  const handleNewsletterPreferenceSaved = useCallback(
+    (nextNewsletterPreference: boolean) => {
+      setTempNewsletterPreference(nextNewsletterPreference);
+      newsletterPreference.reset();
+    },
+    [newsletterPreference.reset]
+  );
 
-    try {
-      const result = await updatePreferredLocaleAction(formData);
-      if (result?.error) {
-        preferredLocale.setError(result.error);
-      } else {
-        preferredLocale.setIsEditing(false);
-      }
-    } catch (error) {
-      console.error("Error updating preferred locale:", error);
-      preferredLocale.setError(t("Errors.genericLater"));
-    } finally {
-      preferredLocale.setIsUpdating(false);
-    }
-  };
-
-  const handlePreferredLocaleCancel = () => {
+  const handlePreferredLocaleCancel = useCallback(() => {
     setTempPreferredLocale(profile?.preferred_locale ?? defaultLocale);
     preferredLocale.reset();
-  };
+  }, [preferredLocale.reset, profile?.preferred_locale]);
+
+  const handlePreferredLocaleSaved = useCallback(
+    (nextLocale: Locale) => {
+      setTempPreferredLocale(nextLocale);
+      preferredLocale.reset();
+    },
+    [preferredLocale.reset]
+  );
 
   return (
     <List>
       <ListItem editing={firstName.isEditing}>
         {firstName.isEditing ? (
-          <Form nested={true} action={handleFirstNameUpdate}>
-            <Field>
-              <Label>{t("Profile.account.firstName")}</Label>
-              <InputComponent
-                name="first_name"
-                {...FIELD_CONFIGS.firstName}
-                defaultValue={tempFirstName}
-                error={firstName.error}
-              />
-              {firstName.error && (
-                <InputHint variant="error">{firstName.error}</InputHint>
-              )}
-            </Field>
-
-            <ButtonGroup>
-              <SubmitButton
-                disabled={firstName.isUpdating}
-                loading={firstName.isUpdating}
-                pendingText={t("Status.updating")}
-              >
-                {t("Actions.update")}
-              </SubmitButton>
-              <Button
-                variant="secondary"
-                onClick={handleFirstNameCancel}
-                disabled={firstName.isUpdating}
-              >
-                {t("Actions.cancel")}
-              </Button>
-            </ButtonGroup>
-          </Form>
+          <FirstNameEditor
+            action={updateFirstNameAction}
+            currentFirstName={tempFirstName}
+            onCancel={handleFirstNameCancel}
+            onSaved={handleFirstNameSaved}
+          />
         ) : (
           <>
             <ListItemReadField>
               <Label>{t("Profile.account.firstName")}</Label>
-              <p>{tempFirstName}</p>
+              <p data-testid="profile-account-first-name-value">
+                {tempFirstName}
+              </p>
             </ListItemReadField>
             <Button
               variant="secondary"
               onClick={() => firstName.setIsEditing(true)}
+              data-testid="profile-account-first-name-edit"
             >
               {t("Actions.edit")}
             </Button>
@@ -345,46 +518,12 @@ function ProfileAccountSettings({
 
       <ListItem editing={email.isEditing}>
         {email.isEditing ? (
-          <Form nested={true} action={handleEmailUpdate}>
-            <Field>
-              <Label>{t("Common.email")}</Label>
-              <InputComponent
-                name="email"
-                defaultValue={user.email}
-                {...FIELD_CONFIGS.email}
-                error={email.error}
-              />
-              <InputHint
-                variant={
-                  email.error ? "error" : email.success ? "success" : "default"
-                }
-              >
-                {email.error
-                  ? email.error
-                  : email.success
-                    ? t("Profile.account.emailSuccess")
-                    : t("Profile.account.emailHint")}
-              </InputHint>
-            </Field>
-            <ButtonGroup>
-              {!email.success && (
-                <SubmitButton
-                  disabled={email.isUpdating}
-                  loading={email.isUpdating}
-                  pendingText={t("Status.sending")}
-                >
-                  {t("Actions.sendLink")}
-                </SubmitButton>
-              )}
-              <Button
-                variant="secondary"
-                onClick={() => email.reset()}
-                disabled={email.isUpdating}
-              >
-                {email.success ? t("Actions.close") : t("Actions.cancel")}
-              </Button>
-            </ButtonGroup>
-          </Form>
+          <EmailEditor
+            action={sendEmailChangeEmailAction}
+            currentEmail={user.email}
+            currentLocale={tempPreferredLocale}
+            onCancel={handleEmailCancel}
+          />
         ) : (
           <>
             <ListItemReadField>
@@ -394,6 +533,7 @@ function ProfileAccountSettings({
             <Button
               variant="secondary"
               onClick={() => email.setIsEditing(true)}
+              data-testid="profile-account-email-edit"
             >
               {t("Actions.edit")}
             </Button>
@@ -403,54 +543,19 @@ function ProfileAccountSettings({
 
       <ListItem editing={newsletterPreference.isEditing}>
         {newsletterPreference.isEditing ? (
-          <Form nested={true} action={handleNewsletterPreferenceUpdate}>
-            <Field>
-              <Label>{t("Common.newsletter")}</Label>
-              <Select
-                name="newsletter_preference"
-                value={String(tempNewsletterPreference)}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  setTempNewsletterPreference(event.target.value === "true")
-                }
-                required={true}
-              >
-                <option value="false">{t("Common.notSubscribed")}</option>
-                <option value="true">{t("Common.subscribed")}</option>
-              </Select>
-              <InputHint
-                variant={newsletterPreference.error ? "error" : "default"}
-              >
-                {newsletterPreference.error
-                  ? newsletterPreference.error
-                  : tempNewsletterPreference
-                    ? t("Profile.account.newsletterSubscribedHint")
-                    : t("Profile.account.newsletterNotSubscribedHint")}
-              </InputHint>
-            </Field>
-
-            <ButtonGroup>
-              <SubmitButton
-                disabled={newsletterPreference.isUpdating}
-                loading={newsletterPreference.isUpdating}
-                pendingText={t("Status.updating")}
-              >
-                {t("Actions.update")}
-              </SubmitButton>
-              <Button
-                variant="secondary"
-                onClick={handleNewsletterPreferenceCancel}
-                disabled={newsletterPreference.isUpdating}
-              >
-                {t("Actions.cancel")}
-              </Button>
-            </ButtonGroup>
-          </Form>
+          <NewsletterPreferenceEditor
+            action={updateNewsletterPreferenceAction}
+            currentPreference={tempNewsletterPreference}
+            onCancel={handleNewsletterPreferenceCancel}
+            onPreferenceChange={setTempNewsletterPreference}
+            onSaved={handleNewsletterPreferenceSaved}
+          />
         ) : (
           <>
             <ListItemReadField>
               <Label>{t("Common.newsletter")}</Label>
-              <p>
-                {tempNewsletterPreference === true
+              <p data-testid="profile-account-newsletter-value">
+                {tempNewsletterPreference
                   ? t("Common.subscribed")
                   : t("Common.notSubscribed")}
               </p>
@@ -458,6 +563,7 @@ function ProfileAccountSettings({
             <Button
               variant="secondary"
               onClick={() => newsletterPreference.setIsEditing(true)}
+              data-testid="profile-account-newsletter-edit"
             >
               {t("Actions.edit")}
             </Button>
@@ -467,56 +573,25 @@ function ProfileAccountSettings({
 
       <ListItem editing={preferredLocale.isEditing}>
         {preferredLocale.isEditing ? (
-          <Form nested={true} action={handlePreferredLocaleUpdate}>
-            <Field>
-              <Label>{t("Common.language")}</Label>
-              <Select
-                name="preferred_locale"
-                value={tempPreferredLocale}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  setTempPreferredLocale(event.target.value as Locale)
-                }
-                required={true}
-              >
-                {locales.map((locale) => (
-                  <option key={locale} value={locale}>
-                    {localeLabels[locale]}
-                  </option>
-                ))}
-              </Select>
-              <InputHint variant={preferredLocale.error ? "error" : "default"}>
-                {preferredLocale.error
-                  ? preferredLocale.error
-                  : t("Profile.account.languageHint")}
-              </InputHint>
-            </Field>
-
-            <ButtonGroup>
-              <SubmitButton
-                disabled={preferredLocale.isUpdating}
-                loading={preferredLocale.isUpdating}
-                pendingText={t("Status.updating")}
-              >
-                {t("Actions.update")}
-              </SubmitButton>
-              <Button
-                variant="secondary"
-                onClick={handlePreferredLocaleCancel}
-                disabled={preferredLocale.isUpdating}
-              >
-                {t("Actions.cancel")}
-              </Button>
-            </ButtonGroup>
-          </Form>
+          <PreferredLocaleEditor
+            action={updatePreferredLocaleAction}
+            currentLocale={tempPreferredLocale}
+            onCancel={handlePreferredLocaleCancel}
+            onLocaleChange={setTempPreferredLocale}
+            onSaved={handlePreferredLocaleSaved}
+          />
         ) : (
           <>
             <ListItemReadField>
               <Label>{t("Common.language")}</Label>
-              <p>{localeLabels[tempPreferredLocale]}</p>
+              <p data-testid="profile-account-language-value">
+                {localeLabels[tempPreferredLocale]}
+              </p>
             </ListItemReadField>
             <Button
               variant="secondary"
               onClick={() => preferredLocale.setIsEditing(true)}
+              data-testid="profile-account-language-edit"
             >
               {t("Actions.edit")}
             </Button>

--- a/src/components/ProfileActions/ProfileActions.tsx
+++ b/src/components/ProfileActions/ProfileActions.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { signOutAction, deleteAccountAction } from "@/app/actions";
 import { siteConfig } from "@/config/site";
 import ButtonToDialog from "@/components/ButtonToDialog";
 import EncodedEmailLink from "@/components/EncodedEmailLink";
@@ -42,9 +41,15 @@ const ActionForm = styled("form")({
 
 type ProfileActionsProps = {
   listings?: unknown[];
+  signOutAction: React.FormHTMLAttributes<HTMLFormElement>["action"];
+  deleteAccountAction: React.FormHTMLAttributes<HTMLFormElement>["action"];
 };
 
-export default function ProfileActions({ listings = [] }: ProfileActionsProps) {
+export default function ProfileActions({
+  listings = [],
+  signOutAction,
+  deleteAccountAction,
+}: ProfileActionsProps) {
   const t = useTranslations();
 
   return (
@@ -57,7 +62,7 @@ export default function ProfileActions({ listings = [] }: ProfileActionsProps) {
         <ActionForm action={signOutAction}>
           <SubmitButton
             variant="secondary"
-            loadingText={t("Status.signingOut")}
+            pendingText={t("Status.signingOut")}
           >
             {t("Actions.signOut")}
           </SubmitButton>

--- a/src/components/SignInForm/SignInForm.tsx
+++ b/src/components/SignInForm/SignInForm.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import { useState } from "react";
 import { signInAction } from "@/app/actions";
-import Button from "@/components/Button";
 import Input from "@/components/Input";
 import Label from "@/components/Label";
 import Form from "@/components/Form";
@@ -10,41 +6,34 @@ import Field from "@/components/Field";
 import FieldHeader from "@/components/FieldHeader";
 import StrongLink from "@/components/StrongLink";
 import FormMessage from "@/components/FormMessage";
-import { useTranslations } from "next-intl";
+import SubmitButton from "@/components/SubmitButton";
+import { getTranslations } from "next-intl/server";
 
-function SignInForm({ searchParams }) {
-  const t = useTranslations();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    if (isSubmitting) return;
-
-    setIsSubmitting(true);
-
-    try {
-      // Create FormData from the form
-      const formData = new FormData(event.currentTarget);
-
-      // Add redirect_to if it exists in searchParams
-      if (searchParams?.redirect_to) {
-        formData.append("redirect_to", searchParams.redirect_to);
-      }
-
-      console.log("Submitting sign in data");
-      await signInAction(formData);
-      // Don't reset isSubmitting on success - let the redirect handle cleanup
-    } catch (error) {
-      console.error("Sign in error:", error);
-      setIsSubmitting(false);
-    }
+type SignInFormProps = {
+  searchParams?: {
+    redirect_to?: string;
+    error?: string;
+    success?: string;
   };
+};
+
+async function SignInForm({ searchParams }: SignInFormProps) {
+  const t = await getTranslations();
 
   return (
-    <Form onSubmit={handleSubmit} data-testid="sign-in-form">
+    <Form action={signInAction} data-testid="sign-in-form">
       {searchParams?.success && (
         <FormMessage message={{ success: searchParams.success }} />
       )}
+
+      {searchParams?.redirect_to && (
+        <input
+          type="hidden"
+          name="redirect_to"
+          value={searchParams.redirect_to}
+        />
+      )}
+
       <Field>
         <Label htmlFor="email">{t("Common.email")}</Label>
         <Input
@@ -78,15 +67,13 @@ function SignInForm({ searchParams }) {
         <FormMessage message={{ error: searchParams.error }} />
       )}
 
-      <Button
-        type="submit"
+      <SubmitButton
         variant="primary"
-        loading={isSubmitting}
-        loadingText={t("Status.signingIn")}
+        pendingText={t("Status.signingIn")}
         data-testid="sign-in-submit"
       >
         {t("Actions.signIn")}
-      </Button>
+      </SubmitButton>
     </Form>
   );
 }

--- a/src/types/actionResult.ts
+++ b/src/types/actionResult.ts
@@ -1,0 +1,5 @@
+export type InlineActionResult<T = undefined> = {
+  success: boolean;
+  error: string | null;
+  data?: T;
+};


### PR DESCRIPTION
## Summary

- standardise natural-fit profile/account forms around server actions plus `useActionState` and `useFormStatus`
- convert `SignInForm` to a server-rendered action form so sign-in now follows the same server-first pattern
- tighten shared button/dialog primitives and align forgot-password/reset-password with form-level actions
- add stable smoke coverage for sign-in redirect behaviour and profile account pending feedback

## Why

This codebase has grown through a few generations of React patterns. This refactor pulls the natural-fit forms back towards current React/Next guidance: real form actions, server-owned mutations, and thinner client boundaries.

The sign-in form was worth converting now. In practice, the cleaner server-component form works in this app, the focused sign-in redirect smoke passes, and the old client wrapper was just preserving a historical quirk.

## Profile pending-state fix

The profile inline editors were submitting correctly, but their pending state was not surfacing reliably with the original `useActionState` wiring. The fix was to bind the `useActionState` dispatcher on the submit button `formAction` in those inline editors rather than on the parent form element in this specific setup. That now gives immediate disabled/busy feedback and keeps the flow within React/Next action patterns.

## Validation

- `npm run check` ✅
- `npm run build` ✅
- `npx playwright test --config=playwright.prod.config.ts e2e/smoke.spec.ts --workers=1` ✅

## Notes

- The remaining client-owned flows are the deliberate exceptions: Turnstile-driven sign-up, listing write/edit, chat sending, and similar JS-led interactions.
- Smoke assertions were also made locale-safe and rerun-safe so changing language no longer makes the suite brittle.
