### PR TITLE
member flow hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Peels keeps testing intentionally small:
 
 The smoke suite covers seeded sign-in, public listing, profile, and chat flows against local Supabase data. It is designed to stay small and high-signal rather than grow into a broad frontend testing matrix.
 
-Before `npm run test:e2e:prod`, make sure you are using the local seeded app stack, not hosted Supabase:
+Before `npm run test:e2e` or `npm run test:e2e:prod`, make sure you are using the local seeded app stack, not hosted Supabase:
 
 - Run `npm run supabase:start`
 - Run `npm run supabase:reset`
@@ -279,7 +279,13 @@ NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<paste the ANON_KEY from npm run supabase:env>
 ```
 
-Then run:
+Then run either:
+
+```bash
+npm run test:e2e
+```
+
+or:
 
 ```bash
 npm run test:e2e:prod

--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ Peels keeps testing intentionally small:
 
 The smoke suite covers seeded sign-in, public listing, profile, and chat flows against local Supabase data. It is designed to stay small and high-signal rather than grow into a broad frontend testing matrix.
 
+Before `npm run test:e2e:prod`, make sure you are using the local seeded app stack, not hosted Supabase:
+
+- Run `npm run supabase:start`
+- Run `npm run supabase:reset`
+- Run `npm run seed:local-media`
+- Run `npm run supabase:env`
+- Make sure `.env.local` uses `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331`
+- Copy the local `ANON_KEY` into `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+The production-like Playwright config starts its own `next start` server so it does not accidentally reuse a stray `next dev` process on port `3000`.
+
 In CI, pull requests run `npm run check` and `npm run build`. Pushes to `main` also run the production-like Playwright smoke suite.
 
 For the first local Playwright run, install the browser once with:

--- a/README.md
+++ b/README.md
@@ -271,6 +271,22 @@ Before `npm run test:e2e:prod`, make sure you are using the local seeded app sta
 - Make sure `.env.local` uses `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331`
 - Copy the local `ANON_KEY` into `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
+If your `.env.local` was previously set up for the hosted Peels project, update it before running Playwright. A working local test setup looks like:
+
+```bash
+NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3000
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<paste the ANON_KEY from npm run supabase:env>
+```
+
+Then run:
+
+```bash
+npm run test:e2e:prod
+```
+
+Use the local anon key that matches the running local Supabase stack. Do not mix the hosted project URL with the local anon key, or the local URL with a hosted anon key.
+
 The production-like Playwright config starts its own `next start` server so it does not accidentally reuse a stray `next dev` process on port `3000`.
 
 In CI, pull requests run `npm run check` and `npm run build`. Pushes to `main` also run the production-like Playwright smoke suite.

--- a/docs/supabase-local-first.md
+++ b/docs/supabase-local-first.md
@@ -98,6 +98,29 @@ Finally:
 npm run dev
 ```
 
+### Local `.env.local` for Playwright
+
+The production-like Playwright suite expects the local seeded Supabase stack, not the hosted Peels project.
+
+Use this shape in `.env.local` before `npm run test:e2e:prod`:
+
+```bash
+NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3000
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<paste the ANON_KEY value from npm run supabase:env>
+```
+
+Recommended sequence:
+
+1. Run `npm run supabase:start`
+2. Run `npm run supabase:reset`
+3. Run `npm run seed:local-media`
+4. Run `npm run supabase:env`
+5. Paste the printed `ANON_KEY` into `.env.local`
+6. Run `npm run test:e2e:prod`
+
+If `.env.local` still points at `https://mfnaqdyunuafbwukbbyr.supabase.co`, the smoke suite will not see the seeded local listings, demo accounts, or demo chat thread.
+
 ### Local URLs
 
 - App: `http://127.0.0.1:3000`

--- a/docs/supabase-local-first.md
+++ b/docs/supabase-local-first.md
@@ -100,7 +100,7 @@ npm run dev
 
 ### Local `.env.local` for Playwright
 
-The production-like Playwright suite expects the local seeded Supabase stack, not the hosted Peels project.
+Both Playwright suites expect the local seeded Supabase stack, not the hosted Peels project.
 
 Use this shape in `.env.local` before `npm run test:e2e:prod`:
 
@@ -117,7 +117,7 @@ Recommended sequence:
 3. Run `npm run seed:local-media`
 4. Run `npm run supabase:env`
 5. Paste the printed `ANON_KEY` into `.env.local`
-6. Run `npm run test:e2e:prod`
+6. Run `npm run test:e2e` or `npm run test:e2e:prod`
 
 If `.env.local` still points at `https://mfnaqdyunuafbwukbbyr.supabase.co`, the smoke suite will not see the seeded local listings, demo accounts, or demo chat thread.
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { DONOR_EMAIL, SEEDED_THREAD_ID, signIn } from "./helpers";
+import {
+  DONOR_EMAIL,
+  SEEDED_THREAD_ID,
+  delayChatSendRequests,
+  failChatSendRequests,
+  signIn,
+} from "./helpers";
 
 test("chat loads the seeded thread and composer for a signed-in donor", async ({
   page,
@@ -19,6 +25,51 @@ test("chat loads the seeded thread and composer for a signed-in donor", async ({
   );
   await expect(page.getByTestId("chat-composer")).toBeVisible();
   await expect(page.getByTestId("chat-composer-input")).toBeVisible();
+});
+
+test("chat send disables the composer while pending and appends the new message", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+  await delayChatSendRequests(page);
+
+  const composerInput = page.getByTestId("chat-composer-input");
+  const sendButton = page.getByTestId("chat-composer-send");
+  const message = `Playwright chat message ${Date.now()}`;
+
+  await composerInput.fill(message);
+
+  const messageVisible = page
+    .getByTestId("chat-message-list")
+    .getByText(message);
+  await sendButton.click();
+  await expect(sendButton).toBeDisabled();
+  await expect(sendButton).toHaveAttribute("aria-busy", "true");
+  await expect(composerInput).toBeDisabled();
+  await expect(messageVisible).toBeVisible();
+  await expect(composerInput).toHaveValue("");
+});
+
+test("chat send failures preserve the draft and show inline feedback", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+  await failChatSendRequests(page);
+
+  const composerInput = page.getByTestId("chat-composer-input");
+  const failedMessage = `Chat failure draft ${Date.now()}`;
+
+  await composerInput.fill(failedMessage);
+  await page.getByTestId("chat-composer-send").click();
+
+  await expect(composerInput).toHaveValue(failedMessage);
+  await expect(page.getByText("Synthetic chat failure")).toBeVisible();
 });
 
 test("invalid chat thread ids redirect back to the chat index", async ({

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -37,10 +37,47 @@ export async function signIn(
   ]);
 }
 
+export async function delayServerActionRequests(page: Page, delayMs = 500) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+
+    if (
+      request.method() === "POST" &&
+      request.headers()["next-action"] !== undefined
+    ) {
+      await page.waitForTimeout(delayMs);
+    }
+
+    await route.continue();
+  });
+}
+
 export async function delayProfileActionRequests(page: Page, delayMs = 500) {
-  await page.route(/\/profile(?:\/|\?|$)/, async (route) => {
+  await delayServerActionRequests(page, delayMs);
+}
+
+export async function delayChatSendRequests(page: Page, delayMs = 500) {
+  await page.route(/\/rest\/v1\/chat_messages(?:\?|$)/, async (route) => {
     if (route.request().method() === "POST") {
       await page.waitForTimeout(delayMs);
+    }
+
+    await route.continue();
+  });
+}
+
+export async function failChatSendRequests(
+  page: Page,
+  message = "Synthetic chat failure"
+) {
+  await page.route(/\/rest\/v1\/chat_messages(?:\?|$)/, async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message }),
+      });
+      return;
     }
 
     await route.continue();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -40,14 +40,16 @@ export async function signIn(
 export async function delayServerActionRequests(page: Page, delayMs = 500) {
   await page.route("**/*", async (route) => {
     const request = route.request();
-
-    if (
+    const isServerActionRequest =
       request.method() === "POST" &&
-      request.headers()["next-action"] !== undefined
-    ) {
-      await page.waitForTimeout(delayMs);
+      request.headers()["next-action"] !== undefined;
+
+    if (!isServerActionRequest) {
+      await route.fallback();
+      return;
     }
 
+    await page.waitForTimeout(delayMs);
     await route.continue();
   });
 }

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { HOST_EMAIL, PROFILE_RENDER_TIMEOUT_MS, signIn } from "./helpers";
+import {
+  HOST_EMAIL,
+  PROFILE_RENDER_TIMEOUT_MS,
+  delayServerActionRequests,
+  signIn,
+} from "./helpers";
 
 const BUSINESS_LISTING_EDIT_PATH = "/profile/listings/demo-inner-west-cafe";
 const ALTERNATE_BUSINESS_DESCRIPTION =
@@ -83,11 +88,16 @@ test("listing edit saves and restores seeded business fields", async ({
 
   await descriptionInput.fill(updatedDescription);
   await visibilityInput.selectOption(updatedVisibility);
+  await delayServerActionRequests(page);
 
-  await Promise.all([
-    page.waitForURL(/\/listings\/demo-inner-west-cafe\?status=updated$/),
-    page.getByTestId("listing-write-submit").click(),
-  ]);
+  const submitButton = page.getByTestId("listing-write-submit");
+  const updateNavigation = page.waitForURL(
+    /\/listings\/demo-inner-west-cafe\?status=updated$/
+  );
+  await submitButton.click();
+  await expect(submitButton).toBeDisabled();
+  await expect(submitButton).toHaveAttribute("aria-busy", "true");
+  await updateNavigation;
 
   await page.goto(BUSINESS_LISTING_EDIT_PATH);
   await expect(page.locator("#description")).toHaveValue(updatedDescription);

--- a/messages/de.json
+++ b/messages/de.json
@@ -34,6 +34,7 @@
     "signInToContact": "Zum Kontaktieren anmelden",
     "signOut": "Abmelden",
     "signUp": "Registrieren",
+    "tryAgain": "Erneut versuchen",
     "update": "Aktualisieren",
     "viewFullListing": "Vollständigen Eintrag ansehen",
     "viewListing": "Eintrag ansehen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -34,6 +34,7 @@
     "signInToContact": "Sign in to contact",
     "signOut": "Sign out",
     "signUp": "Sign up",
+    "tryAgain": "Try again",
     "update": "Update",
     "viewFullListing": "View full listing",
     "viewListing": "View listing"

--- a/messages/es.json
+++ b/messages/es.json
@@ -34,6 +34,7 @@
     "signInToContact": "Inicia sesión para contactar",
     "signOut": "Cerrar sesión",
     "signUp": "Registrarse",
+    "tryAgain": "Intentarlo de nuevo",
     "update": "Actualizar",
     "viewFullListing": "Ver anuncio completo",
     "viewListing": "Ver anuncio"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -34,6 +34,7 @@
     "signInToContact": "Se connecter pour contacter",
     "signOut": "Se déconnecter",
     "signUp": "S’inscrire",
+    "tryAgain": "Réessayer",
     "update": "Mettre à jour",
     "viewFullListing": "Voir l’annonce complète",
     "viewListing": "Voir l’annonce"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -34,6 +34,7 @@
     "signInToContact": "Entrar para falar",
     "signOut": "Sair",
     "signUp": "Criar conta",
+    "tryAgain": "Tentar novamente",
     "update": "Atualizar",
     "viewFullListing": "Ver anúncio completo",
     "viewListing": "Ver anúncio"

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   webServer: {
     ...sharedWebServer,
     command: "npm run start -- --hostname 127.0.0.1 --port 3000",
+    reuseExistingServer: false,
   },
 });

--- a/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/error.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations();
+
+  return (
+    <RouteBoundaryState
+      message={t("Errors.genericLater")}
+      onRetry={reset}
+      retryLabel={t("Actions.tryAgain")}
+    />
+  );
+}

--- a/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/loading.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/loading.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Loading() {
+  const t = useTranslations();
+
+  return <RouteBoundaryState message={t("Common.loading")} />;
+}

--- a/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from "@/utils/supabase/server";
 import ChatPageClient from "@/components/ChatPageClient";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
-import type { ChatThreadRecord } from "@/types/chat";
+import type { ChatThreadRecord, ChatThreadView } from "@/types/chat";
 
 type ChatsPageProps = {
   params: Promise<{
@@ -13,6 +13,14 @@ type ChatsPageProps = {
 export const metadata: Metadata = {
   title: "Chats",
 };
+
+function toChatThreadView(thread: ChatThreadRecord): ChatThreadView {
+  return {
+    ...thread,
+    listing: thread.listing ?? null,
+    messages: thread.chat_messages_with_senders ?? thread.chat_messages ?? [],
+  };
+}
 
 export default async function ChatsPage({ params }: ChatsPageProps) {
   const { threadId: threadIdSegments } = await params;
@@ -41,10 +49,11 @@ export default async function ChatsPage({ params }: ChatsPageProps) {
     .order("created_at", { ascending: false });
 
   const typedThreads = (threads ?? []) as ChatThreadRecord[];
-  const selectedThread =
+  const matchedThread =
     threadId && typedThreads.length > 0
       ? (typedThreads.find((thread) => thread.id === threadId) ?? null)
       : null;
+  const selectedThread = matchedThread ? toChatThreadView(matchedThread) : null;
 
   if (threadId && !selectedThread) {
     redirect("/chats");

--- a/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
@@ -2,7 +2,13 @@ import { createClient } from "@/utils/supabase/server";
 import ChatPageClient from "@/components/ChatPageClient";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
-import type { ChatThreadRecord, ChatThreadView } from "@/types/chat";
+import type {
+  ChatMessageRecord,
+  ChatThreadListItem,
+  ChatThreadPreviewRecord,
+  ChatThreadRecord,
+  ChatThreadView,
+} from "@/types/chat";
 
 type ChatsPageProps = {
   params: Promise<{
@@ -16,9 +22,52 @@ export const metadata: Metadata = {
 
 function toChatThreadView(thread: ChatThreadRecord): ChatThreadView {
   return {
-    ...thread,
+    id: thread.id,
+    initiator_id: thread.initiator_id ?? null,
+    initiator_first_name: thread.initiator_first_name ?? null,
+    initiator_avatar: thread.initiator_avatar ?? null,
+    owner_id: thread.owner_id ?? null,
+    owner_first_name: thread.owner_first_name ?? null,
     listing: thread.listing ?? null,
     messages: thread.chat_messages_with_senders ?? thread.chat_messages ?? [],
+  };
+}
+
+function toLastMessage(
+  thread: ChatThreadPreviewRecord
+): ChatMessageRecord | null {
+  if (
+    thread.latest_message_id == null ||
+    thread.latest_message_content == null ||
+    thread.latest_message_created_at == null
+  ) {
+    return null;
+  }
+
+  return {
+    id: thread.latest_message_id,
+    content: thread.latest_message_content,
+    created_at: thread.latest_message_created_at,
+    read_at: thread.latest_message_read_at ?? null,
+    sender_id: thread.latest_message_sender_id ?? null,
+    thread_id: thread.id,
+  };
+}
+
+function toChatThreadListItem(
+  thread: ChatThreadPreviewRecord,
+  unreadThreadIds: ReadonlySet<string>
+): ChatThreadListItem {
+  return {
+    id: thread.id,
+    initiator_id: thread.initiator_id ?? null,
+    initiator_first_name: thread.initiator_first_name ?? null,
+    initiator_avatar: thread.initiator_avatar ?? null,
+    owner_id: thread.owner_id ?? null,
+    owner_first_name: thread.owner_first_name ?? null,
+    listing: thread.listing ?? null,
+    has_unread_messages: unreadThreadIds.has(thread.id),
+    last_message: toLastMessage(thread),
   };
 }
 
@@ -36,24 +85,97 @@ export default async function ChatsPage({ params }: ChatsPageProps) {
     redirect(`/sign-in?redirect_to=${redirectPath}`);
   }
 
-  const { data: threads } = await supabase
-    .from("chat_threads_with_participants")
-    .select(
-      `
-        *,
-        chat_messages_with_senders (*),
-        listing:listings_private_data (*)
-      `
-    )
-    .or(`initiator_id.eq.${user.id},owner_id.eq.${user.id}`)
-    .order("created_at", { ascending: false });
+  const threadParticipantFilter = `initiator_id.eq.${user.id},owner_id.eq.${user.id}`;
 
-  const typedThreads = (threads ?? []) as ChatThreadRecord[];
-  const matchedThread =
-    threadId && typedThreads.length > 0
-      ? (typedThreads.find((thread) => thread.id === threadId) ?? null)
-      : null;
-  const selectedThread = matchedThread ? toChatThreadView(matchedThread) : null;
+  const [threadsResult, selectedThreadResult] = await Promise.all([
+    supabase
+      .from("chat_threads_with_participants")
+      .select(
+        `
+          id,
+          initiator_id,
+          initiator_first_name,
+          initiator_avatar,
+          owner_id,
+          owner_first_name,
+          latest_message_id,
+          latest_message_content,
+          latest_message_created_at,
+          latest_message_read_at,
+          latest_message_sender_id,
+          listing:listings_private_data (*)
+        `
+      )
+      .or(threadParticipantFilter)
+      .order("created_at", { ascending: false }),
+    threadId
+      ? supabase
+          .from("chat_threads_with_participants")
+          .select(
+            `
+              id,
+              initiator_id,
+              initiator_first_name,
+              initiator_avatar,
+              owner_id,
+              owner_first_name,
+              listing:listings_private_data (*),
+              chat_messages_with_senders (
+                id,
+                content,
+                created_at,
+                read_at,
+                sender_id,
+                thread_id
+              )
+            `
+          )
+          .or(threadParticipantFilter)
+          .eq("id", threadId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  if (threadsResult.error) {
+    throw new Error(threadsResult.error.message);
+  }
+
+  if (selectedThreadResult.error) {
+    throw new Error(selectedThreadResult.error.message);
+  }
+
+  const previewThreads = (threadsResult.data ??
+    []) as ChatThreadPreviewRecord[];
+  const previewThreadIds = previewThreads.map((thread) => thread.id);
+  const { data: unreadMessages, error: unreadMessagesError } =
+    previewThreadIds.length > 0
+      ? await supabase
+          .from("chat_messages")
+          .select("thread_id")
+          .in("thread_id", previewThreadIds)
+          .neq("sender_id", user.id)
+          .is("read_at", null)
+      : { data: [], error: null };
+
+  if (unreadMessagesError) {
+    throw new Error(unreadMessagesError.message);
+  }
+
+  const unreadThreadIds = new Set(
+    (unreadMessages ?? [])
+      .map((message) => message.thread_id)
+      .filter((messageThreadId): messageThreadId is string =>
+        Boolean(messageThreadId)
+      )
+  );
+  const typedThreads = previewThreads.map((thread) =>
+    toChatThreadListItem(thread, unreadThreadIds)
+  );
+  const selectedThreadRecord =
+    selectedThreadResult.data as ChatThreadRecord | null;
+  const selectedThread = selectedThreadRecord
+    ? toChatThreadView(selectedThreadRecord)
+    : null;
 
   if (threadId && !selectedThread) {
     redirect("/chats");

--- a/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[[...threadId]]/page.tsx
@@ -16,9 +16,19 @@ type ChatsPageProps = {
   }>;
 };
 
+type UnreadThreadRow = {
+  thread_id: string | null;
+};
+
 export const metadata: Metadata = {
   title: "Chats",
 };
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value
+  );
+}
 
 function toChatThreadView(thread: ChatThreadRecord): ChatThreadView {
   return {
@@ -85,6 +95,10 @@ export default async function ChatsPage({ params }: ChatsPageProps) {
     redirect(`/sign-in?redirect_to=${redirectPath}`);
   }
 
+  if (threadId && !isUuid(threadId)) {
+    redirect("/chats");
+  }
+
   const threadParticipantFilter = `initiator_id.eq.${user.id},owner_id.eq.${user.id}`;
 
   const [threadsResult, selectedThreadResult] = await Promise.all([
@@ -147,23 +161,20 @@ export default async function ChatsPage({ params }: ChatsPageProps) {
   const previewThreads = (threadsResult.data ??
     []) as ChatThreadPreviewRecord[];
   const previewThreadIds = previewThreads.map((thread) => thread.id);
-  const { data: unreadMessages, error: unreadMessagesError } =
+  const { data: unreadThreads, error: unreadThreadsError } =
     previewThreadIds.length > 0
-      ? await supabase
-          .from("chat_messages")
-          .select("thread_id")
-          .in("thread_id", previewThreadIds)
-          .neq("sender_id", user.id)
-          .is("read_at", null)
+      ? await supabase.rpc("unread_chat_thread_ids", {
+          thread_ids: previewThreadIds,
+        })
       : { data: [], error: null };
 
-  if (unreadMessagesError) {
-    throw new Error(unreadMessagesError.message);
+  if (unreadThreadsError) {
+    throw new Error(unreadThreadsError.message);
   }
 
   const unreadThreadIds = new Set(
-    (unreadMessages ?? [])
-      .map((message) => message.thread_id)
+    ((unreadThreads as UnreadThreadRow[] | null) ?? [])
+      .map((thread) => thread.thread_id)
       .filter((messageThreadId): messageThreadId is string =>
         Boolean(messageThreadId)
       )

--- a/src/app/(forms)/profile/listings/[slug]/error.tsx
+++ b/src/app/(forms)/profile/listings/[slug]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations();
+
+  return (
+    <RouteBoundaryState
+      message={t("Errors.genericLater")}
+      onRetry={reset}
+      retryLabel={t("Actions.tryAgain")}
+    />
+  );
+}

--- a/src/app/(forms)/profile/listings/[slug]/loading.tsx
+++ b/src/app/(forms)/profile/listings/[slug]/loading.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Loading() {
+  const t = useTranslations();
+
+  return <RouteBoundaryState message={t("Common.loading")} />;
+}

--- a/src/app/(forms)/profile/listings/new/[type]/error.tsx
+++ b/src/app/(forms)/profile/listings/new/[type]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations();
+
+  return (
+    <RouteBoundaryState
+      message={t("Errors.genericLater")}
+      onRetry={reset}
+      retryLabel={t("Actions.tryAgain")}
+    />
+  );
+}

--- a/src/app/(forms)/profile/listings/new/[type]/loading.tsx
+++ b/src/app/(forms)/profile/listings/new/[type]/loading.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import RouteBoundaryState from "@/components/RouteBoundaryState/RouteBoundaryState";
+import { useTranslations } from "next-intl";
+
+export default function Loading() {
+  const t = useTranslations();
+
+  return <RouteBoundaryState message={t("Common.loading")} />;
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -19,6 +19,12 @@ import { normaliseNextPath, resolveAuthLocale } from "@/utils/authRedirects";
 import { isMissingPreferredLocaleColumn } from "@/utils/postgrest";
 import { normaliseLocale, type Locale } from "@/i18n/config";
 import type { InlineActionResult } from "@/types/actionResult";
+import type {
+  DeleteListingResult,
+  ListingDraftInput,
+  ListingSubmitResult,
+  ListingType,
+} from "@/types/listing";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
@@ -609,7 +615,9 @@ export const signOutAction = async () => {
   return redirect("/");
 };
 
-export const deleteListingAction = async (slug: string) => {
+export const deleteListingAction = async (
+  slug: string
+): Promise<InlineActionResult<DeleteListingResult>> => {
   const t = await getTranslations();
   // Check if user is logged in first
   const supabase = await createClient();
@@ -641,17 +649,26 @@ export const deleteListingAction = async (slug: string) => {
 
     if (!response.ok) {
       console.error("Error deleting listing:", data.message);
-      return { success: false, message: t("Errors.failedDeleteListing") };
-    } else {
-      console.log("Listing successfully deleted:", slug);
-      return { success: true, message: t("Listings.delete.success") };
+      return actionError(t("Errors.failedDeleteListing"));
     }
+
+    console.log("Listing successfully deleted:", slug);
+    const message = t("Listings.delete.success");
+
+    revalidatePath("/map");
+    revalidatePath("/listings");
+    revalidatePath("/profile");
+    revalidatePath("/profile/listings");
+    revalidatePath(`/listings/${slug}`);
+
+    return actionSuccess({
+      slug,
+      message,
+      redirectTo: `/profile/?message=${encodeURIComponent(message)}`,
+    });
   } catch (error) {
     console.error("Error deleting listing:", error);
-    return {
-      success: false,
-      message: t("Errors.generic"),
-    };
+    return actionError(t("Errors.generic"));
   }
 };
 
@@ -760,7 +777,9 @@ export async function fetchListingsInView(
   }
 }
 
-export const createOrUpdateListingAction = async (listingData: any) => {
+export const createOrUpdateListingAction = async (
+  listingData: ListingDraftInput
+): Promise<InlineActionResult<ListingSubmitResult>> => {
   const t = await getTranslations("Errors");
   const supabase = await createClient();
 
@@ -772,14 +791,14 @@ export const createOrUpdateListingAction = async (listingData: any) => {
       listingData.type !== "community" &&
       listingData.type !== "residential"
     ) {
-      return { error: t("unexpected") };
+      return actionError(t("unexpected"));
     }
 
     // Check name validation
     if (listingData.type !== "residential" && listingData.name) {
       const nameValidation = validateName(listingData.name);
       if (!nameValidation.isValid) {
-        return { error: t("emptyName") };
+        return actionError(t("emptyName"));
       }
       // Use the validated value
       listingData.name = nameValidation.value;
@@ -797,13 +816,14 @@ export const createOrUpdateListingAction = async (listingData: any) => {
 
       // Return specific error messages based on error codes
       if (error.code === "42501") {
-        return {
-          error: t("tooManyListings"),
-        };
-      } else if (error.code === "23505") {
-        return { error: t("duplicateListing") };
+        return actionError(t("tooManyListings"));
       }
-      return { error: t("genericLater") };
+
+      if (error.code === "23505") {
+        return actionError(t("duplicateListing"));
+      }
+
+      return actionError(t("genericLater"));
     }
 
     // If this was a new listing with pending photos, update them
@@ -815,7 +835,7 @@ export const createOrUpdateListingAction = async (listingData: any) => {
 
       if (updateError) {
         console.error("Error updating photos:", updateError);
-        return { error: t("savePhotosFailed") };
+        return actionError(t("savePhotosFailed"));
       }
     }
 
@@ -825,10 +845,22 @@ export const createOrUpdateListingAction = async (listingData: any) => {
     if (data?.slug) {
       revalidatePath(`/listings/${data.slug}`);
     }
+    revalidatePath("/profile");
+    revalidatePath("/profile/listings");
 
-    return { data };
+    if (!data?.slug || !data?.id) {
+      return actionError(t("genericLater"));
+    }
+
+    return actionSuccess({
+      created: !listingData.id,
+      id: data.id,
+      redirectTo: `/listings/${data.slug}?status=${listingData.id ? "updated" : "created"}`,
+      slug: data.slug,
+      type: listingData.type as ListingType,
+    });
   } catch (error) {
     console.error("Unexpected error in createOrUpdateListingAction:", error);
-    return { error: t("unexpected") };
+    return actionError(t("unexpected"));
   }
 };

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -69,7 +69,9 @@ type ButtonToDialogProps = {
   confirmLoadingText?: string;
   cancelButtonText?: ReactNode;
   action?: React.FormHTMLAttributes<HTMLFormElement>["action"];
+  disabled?: boolean;
   onSubmit?: React.FormEventHandler<HTMLFormElement>;
+  pending?: boolean;
 };
 
 function ButtonToDialog({
@@ -82,7 +84,9 @@ function ButtonToDialog({
   confirmLoadingText,
   cancelButtonText,
   action,
+  disabled = false,
   onSubmit,
+  pending = false,
   // ...props // Setting this on Button (for size etc) seems to stop the dialog from opening
 }: ButtonToDialogProps) {
   const t = useTranslations();
@@ -91,11 +95,12 @@ function ButtonToDialog({
     confirmLoadingText ||
     (variant === "danger" ? t("Status.deleting") : t("Status.working"));
   const resolvedCancelButtonText = cancelButtonText || t("Actions.noCancel");
+  const isPending = pending || isSubmitting;
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> | undefined =
     onSubmit
       ? async (event) => {
-          if (isSubmitting) {
+          if (isPending) {
             event.preventDefault();
             return;
           }
@@ -112,7 +117,12 @@ function ButtonToDialog({
   return (
     <Dialog.Root>
       <Dialog.Trigger asChild>
-        <Button width="contained" variant={variant} size={size}>
+        <Button
+          width="contained"
+          variant={variant}
+          size={size}
+          disabled={disabled || isPending}
+        >
           {initialButtonText}
         </Button>
       </Dialog.Trigger>
@@ -128,6 +138,8 @@ function ButtonToDialog({
               <SubmitButton
                 variant={variant !== "danger" ? "primary" : "danger"}
                 width="contained"
+                disabled={disabled || isPending}
+                pending={isPending}
                 pendingText={resolvedConfirmLoadingText}
                 // tabIndex={undefined} // Doesn't work. See below.
                 autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
@@ -140,7 +152,8 @@ function ButtonToDialog({
               <SubmitButton
                 variant={variant !== "danger" ? "primary" : "danger"}
                 width="contained"
-                loading={isSubmitting}
+                disabled={disabled || isPending}
+                loading={isPending}
                 loadingText={resolvedConfirmLoadingText}
                 // tabIndex={undefined} // Doesn't work. See below.
                 autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
@@ -150,7 +163,7 @@ function ButtonToDialog({
             </form>
           ) : null}
           <Dialog.Close asChild>
-            <Button variant="secondary" width="contained">
+            <Button variant="secondary" width="contained" disabled={isPending}>
               {resolvedCancelButtonText}
             </Button>
           </Dialog.Close>

--- a/src/components/ChatPageClient/ChatPageClient.tsx
+++ b/src/components/ChatPageClient/ChatPageClient.tsx
@@ -11,7 +11,7 @@ import PeelsLogo from "@/components/PeelsLogo";
 
 import { styled } from "next-yak";
 import type { User } from "@supabase/supabase-js";
-import type { ChatThreadRecord, ChatThreadView } from "@/types/chat";
+import type { ChatThreadListItem, ChatThreadView } from "@/types/chat";
 
 const ChatPageLayout = styled.main`
   display: flex;
@@ -68,7 +68,7 @@ export default function ChatPageClient({
   selectedThread,
 }: {
   user: User;
-  initialThreads: ChatThreadRecord[];
+  initialThreads: ChatThreadListItem[];
   initialThreadId?: string | null;
   selectedThread?: ChatThreadView | null;
 }) {

--- a/src/components/ChatPageClient/ChatPageClient.tsx
+++ b/src/components/ChatPageClient/ChatPageClient.tsx
@@ -11,7 +11,7 @@ import PeelsLogo from "@/components/PeelsLogo";
 
 import { styled } from "next-yak";
 import type { User } from "@supabase/supabase-js";
-import type { ChatThreadRecord } from "@/types/chat";
+import type { ChatThreadRecord, ChatThreadView } from "@/types/chat";
 
 const ChatPageLayout = styled.main`
   display: flex;
@@ -70,7 +70,7 @@ export default function ChatPageClient({
   user: User;
   initialThreads: ChatThreadRecord[];
   initialThreadId?: string | null;
-  selectedThread?: ChatThreadRecord | null;
+  selectedThread?: ChatThreadView | null;
 }) {
   const t = useTranslations("Chat");
   const { setTabBarProps } = useTabBar();
@@ -100,18 +100,11 @@ export default function ChatPageClient({
       />
 
       <ChatWindowWrapper>
-        {initialThreadId && selectedThread?.listing ? (
+        {selectedThread?.listing ? (
           <ChatWindow
             user={user}
             listing={selectedThread.listing}
-            existingThread={
-              selectedThread
-                ? {
-                    ...selectedThread,
-                    chat_messages: selectedThread.chat_messages_with_senders,
-                  }
-                : null
-            }
+            existingThread={selectedThread}
           />
         ) : (
           <ChatWindowEmptyState>

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -1,24 +1,31 @@
 "use client";
-import { theme } from "@/styles/theme.yak";
 
-import { useState, useEffect, memo, useMemo } from "react";
+import { theme } from "@/styles/theme.yak";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 
 import { createClient } from "@/utils/supabase/client";
-
 import ChatMessage from "@/components/ChatMessage";
 import ChatComposer from "@/components/ChatComposer";
 import ChatHeader from "@/components/ChatHeader";
-
+import {
+  ensureChatThread,
+  getThreadMessages,
+  markChatThreadRead,
+  sendChatMessage,
+} from "@/components/ChatWindow/chatWindowController";
 import { formatWeekday } from "@/utils/dateUtils";
 
 import { styled } from "next-yak";
 import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
+import { useInlineMutation } from "@/hooks/useInlineMutation";
 import { useTranslations } from "next-intl";
 import type {
   ChatListing,
   ChatMessageRecord,
+  ChatSendResult,
   ChatThreadRecord,
+  ChatThreadView,
 } from "@/types/chat";
 import type { DemoListing } from "@/types/listing";
 
@@ -26,7 +33,7 @@ type ChatWindowProps = {
   isDrawer?: boolean;
   user: User | null;
   listing: ChatListing | DemoListing;
-  existingThread?: ChatThreadRecord | null;
+  existingThread?: ChatThreadRecord | ChatThreadView | null;
   isDemo?: boolean;
 };
 
@@ -37,6 +44,7 @@ const StyledChatWindow = styled.div`
   flex-direction: column;
   overflow: hidden;
   background-color: ${theme.colors.background.top};
+
   @media (min-width: 768px) {
     border-radius: ${theme.corners.base};
     border: 1px solid ${theme.colors.border.base};
@@ -59,6 +67,7 @@ const EmptyState = styled.div`
   align-items: center;
   justify-content: center;
   height: 100%;
+
   & p {
     color: ${theme.colors.text.ui.emptyState};
     font-size: 1.2rem;
@@ -79,22 +88,24 @@ const DayHeader = styled.header`
   flex-direction: column;
   gap: 0.375rem;
   align-items: stretch;
+
   & h3,
   & p {
     text-align: center;
     line-height: 100%;
     font-size: 0.75rem;
   }
+
   & h3 {
     font-weight: 500;
     color: ${theme.colors.text.ui.primary};
   }
+
   & p {
     color: ${theme.colors.text.ui.quaternary};
   }
 `;
 
-// Memoize the ChatWindow component
 const ChatWindow = memo(function ChatWindow({
   isDrawer = false,
   user,
@@ -103,251 +114,192 @@ const ChatWindow = memo(function ChatWindow({
   isDemo = false,
 }: ChatWindowProps) {
   const t = useTranslations();
-  // const router = useRouter();
-  // Move Supabase client creation outside of render
   const supabase = useMemo(() => (isDemo ? null : createClient()), [isDemo]);
   const { setUnreadCount, markThreadAsRead } = useUnreadMessages();
   const realListing = isDemo ? null : (listing as ChatListing);
+  const sendMutation = useInlineMutation<ChatSendResult>();
+  const lastReadSignatureRef = useRef<string | null>(null);
 
   const [message, setMessage] = useState("");
   const [threadId, setThreadId] = useState<string | null>(
-    existingThread?.id || null
+    existingThread?.id ?? null
   );
-  const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
-  const [messageSendError, setMessageSendError] = useState<string | null>(null);
-  const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [messages, setMessages] = useState<ChatMessageRecord[]>(
+    getThreadMessages(existingThread)
+  );
 
-  function handleChatSendError(error: unknown) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Something went wrong.";
+  function resolveChatErrorMessage(errorMessage: string | null) {
+    if (!errorMessage) {
+      return null;
+    }
 
-    // Turn the rate limiting message into something more friendly (original: new row violates row-level security policy for table "chat_messages")
     if (errorMessage.includes("violates row-level security policy")) {
       if (
         errorMessage.includes("chat_threads") ||
         errorMessage.includes('"chat_threads"')
       ) {
-        setMessageSendError(t("Errors.tooManyThreads"));
-      } else {
-        setMessageSendError(t("Errors.tooManyMessages"));
+        return t("Errors.tooManyThreads");
       }
-    } else {
-      setMessageSendError(errorMessage);
+
+      return t("Errors.tooManyMessages");
     }
+
+    return errorMessage;
   }
 
-  // Update messages when existingThread changes
-  // TODO: The if statement seems repetitive, what's the difference between the two?
   useEffect(() => {
-    if (existingThread?.chat_messages_with_senders) {
-      setMessages(existingThread.chat_messages_with_senders);
-    } else if (existingThread?.chat_messages) {
-      setMessages(existingThread.chat_messages);
-    }
+    setThreadId(existingThread?.id ?? null);
+    setMessages(getThreadMessages(existingThread));
+    lastReadSignatureRef.current = null;
   }, [existingThread]);
 
-  // Mark messages as read when thread is viewed
   useEffect(() => {
-    if (isDemo || !supabase || !existingThread?.id || !user) return;
+    if (isDemo || !supabase || !threadId || !user?.id) {
+      return;
+    }
 
-    const markMessagesAsRead = async () => {
-      try {
-        console.log(
-          "Checking for unread messages in thread:",
-          existingThread.id
-        );
+    const unreadMessageIds = messages
+      .filter(
+        (chatMessage) =>
+          chatMessage.sender_id !== user.id && !chatMessage.read_at
+      )
+      .map((chatMessage) => chatMessage.id);
 
-        const { data: unreadMessages, error: countError } = await supabase
-          .from("chat_messages")
-          .select("id")
-          .eq("thread_id", existingThread.id)
-          .neq("sender_id", user.id)
-          .is("read_at", null);
+    if (unreadMessageIds.length === 0) {
+      markThreadAsRead(threadId);
+      lastReadSignatureRef.current = null;
+      return;
+    }
 
-        if (countError) {
-          console.error("Error getting unread count:", countError);
-          return;
-        }
+    const nextSignature = `${threadId}:${unreadMessageIds.join(",")}`;
+    if (lastReadSignatureRef.current === nextSignature) {
+      return;
+    }
 
-        const unreadCount = unreadMessages?.length || 0;
-        console.log("Unread messages found:", unreadCount);
-        if (unreadCount === 0) return;
+    lastReadSignatureRef.current = nextSignature;
+    let isActive = true;
 
-        // Mark messages as read in database
-        const { error } = await supabase
-          .from("chat_messages")
-          .update({ read_at: new Date().toISOString() })
-          .eq("thread_id", existingThread.id)
-          .neq("sender_id", user.id)
-          .is("read_at", null);
+    void (async () => {
+      const result = await markChatThreadRead({
+        messages,
+        supabase,
+        threadId,
+        userId: user.id,
+      });
 
-        if (error) {
-          console.error("Error marking messages as read:", error);
-          return;
-        }
-
-        // Update the messages state
-        setMessages((prevMessages: ChatMessageRecord[]) =>
-          prevMessages.map((msg) =>
-            msg.sender_id !== user.id
-              ? { ...msg, read_at: new Date().toISOString() }
-              : msg
-          )
-        );
-
-        // Update global unread count AND mark thread as read
-        setUnreadCount((prevCount: number) =>
-          Math.max(0, prevCount - unreadCount)
-        );
-        markThreadAsRead(existingThread.id);
-
-        console.log("Messages marked as read, new unread count:", unreadCount);
-      } catch (error) {
-        console.error("Error in markMessagesAsRead:", error);
+      if (!isActive) {
+        return;
       }
-    };
 
-    markMessagesAsRead();
+      if (!result.success || !result.data) {
+        lastReadSignatureRef.current = null;
+        return;
+      }
+
+      const { readAt, readMessageIds } = result.data;
+
+      setMessages((previousMessages) =>
+        previousMessages.map((chatMessage) =>
+          readMessageIds.includes(chatMessage.id)
+            ? { ...chatMessage, read_at: readAt }
+            : chatMessage
+        )
+      );
+      setUnreadCount((previousCount: number) =>
+        Math.max(0, previousCount - readMessageIds.length)
+      );
+      markThreadAsRead(threadId);
+    })();
+
+    return () => {
+      isActive = false;
+    };
   }, [
-    existingThread?.id,
-    user,
-    supabase,
-    setUnreadCount,
     isDemo,
     markThreadAsRead,
+    messages,
+    setUnreadCount,
+    supabase,
+    threadId,
+    user?.id,
   ]);
 
-  async function initializeChat() {
-    if (isDemo || !supabase || !user?.id) return null;
-
-    if (!realListing?.id || !realListing.owner_id) {
-      return null;
-    }
-
-    try {
-      const { data: thread, error } = await supabase
-        .from("chat_threads")
-        .select("id")
-        .match({
-          listing_id: realListing.id,
-          initiator_id: user.id,
-          owner_id: realListing.owner_id,
-        })
-        .maybeSingle();
-
-      if (error) {
-        handleChatSendError(error);
-        return;
-      }
-
-      if (thread) {
-        setThreadId(thread.id);
-        await loadMessages(thread.id);
-        return thread;
-      }
-
-      const { data: newThread, error: createError } = await supabase
-        .from("chat_threads")
-        .upsert(
-          {
-            listing_id: realListing.id,
-            initiator_id: user.id,
-            owner_id: realListing.owner_id,
-          },
-          {
-            onConflict: "listing_id,initiator_id,owner_id",
-            ignoreDuplicates: true,
-          }
-        )
-        .select()
-        .maybeSingle();
-
-      if (createError) {
-        handleChatSendError(createError);
-        return;
-      }
-
-      if (!newThread?.id) return null;
-
-      setThreadId(newThread.id);
-      return newThread;
-    } catch (error) {
-      handleChatSendError(error);
-      return null;
-    }
-  }
-
-  async function loadMessages(threadId: string) {
-    if (isDemo || !supabase) return;
-
-    const { data: messages, error } = await supabase
-      .from("chat_messages_with_senders")
-      .select()
-      .eq("thread_id", threadId)
-      .order("created_at", { ascending: true });
-
-    if (error) {
-      handleChatSendError(error);
-      return;
-    }
-    setMessages(messages || []);
-  }
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setMessageSendError(null);
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
 
     const messageToSend = message.trim();
-    if (!messageToSend || isSendingMessage) return;
-
-    setIsSendingMessage(true);
-    try {
-      if (threadId) {
-        await sendMessage(threadId, messageToSend);
-        return;
-      }
-
-      const thread = await initializeChat();
-      if (thread?.id) {
-        await sendMessage(thread.id, messageToSend);
-      }
-    } catch (error) {
-      handleChatSendError(error);
-      return;
-    } finally {
-      setIsSendingMessage(false);
-    }
-  }
-
-  async function sendMessage(threadId: string, content: string) {
-    if (isDemo || !supabase || !user?.id) return;
-
-    const { error } = await supabase
-      .from("chat_messages")
-      .insert({
-        thread_id: threadId,
-        sender_id: user.id,
-        content,
-      })
-      .select();
-
-    if (error) {
-      handleChatSendError(error);
+    if (!messageToSend || sendMutation.isPending) {
       return;
     }
 
-    // Message sent, clear message and reload messages
-    setMessage("");
-    await loadMessages(threadId);
+    const result = await sendMutation.run(
+      async () => {
+        if (isDemo || !supabase || !user?.id) {
+          return {
+            success: false,
+            error: t("Errors.genericLater"),
+          };
+        }
+
+        let nextThreadId = threadId;
+
+        if (!nextThreadId) {
+          if (!realListing) {
+            return {
+              success: false,
+              error: t("Errors.genericLater"),
+            };
+          }
+
+          const threadResult = await ensureChatThread({
+            listing: realListing,
+            supabase,
+            userId: user.id,
+          });
+
+          if (!threadResult.success || !threadResult.data) {
+            return {
+              success: false,
+              error: threadResult.error,
+            };
+          }
+
+          nextThreadId = threadResult.data.threadId;
+          setThreadId(nextThreadId);
+          setMessages(threadResult.data.messages);
+        }
+
+        return sendChatMessage({
+          content: messageToSend,
+          supabase,
+          threadId: nextThreadId,
+          userId: user.id,
+        });
+      },
+      {
+        fallbackError: t("Errors.genericLater"),
+      }
+    );
+
+    if (result?.success && result.data) {
+      const { message: sentMessage, threadId: sentThreadId } = result.data;
+      setThreadId(sentThreadId);
+      setMessages((previousMessages) => [...previousMessages, sentMessage]);
+      setMessage("");
+    }
   }
 
-  // Optimize the textarea onChange handler
-  const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMessage(e.target.value);
+  const handleMessageChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    if (sendMutation.result.error) {
+      sendMutation.reset();
+    }
+
+    setMessage(event.target.value);
   };
 
   const directionsForDemo = ["sent", "received"] as const;
-
   const role = isDemo
     ? "initiator"
     : existingThread
@@ -355,7 +307,6 @@ const ChatWindow = memo(function ChatWindow({
         ? "initiator"
         : "owner"
       : "initiator";
-
   const otherPersonName =
     role === "initiator"
       ? (listing.owner_first_name ?? "")
@@ -377,54 +328,52 @@ const ChatWindow = memo(function ChatWindow({
             <p>{t("Chat.empty")}</p>
           </EmptyState>
         )}
-        {messages.length > 0 &&
-          messages.map((message, index) => {
-            // Check if this message is the first of its day
-            const showDateHeader =
-              index === 0 ||
-              new Date(message.created_at).toDateString() !==
-                new Date(messages[index - 1].created_at).toDateString();
 
-            // Check if this is the first message at all
-            const showInitiationHeader = index === 0;
+        {messages.map((chatMessage, index) => {
+          const showDateHeader =
+            index === 0 ||
+            new Date(chatMessage.created_at).toDateString() !==
+              new Date(messages[index - 1].created_at).toDateString();
+          const showInitiationHeader = index === 0;
 
-            return (
-              <Day key={isDemo ? index : message.id}>
-                {showDateHeader || showInitiationHeader ? (
-                  <DayHeader>
-                    {showDateHeader && (
-                      <h3>{formatWeekday(message.created_at)}</h3>
-                    )}
-                    {showInitiationHeader && (
-                      <p>
-                        {isDemo || message.sender_id === user?.id
-                          ? t("Chat.youReachedOut", { name: otherPersonName })
-                          : realListing?.owner_has_multiple_non_residential_listings &&
-                              realListing.name
-                            ? t("Chat.personReachedOutAbout", {
-                                name: otherPersonName,
-                                listing: realListing.name,
-                              })
-                            : t("Chat.personReachedOut", {
-                                name: otherPersonName,
-                              })}
-                      </p>
-                    )}
-                  </DayHeader>
-                ) : null}
-                <ChatMessage
-                  direction={
-                    isDemo
-                      ? directionsForDemo[index % 2]
-                      : message.sender_id === user?.id
-                        ? "sent"
-                        : "received"
-                  }
-                  message={message}
-                />
-              </Day>
-            );
-          })}
+          return (
+            <Day key={isDemo ? index : chatMessage.id}>
+              {showDateHeader || showInitiationHeader ? (
+                <DayHeader>
+                  {showDateHeader && (
+                    <h3>{formatWeekday(chatMessage.created_at)}</h3>
+                  )}
+                  {showInitiationHeader && (
+                    <p>
+                      {isDemo || chatMessage.sender_id === user?.id
+                        ? t("Chat.youReachedOut", { name: otherPersonName })
+                        : realListing?.owner_has_multiple_non_residential_listings &&
+                            realListing.name
+                          ? t("Chat.personReachedOutAbout", {
+                              name: otherPersonName,
+                              listing: realListing.name,
+                            })
+                          : t("Chat.personReachedOut", {
+                              name: otherPersonName,
+                            })}
+                    </p>
+                  )}
+                </DayHeader>
+              ) : null}
+
+              <ChatMessage
+                direction={
+                  isDemo
+                    ? directionsForDemo[index % 2]
+                    : chatMessage.sender_id === user?.id
+                      ? "sent"
+                      : "received"
+                }
+                message={chatMessage}
+              />
+            </Day>
+          );
+        })}
       </StyledMessagesContainer>
 
       <ChatComposer
@@ -432,9 +381,9 @@ const ChatWindow = memo(function ChatWindow({
         message={message}
         handleMessageChange={handleMessageChange}
         recipientName={otherPersonName}
-        error={messageSendError}
+        error={resolveChatErrorMessage(sendMutation.result.error)}
         isDemo={isDemo}
-        isSending={isSendingMessage}
+        isSending={sendMutation.isPending}
       />
     </StyledChatWindow>
   );

--- a/src/components/ChatWindow/chatWindowController.ts
+++ b/src/components/ChatWindow/chatWindowController.ts
@@ -11,11 +11,13 @@ type BrowserSupabaseClient = ReturnType<typeof createClient>;
 
 export function getThreadMessages(
   existingThread?: {
+    messages?: ChatMessageRecord[] | null;
     chat_messages?: ChatMessageRecord[] | null;
     chat_messages_with_senders?: ChatMessageRecord[] | null;
   } | null
 ) {
   return (
+    existingThread?.messages ??
     existingThread?.chat_messages_with_senders ??
     existingThread?.chat_messages ??
     []
@@ -120,24 +122,46 @@ export async function ensureChatThread({
       },
       {
         onConflict: "listing_id,initiator_id,owner_id",
-        ignoreDuplicates: true,
       }
     )
     .select("id")
     .maybeSingle();
 
-  if (createError || !newThread?.id) {
+  if (createError) {
     return {
       success: false,
-      error: createError?.message ?? "Unable to create chat thread.",
+      error: createError.message,
     };
+  }
+
+  let threadId = newThread?.id ?? null;
+
+  if (!threadId) {
+    const { data: existingThread, error: existingThreadError } = await supabase
+      .from("chat_threads")
+      .select("id")
+      .match({
+        listing_id: listing.id,
+        initiator_id: userId,
+        owner_id: listing.owner_id,
+      })
+      .maybeSingle();
+
+    if (existingThreadError || !existingThread?.id) {
+      return {
+        success: false,
+        error: existingThreadError?.message ?? "Unable to create chat thread.",
+      };
+    }
+
+    threadId = existingThread.id;
   }
 
   return {
     success: true,
     error: null,
     data: {
-      threadId: newThread.id,
+      threadId,
       messages: [],
     },
   };

--- a/src/components/ChatWindow/chatWindowController.ts
+++ b/src/components/ChatWindow/chatWindowController.ts
@@ -1,0 +1,233 @@
+import { createClient } from "@/utils/supabase/client";
+import type { InlineActionResult } from "@/types/actionResult";
+import type {
+  ChatListing,
+  ChatMessageRecord,
+  ChatReadResult,
+  ChatSendResult,
+} from "@/types/chat";
+
+type BrowserSupabaseClient = ReturnType<typeof createClient>;
+
+export function getThreadMessages(
+  existingThread?: {
+    chat_messages?: ChatMessageRecord[] | null;
+    chat_messages_with_senders?: ChatMessageRecord[] | null;
+  } | null
+) {
+  return (
+    existingThread?.chat_messages_with_senders ??
+    existingThread?.chat_messages ??
+    []
+  );
+}
+
+export async function loadThreadMessages({
+  supabase,
+  threadId,
+}: {
+  supabase: BrowserSupabaseClient;
+  threadId: string;
+}): Promise<InlineActionResult<ChatMessageRecord[]>> {
+  const { data, error } = await supabase
+    .from("chat_messages_with_senders")
+    .select()
+    .eq("thread_id", threadId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+
+  return {
+    success: true,
+    error: null,
+    data: data ?? [],
+  };
+}
+
+export async function ensureChatThread({
+  listing,
+  supabase,
+  userId,
+}: {
+  listing: ChatListing;
+  supabase: BrowserSupabaseClient;
+  userId: string;
+}): Promise<
+  InlineActionResult<{
+    messages: ChatMessageRecord[];
+    threadId: string;
+  }>
+> {
+  if (!listing.id || !listing.owner_id) {
+    return {
+      success: false,
+      error: "Missing listing details for chat.",
+    };
+  }
+
+  const { data: thread, error } = await supabase
+    .from("chat_threads")
+    .select("id")
+    .match({
+      listing_id: listing.id,
+      initiator_id: userId,
+      owner_id: listing.owner_id,
+    })
+    .maybeSingle();
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+
+  if (thread?.id) {
+    const messagesResult = await loadThreadMessages({
+      supabase,
+      threadId: thread.id,
+    });
+
+    if (!messagesResult.success) {
+      return {
+        success: false,
+        error: messagesResult.error,
+      };
+    }
+
+    return {
+      success: true,
+      error: null,
+      data: {
+        threadId: thread.id,
+        messages: messagesResult.data ?? [],
+      },
+    };
+  }
+
+  const { data: newThread, error: createError } = await supabase
+    .from("chat_threads")
+    .upsert(
+      {
+        listing_id: listing.id,
+        initiator_id: userId,
+        owner_id: listing.owner_id,
+      },
+      {
+        onConflict: "listing_id,initiator_id,owner_id",
+        ignoreDuplicates: true,
+      }
+    )
+    .select("id")
+    .maybeSingle();
+
+  if (createError || !newThread?.id) {
+    return {
+      success: false,
+      error: createError?.message ?? "Unable to create chat thread.",
+    };
+  }
+
+  return {
+    success: true,
+    error: null,
+    data: {
+      threadId: newThread.id,
+      messages: [],
+    },
+  };
+}
+
+export async function sendChatMessage({
+  content,
+  supabase,
+  threadId,
+  userId,
+}: {
+  content: string;
+  supabase: BrowserSupabaseClient;
+  threadId: string;
+  userId: string;
+}): Promise<InlineActionResult<ChatSendResult>> {
+  const { data, error } = await supabase
+    .from("chat_messages")
+    .insert({
+      thread_id: threadId,
+      sender_id: userId,
+      content,
+    })
+    .select("id, content, created_at, read_at, sender_id, thread_id")
+    .single();
+
+  if (error || !data) {
+    return {
+      success: false,
+      error: error?.message ?? "Unable to send message.",
+    };
+  }
+
+  return {
+    success: true,
+    error: null,
+    data: {
+      threadId,
+      message: data,
+    },
+  };
+}
+
+export async function markChatThreadRead({
+  messages,
+  supabase,
+  threadId,
+  userId,
+}: {
+  messages: ChatMessageRecord[];
+  supabase: BrowserSupabaseClient;
+  threadId: string;
+  userId: string;
+}): Promise<InlineActionResult<ChatReadResult>> {
+  const unreadMessageIds = messages
+    .filter((message) => message.sender_id !== userId && !message.read_at)
+    .map((message) => message.id);
+
+  if (unreadMessageIds.length === 0) {
+    return {
+      success: true,
+      error: null,
+      data: {
+        threadId,
+        readAt: "",
+        readMessageIds: [],
+      },
+    };
+  }
+
+  const readAt = new Date().toISOString();
+  const { error } = await supabase
+    .from("chat_messages")
+    .update({ read_at: readAt })
+    .in("id", unreadMessageIds);
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+
+  return {
+    success: true,
+    error: null,
+    data: {
+      threadId,
+      readAt,
+      readMessageIds: unreadMessageIds,
+    },
+  };
+}

--- a/src/components/ChatWindow/chatWindowController.ts
+++ b/src/components/ChatWindow/chatWindowController.ts
@@ -121,6 +121,7 @@ export async function ensureChatThread({
         owner_id: listing.owner_id,
       },
       {
+        ignoreDuplicates: true,
         onConflict: "listing_id,initiator_id,owner_id",
       }
     )

--- a/src/components/FormMessage/FormMessage.tsx
+++ b/src/components/FormMessage/FormMessage.tsx
@@ -6,12 +6,22 @@ const successMessageStyles = css`
   text-align: center;
 `;
 
+const errorMessageStyles = css`
+  background: ${theme.colors.background.error};
+  color: ${theme.colors.button.danger.text};
+`;
+
 const StyledFormMessage = styled.aside<{ $variant?: "error" | "success" }>`
   width: 100%;
   padding: 1.5rem 2rem;
   border-radius: ${theme.corners.base};
   background: ${theme.colors.background.pit};
 
+  p {
+    margin: 0;
+  }
+
+  ${({ $variant }) => $variant === "error" && errorMessageStyles}
   ${({ $variant }) => $variant === "success" && successMessageStyles}
 `;
 

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -47,6 +47,7 @@ import {
 import type {
   DeleteListingResult,
   Listing,
+  ListingSubmitFailureData,
   ListingSubmitResult,
   ListingType,
   ListingWriteFieldErrors,
@@ -107,7 +108,9 @@ export default function ListingWrite({
   const [isHydrated, setIsHydrated] = useState(false);
   const listingType =
     initialListing?.type || initialListingType || "residential";
-  const submitMutation = useInlineMutation<ListingSubmitResult>();
+  const submitMutation = useInlineMutation<
+    ListingSubmitResult | ListingSubmitFailureData
+  >();
   const deleteMutation = useInlineMutation<DeleteListingResult>();
 
   useEffect(() => {
@@ -183,7 +186,12 @@ export default function ListingWrite({
       }
     );
 
-    if (result?.success && result.data?.redirectTo) {
+    if (
+      result?.success &&
+      result.data &&
+      "redirectTo" in result.data &&
+      result.data.redirectTo
+    ) {
       router.push(result.data.redirectTo);
     }
   }
@@ -251,13 +259,23 @@ export default function ListingWrite({
           listingType,
           profile,
           validatedName: validation.validatedName,
+          t,
         }),
       {
         fallbackError: t("Errors.unexpected"),
       }
     );
 
-    if (result?.success && result.data?.redirectTo) {
+    if (!result?.success && result?.data && "errors" in result.data) {
+      setErrors(result.data.errors);
+    }
+
+    if (
+      result?.success &&
+      result.data &&
+      "redirectTo" in result.data &&
+      typeof result.data.redirectTo === "string"
+    ) {
       router.push(result.data.redirectTo);
     }
   }

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -1,13 +1,16 @@
 "use client";
+
 import { theme } from "@/styles/theme.yak";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { validateName, FIELD_CONFIGS } from "@/lib/formValidation";
 import {
-  updateFirstNameAction,
-  deleteListingAction,
-  createOrUpdateListingAction,
-} from "@/app/actions";
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type ComponentType,
+  type FormEvent,
+  type InputHTMLAttributes,
+} from "react";
+import { useRouter } from "next/navigation";
+import { FIELD_CONFIGS } from "@/lib/formValidation";
 import LocationSelect from "@/components/LocationSelect";
 import CheckboxCluster from "@/components/CheckboxCluster";
 import LegalAgreement from "@/components/LegalAgreement";
@@ -28,10 +31,27 @@ import InputHint from "@/components/InputHint";
 import Fieldset from "@/components/Fieldset";
 import Lozenge from "@/components/Lozenge";
 import FormMessage from "@/components/FormMessage";
+import SubmitButton from "@/components/SubmitButton";
 import { styled } from "next-yak";
 import { useTranslations } from "next-intl";
 import type { User } from "@supabase/supabase-js";
-import type { Listing, ListingType } from "@/types/listing";
+import { useInlineMutation } from "@/hooks/useInlineMutation";
+import {
+  buildListingDraft,
+  submitListingDelete,
+  submitListingWrite,
+  type ListingWriteFormValues,
+  type LocationSelectProps,
+  validateListingWriteForm,
+} from "@/components/ListingWrite/listingWriteController";
+import type {
+  DeleteListingResult,
+  Listing,
+  ListingSubmitResult,
+  ListingType,
+  ListingWriteFieldErrors,
+  ListingWriteProfile,
+} from "@/types/listing";
 
 const DESCRIPTION_MAX_CHARACTERS = 640;
 
@@ -50,29 +70,24 @@ const AdditionalSettings = styled.footer`
   gap: calc(${theme.spacing.unit} * 1.5);
 `;
 
-const AvatarUploadManagerComponent =
-  AvatarUploadManager as React.ComponentType<any>;
-const InputComponent = Input as React.ComponentType<any>;
-const InputHintComponent = InputHint as React.ComponentType<any>;
-const ListingPhotosManagerComponent =
-  ListingPhotosManager as React.ComponentType<any>;
-const LocationSelectComponent = LocationSelect as React.ComponentType<any>;
-const MultiInputComponent = MultiInput as React.ComponentType<any>;
-const SelectComponent = Select as React.ComponentType<any>;
-const TextareaComponent = Textarea as React.ComponentType<any>;
+const DisabledFieldset = styled.fieldset`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  min-width: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+`;
 
-type Coordinates = {
-  latitude: number;
-  longitude: number;
-};
-
-type ListingErrors = Partial<Record<"name" | "location", string>>;
-
-type ListingWriteProfile = {
-  first_name?: string | null;
-  avatar?: string | null;
-  is_admin?: boolean | null;
-};
+const LocationSelectComponent =
+  LocationSelect as ComponentType<LocationSelectProps>;
+const InputComponent = Input as ComponentType<
+  InputHTMLAttributes<HTMLInputElement> & {
+    error?: string | null;
+  }
+>;
 
 type ListingWriteProps = {
   initialListing?: Listing | null;
@@ -81,7 +96,6 @@ type ListingWriteProps = {
   profile: ListingWriteProfile | null;
 };
 
-// Component
 export default function ListingWrite({
   initialListing,
   listingType: initialListingType,
@@ -91,596 +105,521 @@ export default function ListingWrite({
   const t = useTranslations();
   const router = useRouter();
   const [isHydrated, setIsHydrated] = useState(false);
-
   const listingType =
     initialListing?.type || initialListingType || "residential";
+  const submitMutation = useInlineMutation<ListingSubmitResult>();
+  const deleteMutation = useInlineMutation<DeleteListingResult>();
 
   useEffect(() => {
     setIsHydrated(true);
   }, []);
 
-  // Update error state to handle both field and global errors
-  const [errors, setErrors] = useState<ListingErrors>({});
-  const [globalError, setGlobalError] = useState("");
-
-  // Handle form submission state
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  // Populate editable fields
+  const [errors, setErrors] = useState<ListingWriteFieldErrors>({});
   const [avatar, setAvatar] = useState<string>(
     initialListing ? initialListing.avatar || "" : ""
   );
   const [name, setName] = useState<string>(
     listingType === "residential"
-      ? profile?.first_name || "" // Use profile.first_name for residential listings
-      : initialListing
-        ? initialListing.name || ""
-        : "" // Use listing name for others
+      ? profile?.first_name || ""
+      : initialListing?.name || ""
   );
-
   const [description, setDescription] = useState<string>(
-    initialListing ? initialListing.description || "" : ""
+    initialListing?.description || ""
   );
-
   const [countryCode, setCountryCode] = useState<string>(
-    initialListing ? initialListing.country_code || "" : ""
+    initialListing?.country_code || ""
   );
-
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(
+  const [coordinates, setCoordinates] = useState(
     initialListing?.coordinates ?? null
   );
-
   const [areaName, setAreaName] = useState<string>(
-    initialListing ? initialListing.area_name || "" : ""
+    initialListing?.area_name || ""
   );
-
   const [acceptedItems, setAcceptedItems] = useState<string[]>(
-    initialListing ? initialListing.accepted_items || [""] : [""]
+    initialListing?.accepted_items || [""]
   );
   const [rejectedItems, setRejectedItems] = useState<string[]>(
-    initialListing ? initialListing.rejected_items || [] : []
+    initialListing?.rejected_items || []
   );
-  const [donatedItems, setDonatedItems] = useState<string[]>(
-    initialListing ? initialListing.donated_items || [""] : [""]
-  );
-
-  const [photos, setPhotos] = useState<string[]>(
-    initialListing ? initialListing.photos || [] : []
-  );
-  const [links, setLinks] = useState<string[]>(
-    initialListing ? initialListing.links || [] : []
-  );
+  const [photos, setPhotos] = useState<string[]>(initialListing?.photos || []);
+  const [links, setLinks] = useState<string[]>(initialListing?.links || []);
   const [visibility, setVisibility] = useState<boolean>(
     initialListing?.visibility ?? true
   );
-
   const [isStub, setIsStub] = useState<boolean>(
     initialListing?.is_stub ?? false
   );
-
-  // Other states
-  const [feedbackMessage, setFeedbackMessage] = useState("");
   const [pendingPhotos, setPendingPhotos] = useState<string[]>([]);
 
-  async function handleDeleteListing(event: React.FormEvent<HTMLFormElement>) {
+  const isMutating = submitMutation.isPending || deleteMutation.isPending;
+  const errorCount = Object.keys(errors).length;
+  const feedbackError =
+    deleteMutation.result.error || submitMutation.result.error;
+  const feedbackMessage =
+    feedbackError ||
+    (errorCount > 0
+      ? t("Errors.validationSummary", {
+          count: errorCount,
+        })
+      : null);
+
+  async function handleDeleteListing(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (!initialListing) {
+    if (!initialListing || isMutating) {
       return;
     }
 
-    setFeedbackMessage("");
-    try {
-      const response = await deleteListingAction(initialListing.slug);
-      if (response.success) {
-        router.push(`/profile/?message=${response.message}`);
-      } else {
-        setFeedbackMessage(response.message);
-      }
-    } catch (error) {
-      console.error("Error deleting listing:", error);
-      setFeedbackMessage(t("Errors.generic"));
-    }
-  }
-
-  // Form handling logic here
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    if (isSubmitting) return;
-
-    // Reset all errors
     setErrors({});
-    setGlobalError("");
+    submitMutation.reset();
 
-    // Validate required fields
-    const nextErrors: ListingErrors = {};
-    let validatedName = name; // Store the validated name
-
-    if (listingType === "residential") {
-      // Only validate and update first name if it was changed
-      if (name !== profile?.first_name) {
-        const validation = validateName(name);
-        if (!validation.isValid) {
-          nextErrors.name = validation.error;
-        } else {
-          validatedName = validation.value ?? ""; // Store the trimmed value
-        }
+    const result = await deleteMutation.run(
+      () =>
+        submitListingDelete({
+          slug: initialListing.slug,
+        }),
+      {
+        fallbackError: t("Errors.generic"),
       }
-    } else {
-      // For business/community listings, validate the name field
-      const validation = validateName(name);
-      if (!validation.isValid) {
-        nextErrors.name = t("Errors.emptyListingName", { type: listingType });
-      } else {
-        validatedName = validation.value ?? ""; // Store the trimmed value
-      }
-    }
+    );
 
-    const selectedCoordinates = coordinates;
-
-    if (!selectedCoordinates) {
-      nextErrors.location = t("Errors.missingLocation");
-    }
-
-    if (Object.keys(nextErrors).length > 0) {
-      setErrors(nextErrors);
-      console.log("Validation errors:", nextErrors);
-      return;
-    }
-
-    if (!selectedCoordinates) return;
-
-    setIsSubmitting(true);
-    let shouldResetSubmitting = true;
-
-    try {
-      // For residential listings, update the profile first name if changed
-      if (
-        listingType === "residential" &&
-        profile?.first_name !== validatedName
-      ) {
-        console.log(
-          "Updating first name from",
-          profile?.first_name,
-          "to",
-          validatedName
-        );
-        const formData = new FormData();
-        formData.append("first_name", validatedName);
-        const result = await updateFirstNameAction(formData);
-        if (result?.error) {
-          setErrors({ name: String(result.error) });
-          return;
-        }
-      }
-
-      if (!user?.id) {
-        setGlobalError(t("Errors.generic"));
-        return;
-      }
-
-      // Prepare the listing data
-      const listingData = {
-        // Add the id if it's an existing listing, so we know which to update
-        ...(initialListing && { id: initialListing.id }),
-        owner_id: user.id,
-        type: listingType,
-        ...(listingType !== "residential" && avatar && { avatar }),
-        // Only include name for non-residential listings
-        ...(listingType !== "residential" && { name: validatedName }),
-        description,
-        location: `POINT(${selectedCoordinates.longitude} ${selectedCoordinates.latitude})`,
-        area_name: areaName,
-        country_code: countryCode,
-        accepted_items: acceptedItems.filter((item) => item.trim() !== ""),
-        rejected_items: rejectedItems.filter((item) => item.trim() !== ""),
-        photos: initialListing ? photos : pendingPhotos,
-        links: links.filter((link) => link.trim() !== ""),
-        // Only include is_stub if the user is an admin
-        ...(profile?.is_admin && { is_stub: isStub }),
-        visibility,
-      };
-
-      console.log("Submitting listing data:", listingData);
-
-      const { data, error } = await createOrUpdateListingAction(listingData);
-
-      if (error) {
-        setGlobalError(String(error));
-        return;
-      }
-
-      if (!data?.slug) {
-        setGlobalError(t("Errors.genericLater"));
-        return;
-      }
-
-      // Redirect to the new/updated listing
-      shouldResetSubmitting = false;
-      router.push(
-        `/listings/${data.slug}?status=${initialListing ? "updated" : "created"}`
-      );
-    } catch (error) {
-      console.error("Error in handleSubmit:", error);
-      setGlobalError(t("Errors.unexpected"));
-    } finally {
-      if (shouldResetSubmitting) {
-        setIsSubmitting(false);
-      }
+    if (result?.success && result.data?.redirectTo) {
+      router.push(result.data.redirectTo);
     }
   }
 
-  //   Functions for adding and removing items
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isMutating) {
+      return;
+    }
+
+    setErrors({});
+    deleteMutation.reset();
+
+    const validation = validateListingWriteForm({
+      coordinates,
+      listingType,
+      name,
+      profile,
+      t,
+    });
+
+    if (Object.keys(validation.errors).length > 0) {
+      setErrors(validation.errors);
+      return;
+    }
+
+    if (!user?.id) {
+      submitMutation.setResult({
+        success: false,
+        error: t("Errors.generic"),
+      });
+      return;
+    }
+
+    const formValues: ListingWriteFormValues = {
+      acceptedItems,
+      areaName,
+      avatar,
+      coordinates,
+      countryCode,
+      description,
+      isStub,
+      links,
+      name,
+      pendingPhotos,
+      photos,
+      rejectedItems,
+      visibility,
+    };
+    const draft = buildListingDraft({
+      initialListing,
+      listingType,
+      profile,
+      userId: user.id,
+      validatedName: validation.validatedName,
+      values: formValues,
+    });
+
+    const result = await submitMutation.run(
+      () =>
+        submitListingWrite({
+          draft,
+          fallbackError: t("Errors.genericLater"),
+          listingType,
+          profile,
+          validatedName: validation.validatedName,
+        }),
+      {
+        fallbackError: t("Errors.unexpected"),
+      }
+    );
+
+    if (result?.success && result.data?.redirectTo) {
+      router.push(result.data.redirectTo);
+    }
+  }
+
   const addAcceptedItem = () => {
-    // if (acceptedItems.length < 10) {
     setAcceptedItems([...acceptedItems, ""]);
-    // }
   };
+
   const addRejectedItem = () => {
-    // if (rejectedItems.length < 10) {
     setRejectedItems([...rejectedItems, ""]);
-    // }
   };
+
   const addLink = () => {
-    // if (links.length < 3) {
     setLinks([...links, ""]);
-    // }
   };
+
   const handleAcceptedItemChange = (index: number, value: string) => {
-    const newItems = [...acceptedItems];
-    newItems[index] = value;
-    setAcceptedItems(newItems);
+    const nextItems = [...acceptedItems];
+    nextItems[index] = value;
+    setAcceptedItems(nextItems);
   };
 
   const handleRejectedItemChange = (index: number, value: string) => {
-    const newItems = [...rejectedItems];
-    newItems[index] = value;
-    setRejectedItems(newItems);
+    const nextItems = [...rejectedItems];
+    nextItems[index] = value;
+    setRejectedItems(nextItems);
   };
 
   const handleLinksChange = (index: number, value: string) => {
-    const newLinks = [...links];
-    newLinks[index] = value;
-    setLinks(newLinks);
+    const nextLinks = [...links];
+    nextLinks[index] = value;
+    setLinks(nextLinks);
   };
 
   return (
     <>
-      {initialListing && initialListing.is_stub && (
-        <Lozenge>{t("Common.stub")}</Lozenge>
-      )}
+      {initialListing?.is_stub && <Lozenge>{t("Common.stub")}</Lozenge>}
+
       <Form
         onSubmit={handleSubmit}
         data-testid="listing-write-form"
         data-hydrated={isHydrated ? "true" : "false"}
       >
-        {listingType === "residential" ? (
-          <AvatarUploadManagerComponent
-            initialAvatar={profile?.avatar || ""}
-            bucket="avatars"
-            entityId={user?.id ?? ""}
-            onAvatarChange={setAvatar}
-            inputHintShown={profile?.avatar ? undefined : true}
-            listingType={listingType}
-          />
-        ) : (
-          <AvatarUploadManagerComponent
-            initialAvatar={avatar}
-            bucket="listing_avatars"
-            entityId={initialListing?.slug}
-            onAvatarChange={setAvatar}
-            listingType={listingType}
-          />
-        )}
-
-        <FormSection>
-          <FormSectionHeader>
-            <h2>{t("Listings.form.basics")}</h2>
-          </FormSectionHeader>
-
+        <DisabledFieldset disabled={isMutating}>
           {listingType === "residential" ? (
-            <Field>
-              <Label htmlFor="first_name">
-                {t("Listings.form.yourFirstName")}
-              </Label>
-              <InputComponent
-                id="first_name"
-                name="first_name"
-                {...FIELD_CONFIGS.firstName}
-                defaultValue={profile?.first_name ?? ""}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  setName(event.target.value)
-                }
-                error={errors.name}
-              />
-              <InputHintComponent>
-                {errors.name || t("Profile.account.firstNameHint")}
-              </InputHintComponent>
-            </Field>
+            <AvatarUploadManager
+              initialAvatar={profile?.avatar || ""}
+              bucket="avatars"
+              entityId={user?.id ?? ""}
+              onAvatarChange={setAvatar}
+              inputHintShown={profile?.avatar ? undefined : true}
+              listingType={listingType}
+            />
           ) : (
-            <Field>
-              <Label htmlFor="name">{t("Listings.form.placeName")}</Label>
-              <InputComponent
-                id="name"
-                name="name"
-                required={true}
-                type="text"
-                minLength={FIELD_CONFIGS.firstName.minLength}
-                placeholder={t("Listings.form.placeNamePlaceholder", {
-                  type: listingType,
-                })}
-                value={name}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  setName(event.target.value)
-                }
-                error={errors.name}
-              />
-              {errors.name && (
-                <InputHintComponent variant="error">
-                  {errors.name}
-                </InputHintComponent>
-              )}
-            </Field>
+            <AvatarUploadManager
+              initialAvatar={avatar}
+              bucket="listing_avatars"
+              entityId={initialListing?.slug ?? ""}
+              onAvatarChange={setAvatar}
+              listingType={listingType}
+            />
           )}
 
-          <LocationSelectComponent
-            listingType={listingType}
-            initialPlaceholderText={
-              initialListing
-                ? areaName
-                : listingType === "business"
-                  ? t("Listings.form.businessAddress")
-                  : listingType === "community"
-                    ? t("Listings.form.communityAddress")
-                    : t("Listings.form.residentialAddress")
-            }
-            coordinates={coordinates}
-            setCoordinates={setCoordinates}
-            countryCode={countryCode}
-            setCountryCode={setCountryCode}
-            areaName={areaName}
-            setAreaName={setAreaName}
-            error={errors.location}
-          />
+          <FormSection>
+            <FormSectionHeader>
+              <h2>{t("Listings.form.basics")}</h2>
+            </FormSectionHeader>
 
-          {listingType === "business" ? (
-            <Field>
-              <Label htmlFor="description">
-                {t("Listings.form.donationDetails")}
-              </Label>
-              <TextareaComponent
-                id="description"
-                rows={6}
-                maxLength={DESCRIPTION_MAX_CHARACTERS}
-                required={true}
-                resize="vertical"
-                placeholder={t("Listings.form.donationDetailsPlaceholder")}
-                value={description}
-                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setDescription(event.target.value)
-                }
+            {listingType === "residential" ? (
+              <Field>
+                <Label htmlFor="first_name">
+                  {t("Listings.form.yourFirstName")}
+                </Label>
+                <InputComponent
+                  id="first_name"
+                  name="first_name"
+                  {...FIELD_CONFIGS.firstName}
+                  value={name}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                    setName(event.target.value)
+                  }
+                  error={errors.name ?? null}
+                />
+                <InputHint variant={errors.name ? "error" : "default"}>
+                  {errors.name || t("Profile.account.firstNameHint")}
+                </InputHint>
+              </Field>
+            ) : (
+              <Field>
+                <Label htmlFor="name">{t("Listings.form.placeName")}</Label>
+                <InputComponent
+                  id="name"
+                  name="name"
+                  required={true}
+                  type="text"
+                  minLength={FIELD_CONFIGS.firstName.minLength}
+                  placeholder={t("Listings.form.placeNamePlaceholder", {
+                    type: listingType,
+                  })}
+                  value={name}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                    setName(event.target.value)
+                  }
+                  error={errors.name ?? null}
+                />
+                {errors.name && (
+                  <InputHint variant="error">{errors.name}</InputHint>
+                )}
+              </Field>
+            )}
+
+            <LocationSelectComponent
+              listingType={listingType}
+              initialPlaceholderText={
+                initialListing
+                  ? areaName
+                  : listingType === "business"
+                    ? t("Listings.form.businessAddress")
+                    : listingType === "community"
+                      ? t("Listings.form.communityAddress")
+                      : t("Listings.form.residentialAddress")
+              }
+              coordinates={coordinates}
+              setCoordinates={setCoordinates}
+              countryCode={countryCode}
+              setCountryCode={setCountryCode}
+              areaName={areaName}
+              setAreaName={setAreaName}
+              error={errors.location}
+            />
+
+            {listingType === "business" ? (
+              <Field>
+                <Label htmlFor="description">
+                  {t("Listings.form.donationDetails")}
+                </Label>
+                <Textarea
+                  id="description"
+                  rows={6}
+                  maxLength={DESCRIPTION_MAX_CHARACTERS}
+                  required={true}
+                  resize="vertical"
+                  placeholder={t("Listings.form.donationDetailsPlaceholder")}
+                  value={description}
+                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                    setDescription(event.target.value)
+                  }
+                />
+                <InputHint>{t("Listings.form.donationDetailsHint")}</InputHint>
+              </Field>
+            ) : (
+              <Field>
+                <Label
+                  htmlFor="description"
+                  required={false}
+                  optionalText={t("Common.optional")}
+                >
+                  {t("Listings.form.descriptionLabel")}
+                </Label>
+                <Textarea
+                  id="description"
+                  rows={listingType === "residential" ? 4 : 5}
+                  maxLength={DESCRIPTION_MAX_CHARACTERS}
+                  required={false}
+                  resize="vertical"
+                  placeholder={t("Listings.form.descriptionPlaceholder", {
+                    type: listingType,
+                  })}
+                  value={description}
+                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                    setDescription(event.target.value)
+                  }
+                />
+                <InputHint>
+                  {listingType === "community"
+                    ? t("Listings.form.communityDescriptionHint")
+                    : t("Listings.form.residentialDescriptionHint")}
+                </InputHint>
+              </Field>
+            )}
+          </FormSection>
+
+          {(listingType === "residential" || listingType === "community") && (
+            <FormSection>
+              <FormSectionHeader>
+                <h2>{t("Listings.form.compostingDetails")}</h2>
+                <p>{t("Listings.form.compostingDetailsHint")}</p>
+              </FormSectionHeader>
+
+              <MultiInput
+                label={t("Listings.form.acceptedLabel")}
+                addButtonText={t("Listings.form.addItem")}
+                addAnotherButtonText={t("Listings.form.addAnotherItem")}
+                optionalText={t("Common.optional")}
+                placeholder={t("Listings.form.acceptedPlaceholder")}
+                secondaryPlaceholder={t(
+                  "Listings.form.acceptedSecondaryPlaceholder"
+                )}
+                items={acceptedItems}
+                minRequired={1}
+                handleItemChange={handleAcceptedItemChange}
+                onClick={addAcceptedItem}
+                limit={12}
               />
-              <InputHintComponent>
-                {t("Listings.form.donationDetailsHint")}
-              </InputHintComponent>
-            </Field>
-          ) : (
-            <Field>
+
+              <MultiInput
+                label={t("Listings.form.rejectedLabel")}
+                addButtonText={t("Listings.form.addItem")}
+                addAnotherButtonText={t("Listings.form.addAnotherItem")}
+                optionalText={t("Common.optional")}
+                placeholder={t("Listings.form.rejectedPlaceholder")}
+                secondaryPlaceholder={t(
+                  "Listings.form.rejectedSecondaryPlaceholder"
+                )}
+                items={rejectedItems}
+                handleItemChange={handleRejectedItemChange}
+                onClick={addRejectedItem}
+                limit={16}
+              />
+            </FormSection>
+          )}
+
+          <FormSection>
+            <FormSectionHeader>
+              <h2>{t("Listings.form.media")}</h2>
+              <p>
+                {t("Listings.form.mediaHint", {
+                  subject:
+                    listingType === "residential"
+                      ? t("Listings.form.mediaResidential")
+                      : listingType === "community"
+                        ? t("Listings.form.mediaCommunity")
+                        : t("Listings.form.mediaBusiness"),
+                })}
+              </p>
+            </FormSectionHeader>
+
+            <FieldsetWithGap>
               <Label
-                htmlFor="description"
+                htmlFor="photo-upload-button"
                 required={false}
                 optionalText={t("Common.optional")}
               >
-                {t("Listings.form.descriptionLabel")}
+                {t("Common.photos")}
               </Label>
-              <TextareaComponent
-                id="description"
-                rows={listingType === "residential" ? 4 : 5}
-                maxLength={DESCRIPTION_MAX_CHARACTERS}
-                required={false}
-                resize="vertical"
-                placeholder={t("Listings.form.descriptionPlaceholder", {
-                  type: listingType,
-                })}
-                value={description}
-                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setDescription(event.target.value)
-                }
+              <ListingPhotosManager
+                initialPhotos={initialListing ? photos : pendingPhotos}
+                listingSlug={initialListing?.slug}
+                onPhotosChange={initialListing ? setPhotos : setPendingPhotos}
+                isNewListing={!initialListing}
               />
-              <InputHintComponent>
-                {listingType === "community"
-                  ? t("Listings.form.communityDescriptionHint")
-                  : t("Listings.form.residentialDescriptionHint")}
-              </InputHintComponent>
-            </Field>
+            </FieldsetWithGap>
+
+            {listingType !== "residential" && (
+              <MultiInput
+                label={t("Listings.form.externalLinks")}
+                addButtonText={t("Listings.form.addLink")}
+                optionalText={t("Common.optional")}
+                placeholder={t("Listings.form.linkPlaceholder")}
+                items={links}
+                handleItemChange={handleLinksChange}
+                onClick={addLink}
+                limit={3}
+                type="url"
+                pattern="https?://.+"
+              />
+            )}
+          </FormSection>
+
+          {initialListing && (
+            <FormSection>
+              <FormSectionHeader>
+                <h2>{t("Listings.form.visibility")}</h2>
+                <p>{t("Listings.form.visibilityHint")}</p>
+              </FormSectionHeader>
+
+              <Field>
+                <Label htmlFor="visibility">
+                  {t("Listings.form.mapVisibility")}
+                </Label>
+                <Select
+                  id="visibility"
+                  value={String(visibility)}
+                  onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                    setVisibility(event.target.value === "true")
+                  }
+                  required={true}
+                >
+                  <option value="true">{t("Listings.form.showOnMap")}</option>
+                  <option value="false">
+                    {t("Listings.form.hideFromMap")}
+                  </option>
+                </Select>
+              </Field>
+            </FormSection>
           )}
-        </FormSection>
 
-        {(listingType === "residential" || listingType === "community") && (
-          <FormSection>
-            <FormSectionHeader>
-              <h2>{t("Listings.form.compostingDetails")}</h2>
-              <p>{t("Listings.form.compostingDetailsHint")}</p>
-            </FormSectionHeader>
+          {profile?.is_admin && (
+            <FormSection>
+              <FormSectionHeader>
+                <h2>{t("Common.admin")}</h2>
+                <p>{t("Listings.form.adminHint")}</p>
+              </FormSectionHeader>
 
-            <MultiInputComponent
-              label={t("Listings.form.acceptedLabel")}
-              addButtonText={t("Listings.form.addItem")}
-              addAnotherButtonText={t("Listings.form.addAnotherItem")}
-              optionalText={t("Common.optional")}
-              placeholder={t("Listings.form.acceptedPlaceholder")}
-              secondaryPlaceholder={t(
-                "Listings.form.acceptedSecondaryPlaceholder"
-              )}
-              items={acceptedItems}
-              minRequired={1}
-              handleItemChange={handleAcceptedItemChange}
-              onClick={addAcceptedItem}
-              limit={12}
-            />
-
-            <MultiInputComponent
-              label={t("Listings.form.rejectedLabel")}
-              addButtonText={t("Listings.form.addItem")}
-              addAnotherButtonText={t("Listings.form.addAnotherItem")}
-              optionalText={t("Common.optional")}
-              placeholder={t("Listings.form.rejectedPlaceholder")}
-              secondaryPlaceholder={t(
-                "Listings.form.rejectedSecondaryPlaceholder"
-              )}
-              items={rejectedItems}
-              handleItemChange={handleRejectedItemChange}
-              onClick={addRejectedItem}
-              limit={16}
-            />
-          </FormSection>
-        )}
-
-        <FormSection>
-          <FormSectionHeader>
-            <h2>{t("Listings.form.media")}</h2>
-            <p>
-              {t("Listings.form.mediaHint", {
-                subject:
-                  listingType === "residential"
-                    ? t("Listings.form.mediaResidential")
-                    : listingType === "community"
-                      ? t("Listings.form.mediaCommunity")
-                      : t("Listings.form.mediaBusiness"),
-              })}
-            </p>
-          </FormSectionHeader>
-
-          <FieldsetWithGap>
-            <Label
-              htmlFor="photo-upload-button"
-              required={false}
-              optionalText={t("Common.optional")}
-            >
-              {t("Common.photos")}
-            </Label>
-            <ListingPhotosManagerComponent
-              initialPhotos={initialListing ? photos : pendingPhotos}
-              listingSlug={initialListing?.slug}
-              onPhotosChange={initialListing ? setPhotos : setPendingPhotos}
-              isNewListing={!initialListing}
-            />
-          </FieldsetWithGap>
-
-          {/* TODO: Selecting field should highlight button, just like every other input */}
-          {listingType !== "residential" && (
-            <MultiInputComponent
-              label={t("Listings.form.externalLinks")}
-              required={false}
-              addButtonText={t("Listings.form.addLink")}
-              optionalText={t("Common.optional")}
-              placeholder={t("Listings.form.linkPlaceholder")}
-              items={links}
-              handleItemChange={handleLinksChange}
-              onClick={addLink}
-              limit={3}
-              type="url"
-              pattern="https?://.+"
-            />
+              <Field>
+                <Label htmlFor="stub">{t("Listings.form.stubSettings")}</Label>
+                <Select
+                  id="stub"
+                  value={String(isStub)}
+                  onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                    setIsStub(event.target.value === "true")
+                  }
+                  required={true}
+                >
+                  <option value="false">
+                    {t("Listings.form.regularListing")}
+                  </option>
+                  <option value="true">{t("Listings.form.stubListing")}</option>
+                </Select>
+                <InputHint>
+                  {isStub
+                    ? t("Listings.form.stubActiveHint")
+                    : t("Listings.form.stubInactiveHint")}
+                </InputHint>
+              </Field>
+            </FormSection>
           )}
-        </FormSection>
 
-        {initialListing && (
           <FormSection>
-            <FormSectionHeader>
-              <h2>{t("Listings.form.visibility")}</h2>
-              <p>{t("Listings.form.visibilityHint")}</p>
-            </FormSectionHeader>
-
-            <Field>
-              <Label htmlFor="visibility">
-                {t("Listings.form.mapVisibility")}
-              </Label>
-              <SelectComponent
-                id="visibility"
-                value={String(initialListing ? visibility : true)}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  setVisibility(event.target.value === "true")
-                }
+            <CheckboxCluster>
+              <LegalAgreement
                 required={true}
-              >
-                <option value="true">{t("Listings.form.showOnMap")}</option>
-                <option value="false">{t("Listings.form.hideFromMap")}</option>
-              </SelectComponent>
-            </Field>
+                defaultChecked={initialListing ? true : undefined}
+              />
+            </CheckboxCluster>
           </FormSection>
-        )}
 
-        {profile?.is_admin && (
-          <FormSection>
-            <FormSectionHeader>
-              <h2>{t("Common.admin")}</h2>
-              <p>{t("Listings.form.adminHint")}</p>
-            </FormSectionHeader>
-
-            <Field>
-              <Label htmlFor="stub">{t("Listings.form.stubSettings")}</Label>
-              <SelectComponent
-                id="stub"
-                value={String(isStub)}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  setIsStub(event.target.value === "true")
-                }
-                required={true}
-              >
-                <option value="false">
-                  {t("Listings.form.regularListing")}
-                </option>
-                <option value="true">{t("Listings.form.stubListing")}</option>
-              </SelectComponent>
-              <InputHintComponent>
-                {isStub
-                  ? t("Listings.form.stubActiveHint")
-                  : t("Listings.form.stubInactiveHint")}
-              </InputHintComponent>
-            </Field>
-          </FormSection>
-        )}
-
-        <FormSection>
-          <CheckboxCluster>
-            <LegalAgreement
-              required={true}
-              defaultChecked={initialListing ? true : undefined}
-            />
-          </CheckboxCluster>
-        </FormSection>
-
-        {(Object.keys(errors).length > 0 || globalError) && (
-          <FormMessage
-            message={{
-              error:
-                globalError ||
-                t("Errors.validationSummary", {
-                  count: Object.keys(errors).length,
-                }),
-            }}
-          />
-        )}
-        <Button
-          data-testid="listing-write-submit"
-          type="submit"
-          variant="primary"
-          loading={isSubmitting}
-          loadingText={initialListing ? t("Status.saving") : t("Status.adding")}
-        >
-          {initialListing ? t("Actions.saveChanges") : t("Actions.addListing")}
-        </Button>
+          <SubmitButton
+            data-testid="listing-write-submit"
+            variant="primary"
+            pending={submitMutation.isPending}
+            pendingText={
+              initialListing ? t("Status.saving") : t("Status.adding")
+            }
+            disabled={deleteMutation.isPending}
+          >
+            {initialListing
+              ? t("Actions.saveChanges")
+              : t("Actions.addListing")}
+          </SubmitButton>
+        </DisabledFieldset>
       </Form>
 
-      {/* TODO: Fix styling but do not move into above form, as that means nested forms (and an error) */}
+      {feedbackMessage && <FormMessage message={{ error: feedbackMessage }} />}
+
       {initialListing && (
         <AdditionalSettings>
           <Button
             variant="secondary"
             width="contained"
             href={`/listings/${initialListing.slug}`}
+            disabled={isMutating}
           >
             {t("Actions.viewListing")}
           </Button>
@@ -691,14 +630,14 @@ export default function ListingWrite({
             dialogTitle={t("Actions.deleteListing")}
             confirmButtonText={t("Listings.delete.confirm")}
             confirmLoadingText={t("Status.deleting")}
+            disabled={submitMutation.isPending}
             onSubmit={handleDeleteListing}
+            pending={deleteMutation.isPending}
           >
             {t("Listings.delete.dialog")}
           </ButtonToDialog>
         </AdditionalSettings>
       )}
-
-      {feedbackMessage && <p>{feedbackMessage}</p>}
     </>
   );
 }

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -204,6 +204,7 @@ export default function ListingWrite({
     }
 
     setErrors({});
+    submitMutation.reset();
     deleteMutation.reset();
 
     const validation = validateListingWriteForm({

--- a/src/components/ListingWrite/listingWriteController.ts
+++ b/src/components/ListingWrite/listingWriteController.ts
@@ -3,7 +3,11 @@ import {
   deleteListingAction,
   updateFirstNameAction,
 } from "@/app/actions";
-import { validateName } from "@/lib/formValidation";
+import {
+  validateFirstName,
+  validateName,
+  type FirstNameErrorCode,
+} from "@/lib/formValidation";
 import type { Dispatch, SetStateAction } from "react";
 import type { InlineActionResult } from "@/types/actionResult";
 import type {
@@ -11,6 +15,7 @@ import type {
   Listing,
   ListingCoordinates,
   ListingDraftInput,
+  ListingSubmitFailureData,
   ListingSubmitResult,
   ListingType,
   ListingWriteFieldErrors,
@@ -50,6 +55,24 @@ export type LocationSelectProps = {
   error?: string;
 };
 
+function translateFirstNameFieldError(t: Translate, code?: FirstNameErrorCode) {
+  switch (code) {
+    case "empty":
+      return t("Errors.emptyName");
+    case "tooShort":
+      return t("Errors.firstNameTooShort");
+    case "tooLong":
+      return t("Errors.firstNameTooLong");
+    case "forbiddenContent":
+    case "reserved":
+      return t("Errors.firstNameNotAllowed");
+    case "invalidChars":
+      return t("Errors.firstNameInvalidChars");
+    default:
+      return t("Errors.generic");
+  }
+}
+
 export function validateListingWriteForm({
   coordinates,
   listingType,
@@ -71,10 +94,10 @@ export function validateListingWriteForm({
 
   if (listingType === "residential") {
     if (name !== profile?.first_name) {
-      const validation = validateName(name);
+      const validation = validateFirstName(name);
 
       if (!validation.isValid) {
-        errors.name = validation.error;
+        errors.name = translateFirstNameFieldError(t, validation.error);
       } else {
         validatedName = validation.value ?? "";
       }
@@ -144,13 +167,17 @@ export async function submitListingWrite({
   listingType,
   profile,
   validatedName,
+  t,
 }: {
   draft: ListingDraftInput | null;
   fallbackError: string;
   listingType: ListingType;
   profile: ListingWriteProfile | null;
   validatedName: string;
-}): Promise<InlineActionResult<ListingSubmitResult>> {
+  t: Translate;
+}): Promise<
+  InlineActionResult<ListingSubmitResult | ListingSubmitFailureData>
+> {
   if (!draft) {
     return {
       success: false,
@@ -165,9 +192,16 @@ export async function submitListingWrite({
     const result = await updateFirstNameAction(formData);
 
     if (result?.error) {
+      const nameError = String(result.error);
+
       return {
         success: false,
-        error: String(result.error),
+        error: nameError,
+        data: {
+          errors: {
+            name: nameError,
+          },
+        },
       };
     }
   }

--- a/src/components/ListingWrite/listingWriteController.ts
+++ b/src/components/ListingWrite/listingWriteController.ts
@@ -1,0 +1,184 @@
+import {
+  createOrUpdateListingAction,
+  deleteListingAction,
+  updateFirstNameAction,
+} from "@/app/actions";
+import { validateName } from "@/lib/formValidation";
+import type { Dispatch, SetStateAction } from "react";
+import type { InlineActionResult } from "@/types/actionResult";
+import type {
+  DeleteListingResult,
+  Listing,
+  ListingCoordinates,
+  ListingDraftInput,
+  ListingSubmitResult,
+  ListingType,
+  ListingWriteFieldErrors,
+  ListingWriteProfile,
+} from "@/types/listing";
+
+export type ListingWriteFormValues = {
+  acceptedItems: string[];
+  areaName: string;
+  avatar: string;
+  coordinates: ListingCoordinates | null;
+  countryCode: string;
+  description: string;
+  isStub: boolean;
+  links: string[];
+  name: string;
+  pendingPhotos: string[];
+  photos: string[];
+  rejectedItems: string[];
+  visibility: boolean;
+};
+
+type Translate = (
+  key: string,
+  values?: Record<string, string | number | Date>
+) => string;
+
+export type LocationSelectProps = {
+  listingType: string;
+  coordinates: ListingCoordinates | null;
+  setCoordinates: Dispatch<SetStateAction<ListingCoordinates | null>>;
+  countryCode: string;
+  setCountryCode: Dispatch<SetStateAction<string>>;
+  areaName: string;
+  setAreaName: Dispatch<SetStateAction<string>>;
+  initialPlaceholderText?: string;
+  error?: string;
+};
+
+export function validateListingWriteForm({
+  coordinates,
+  listingType,
+  name,
+  profile,
+  t,
+}: {
+  coordinates: ListingCoordinates | null;
+  listingType: ListingType;
+  name: string;
+  profile: ListingWriteProfile | null;
+  t: Translate;
+}): {
+  errors: ListingWriteFieldErrors;
+  validatedName: string;
+} {
+  const errors: ListingWriteFieldErrors = {};
+  let validatedName = name;
+
+  if (listingType === "residential") {
+    if (name !== profile?.first_name) {
+      const validation = validateName(name);
+
+      if (!validation.isValid) {
+        errors.name = validation.error;
+      } else {
+        validatedName = validation.value ?? "";
+      }
+    }
+  } else {
+    const validation = validateName(name);
+
+    if (!validation.isValid) {
+      errors.name = t("Errors.emptyListingName", { type: listingType });
+    } else {
+      validatedName = validation.value ?? "";
+    }
+  }
+
+  if (!coordinates) {
+    errors.location = t("Errors.missingLocation");
+  }
+
+  return {
+    errors,
+    validatedName,
+  };
+}
+
+export function buildListingDraft({
+  initialListing,
+  listingType,
+  profile,
+  userId,
+  validatedName,
+  values,
+}: {
+  initialListing?: Listing | null;
+  listingType: ListingType;
+  profile: ListingWriteProfile | null;
+  userId: string;
+  validatedName: string;
+  values: ListingWriteFormValues;
+}): ListingDraftInput | null {
+  if (!values.coordinates) {
+    return null;
+  }
+
+  return {
+    ...(initialListing && { id: initialListing.id }),
+    owner_id: userId,
+    type: listingType,
+    ...(listingType !== "residential" &&
+      values.avatar && { avatar: values.avatar }),
+    ...(listingType !== "residential" && { name: validatedName }),
+    description: values.description,
+    location: `POINT(${values.coordinates.longitude} ${values.coordinates.latitude})`,
+    area_name: values.areaName,
+    country_code: values.countryCode,
+    accepted_items: values.acceptedItems.filter((item) => item.trim() !== ""),
+    rejected_items: values.rejectedItems.filter((item) => item.trim() !== ""),
+    photos: initialListing ? values.photos : values.pendingPhotos,
+    links: values.links.filter((link) => link.trim() !== ""),
+    ...(profile?.is_admin && { is_stub: values.isStub }),
+    visibility: values.visibility,
+  };
+}
+
+export async function submitListingWrite({
+  draft,
+  fallbackError,
+  listingType,
+  profile,
+  validatedName,
+}: {
+  draft: ListingDraftInput | null;
+  fallbackError: string;
+  listingType: ListingType;
+  profile: ListingWriteProfile | null;
+  validatedName: string;
+}): Promise<InlineActionResult<ListingSubmitResult>> {
+  if (!draft) {
+    return {
+      success: false,
+      error: fallbackError,
+    };
+  }
+
+  if (listingType === "residential" && profile?.first_name !== validatedName) {
+    const formData = new FormData();
+    formData.append("first_name", validatedName);
+
+    const result = await updateFirstNameAction(formData);
+
+    if (result?.error) {
+      return {
+        success: false,
+        error: String(result.error),
+      };
+    }
+  }
+
+  return createOrUpdateListingAction(draft);
+}
+
+export async function submitListingDelete({
+  slug,
+}: {
+  slug: string;
+}): Promise<InlineActionResult<DeleteListingResult>> {
+  return deleteListingAction(slug);
+}

--- a/src/components/RouteBoundaryState/RouteBoundaryState.tsx
+++ b/src/components/RouteBoundaryState/RouteBoundaryState.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Form from "@/components/Form";
+import Button from "@/components/Button";
+import { styled } from "next-yak";
+
+const Content = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+`;
+
+type RouteBoundaryStateProps = {
+  message: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+};
+
+export default function RouteBoundaryState({
+  message,
+  onRetry,
+  retryLabel,
+}: RouteBoundaryStateProps) {
+  return (
+    <Form as="container">
+      <Content>
+        <p>{message}</p>
+        {onRetry && retryLabel ? (
+          <Button variant="secondary" onClick={onRetry}>
+            {retryLabel}
+          </Button>
+        ) : null}
+      </Content>
+    </Form>
+  );
+}

--- a/src/components/ThreadsList/ThreadsList.tsx
+++ b/src/components/ThreadsList/ThreadsList.tsx
@@ -7,11 +7,11 @@ import AvatarPair from "@/components/AvatarPair";
 import { css, styled } from "next-yak";
 import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
 import { useTranslations } from "next-intl";
-import type { ChatThreadRecord, ChatUser } from "@/types/chat";
+import type { ChatThreadListItem, ChatUser } from "@/types/chat";
 
 type ThreadsListProps = {
   user: ChatUser;
-  threads?: ChatThreadRecord[] | null;
+  threads?: ChatThreadListItem[] | null;
   currentThreadId?: string | null;
 };
 
@@ -177,9 +177,7 @@ function ThreadsList({ user, threads, currentThreadId }: ThreadsListProps) {
                 : otherPersonName;
 
             const hasUnreadMessages =
-              thread.chat_messages_with_senders?.some(
-                (msg) => !msg.read_at && msg.sender_id !== user.id
-              ) && !isThreadRead(thread.id);
+              thread.has_unread_messages && !isThreadRead(thread.id);
 
             return (
               <li key={thread.id}>
@@ -221,16 +219,9 @@ function ThreadsList({ user, threads, currentThreadId }: ThreadsListProps) {
                   />
                   <ThreadPreviewText>
                     <h3>{displayNameVerbose}</h3>
-                    {thread.chat_messages_with_senders &&
-                      thread.chat_messages_with_senders.length > 0 && (
-                        <p>
-                          {
-                            thread.chat_messages_with_senders[
-                              thread.chat_messages_with_senders.length - 1
-                            ].content
-                          }
-                        </p>
-                      )}
+                    {thread.last_message && (
+                      <p>{thread.last_message.content}</p>
+                    )}
                   </ThreadPreviewText>
                 </ThreadPreview>
               </li>

--- a/src/data/demo/threads.ts
+++ b/src/data/demo/threads.ts
@@ -1,8 +1,12 @@
 type DemoThread = {
   id: string;
   chat_messages_with_senders: Array<{
+    id: string;
     content: string;
     created_at: string;
+    read_at: string | null;
+    sender_id: string | null;
+    thread_id: string | null;
   }>;
 };
 
@@ -21,13 +25,21 @@ export const demoThreads: DemoThread[] = [
     id: "demo-thread-1",
     chat_messages_with_senders: [
       {
+        id: "demo-thread-1-message-1",
         content: "Hey Becca, are you still accepting food scraps?",
         created_at: timestampOne.toISOString(),
+        read_at: timestampOne.toISOString(),
+        sender_id: "demo-initiator",
+        thread_id: "demo-thread-1",
       },
       {
+        id: "demo-thread-1-message-2",
         content:
           "Yes please! We’re home most days after 4pm. Ring the bell at 12 Ingham Dr",
         created_at: timestampTwo.toISOString(),
+        read_at: timestampTwo.toISOString(),
+        sender_id: "demo-owner",
+        thread_id: "demo-thread-1",
       },
     ],
   },

--- a/src/hooks/useInlineMutation.ts
+++ b/src/hooks/useInlineMutation.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { InlineActionResult } from "@/types/actionResult";
+
+export function getInitialInlineActionResult<T>(): InlineActionResult<T> {
+  return {
+    success: false,
+    error: null,
+  };
+}
+
+type InlineMutationOptions = {
+  fallbackError?: string;
+};
+
+export function useInlineMutation<T>() {
+  const [result, setResult] = useState<InlineActionResult<T>>(
+    getInitialInlineActionResult<T>()
+  );
+  const [isPending, setIsPending] = useState(false);
+
+  const reset = useCallback(() => {
+    setResult(getInitialInlineActionResult<T>());
+  }, []);
+
+  const run = useCallback(
+    async (
+      mutation: () => Promise<InlineActionResult<T>>,
+      options: InlineMutationOptions = {}
+    ) => {
+      if (isPending) {
+        return null;
+      }
+
+      setIsPending(true);
+      setResult(getInitialInlineActionResult<T>());
+
+      try {
+        const nextResult = await mutation();
+        setResult(nextResult);
+        return nextResult;
+      } catch (error) {
+        const fallbackResult: InlineActionResult<T> = {
+          success: false,
+          error:
+            options.fallbackError ||
+            (error instanceof Error ? error.message : "Something went wrong."),
+        };
+
+        setResult(fallbackResult);
+        return fallbackResult;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [isPending]
+  );
+
+  return {
+    isPending,
+    reset,
+    result,
+    setResult,
+    run,
+  };
+}

--- a/src/hooks/useInlineMutation.ts
+++ b/src/hooks/useInlineMutation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { InlineActionResult } from "@/types/actionResult";
 
 export function getInitialInlineActionResult<T>(): InlineActionResult<T> {
@@ -19,6 +19,7 @@ export function useInlineMutation<T>() {
     getInitialInlineActionResult<T>()
   );
   const [isPending, setIsPending] = useState(false);
+  const isPendingRef = useRef(false);
 
   const reset = useCallback(() => {
     setResult(getInitialInlineActionResult<T>());
@@ -29,10 +30,11 @@ export function useInlineMutation<T>() {
       mutation: () => Promise<InlineActionResult<T>>,
       options: InlineMutationOptions = {}
     ) => {
-      if (isPending) {
+      if (isPendingRef.current) {
         return null;
       }
 
+      isPendingRef.current = true;
       setIsPending(true);
       setResult(getInitialInlineActionResult<T>());
 
@@ -51,10 +53,11 @@ export function useInlineMutation<T>() {
         setResult(fallbackResult);
         return fallbackResult;
       } finally {
+        isPendingRef.current = false;
         setIsPending(false);
       }
     },
-    [isPending]
+    []
   );
 
   return {

--- a/src/styles/theme.yak.d.ts
+++ b/src/styles/theme.yak.d.ts
@@ -1,0 +1,1 @@
+export { rawTheme, theme } from "./theme";

--- a/src/styles/theme.yak.js
+++ b/src/styles/theme.yak.js
@@ -44,7 +44,7 @@ const palette = {
     700: "hsla(47, 100%, 50%, 1)",
     800: "hsla(47, 100%, 46%, 1)",
   },
-} as const;
+};
 
 const spacing = {
   unit: "0.5rem",
@@ -83,7 +83,7 @@ const spacing = {
   dropdownMenu: {
     gap: "4px",
   },
-} as const;
+};
 
 const corners = {
   thumbnail: "0.375rem",
@@ -92,16 +92,16 @@ const corners = {
     small: "0.375rem",
     large: "0.5rem",
   },
-} as const;
+};
 
 const rotations = {
   avatar: "-3deg",
-} as const;
+};
 
 const transitions = {
   textColor: "color 150ms ease-in-out",
   svgColor: "stroke 150ms ease-in-out",
-} as const;
+};
 
 const typography = {
   size: {
@@ -119,9 +119,9 @@ const typography = {
       lg: "160%",
     },
   },
-} as const;
+};
 
-const cssVar = (name: string) => `var(${name})`;
+const cssVar = (name) => `var(${name})`;
 
 export const theme = {
   colors: {
@@ -282,7 +282,7 @@ export const theme = {
   rotations,
   transitions,
   typography,
-} as const;
+};
 
 export const rawTheme = {
   palette,
@@ -291,4 +291,4 @@ export const rawTheme = {
   rotations,
   transitions,
   typography,
-} as const;
+};

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -18,12 +18,12 @@ export type ChatListing = {
 };
 
 export type ChatMessageRecord = {
-  id?: string;
+  id: string;
   content: string;
   created_at: string;
-  read_at?: string | null;
-  sender_id?: string | null;
-  thread_id?: string | null;
+  read_at: string | null;
+  sender_id: string | null;
+  thread_id: string | null;
 };
 
 export type ChatThreadRecord = {
@@ -36,4 +36,20 @@ export type ChatThreadRecord = {
   listing?: ChatListing | null;
   chat_messages_with_senders?: ChatMessageRecord[] | null;
   chat_messages?: ChatMessageRecord[] | null;
+};
+
+export type ChatThreadView = ChatThreadRecord & {
+  listing: ChatListing | null;
+  messages: ChatMessageRecord[];
+};
+
+export type ChatSendResult = {
+  message: ChatMessageRecord;
+  threadId: string;
+};
+
+export type ChatReadResult = {
+  readAt: string;
+  readMessageIds: string[];
+  threadId: string;
 };

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -26,7 +26,7 @@ export type ChatMessageRecord = {
   thread_id: string | null;
 };
 
-export type ChatThreadRecord = {
+export type ChatThreadBase = {
   id: string;
   initiator_id?: string | null;
   initiator_first_name?: string | null;
@@ -34,11 +34,27 @@ export type ChatThreadRecord = {
   owner_id?: string | null;
   owner_first_name?: string | null;
   listing?: ChatListing | null;
+};
+
+export type ChatThreadRecord = ChatThreadBase & {
   chat_messages_with_senders?: ChatMessageRecord[] | null;
   chat_messages?: ChatMessageRecord[] | null;
 };
 
-export type ChatThreadView = ChatThreadRecord & {
+export type ChatThreadPreviewRecord = ChatThreadBase & {
+  latest_message_id?: string | null;
+  latest_message_content?: string | null;
+  latest_message_created_at?: string | null;
+  latest_message_read_at?: string | null;
+  latest_message_sender_id?: string | null;
+};
+
+export type ChatThreadListItem = ChatThreadBase & {
+  has_unread_messages: boolean;
+  last_message: ChatMessageRecord | null;
+};
+
+export type ChatThreadView = ChatThreadBase & {
   listing: ChatListing | null;
   messages: ChatMessageRecord[];
 };

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -9,6 +9,48 @@ export type ListingCoordinates = {
   longitude: number;
 };
 
+export type ListingWriteFieldErrors = Partial<
+  Record<"name" | "location", string>
+>;
+
+export type ListingWriteProfile = {
+  first_name?: string | null;
+  avatar?: string | null;
+  is_admin?: boolean | null;
+};
+
+export type ListingDraftInput = {
+  id?: number;
+  owner_id: string;
+  type: ListingType;
+  avatar?: string;
+  name?: string;
+  description: string;
+  location: string;
+  area_name: string;
+  country_code: string;
+  accepted_items: string[];
+  rejected_items: string[];
+  photos: string[];
+  links: string[];
+  is_stub?: boolean;
+  visibility: boolean;
+};
+
+export type ListingSubmitResult = {
+  created: boolean;
+  id: number;
+  redirectTo: string;
+  slug: string;
+  type: ListingType;
+};
+
+export type DeleteListingResult = {
+  message: string;
+  redirectTo: string;
+  slug: string;
+};
+
 /**
  * Shape of a row from `listings_public_data` (anonymous readers) and
  * `listings_private_data` (authenticated readers). Owner-scoped fields are

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -45,6 +45,10 @@ export type ListingSubmitResult = {
   type: ListingType;
 };
 
+export type ListingSubmitFailureData = {
+  errors: ListingWriteFieldErrors;
+};
+
 export type DeleteListingResult = {
   message: string;
   redirectTo: string;

--- a/supabase/migrations/20260423140629_add_chat_thread_previews_to_threads_view.sql
+++ b/supabase/migrations/20260423140629_add_chat_thread_previews_to_threads_view.sql
@@ -15,17 +15,17 @@ select
   listings.area_name as listing_area_name,
   owner.avatar as owner_avatar,
   initiator.avatar as initiator_avatar,
-  latest_message.id as latest_message_id,
-  latest_message.content as latest_message_content,
-  latest_message.created_at as latest_message_created_at,
-  latest_message.read_at as latest_message_read_at,
-  latest_message.sender_id as latest_message_sender_id,
   (
     select count(*) >= 2
     from public.listings as owner_listings
     where owner_listings.owner_id = chat_threads.owner_id
       and owner_listings.type in ('community', 'business')
-  ) as owner_has_multiple_non_residential_listings
+  ) as owner_has_multiple_non_residential_listings,
+  latest_message.id as latest_message_id,
+  latest_message.content as latest_message_content,
+  latest_message.created_at as latest_message_created_at,
+  latest_message.read_at as latest_message_read_at,
+  latest_message.sender_id as latest_message_sender_id
 from public.chat_threads
 join public.profiles as initiator on chat_threads.initiator_id = initiator.id
 join public.profiles as owner on chat_threads.owner_id = owner.id
@@ -42,6 +42,9 @@ left join lateral (
   order by chat_messages.created_at desc
   limit 1
 ) as latest_message on true;
+
+create index if not exists chat_messages_thread_id_created_at_idx
+  on public.chat_messages (thread_id, created_at desc);
 
 alter view public.chat_threads_with_participants owner to postgres;
 

--- a/supabase/migrations/20260423140629_add_chat_thread_previews_to_threads_view.sql
+++ b/supabase/migrations/20260423140629_add_chat_thread_previews_to_threads_view.sql
@@ -1,0 +1,52 @@
+create or replace view public.chat_threads_with_participants
+with (security_invoker = on) as
+select
+  chat_threads.id,
+  chat_threads.created_at,
+  chat_threads.listing_id,
+  chat_threads.initiator_id,
+  chat_threads.owner_id,
+  initiator.first_name as initiator_first_name,
+  owner.first_name as owner_first_name,
+  listings.slug as listing_slug,
+  listings.avatar as listing_avatar,
+  listings.name as listing_name,
+  listings.type as listing_type,
+  listings.area_name as listing_area_name,
+  owner.avatar as owner_avatar,
+  initiator.avatar as initiator_avatar,
+  latest_message.id as latest_message_id,
+  latest_message.content as latest_message_content,
+  latest_message.created_at as latest_message_created_at,
+  latest_message.read_at as latest_message_read_at,
+  latest_message.sender_id as latest_message_sender_id,
+  (
+    select count(*) >= 2
+    from public.listings as owner_listings
+    where owner_listings.owner_id = chat_threads.owner_id
+      and owner_listings.type in ('community', 'business')
+  ) as owner_has_multiple_non_residential_listings
+from public.chat_threads
+join public.profiles as initiator on chat_threads.initiator_id = initiator.id
+join public.profiles as owner on chat_threads.owner_id = owner.id
+join public.listings on chat_threads.listing_id = listings.id
+left join lateral (
+  select
+    chat_messages.id,
+    chat_messages.content,
+    chat_messages.created_at,
+    chat_messages.read_at,
+    chat_messages.sender_id
+  from public.chat_messages
+  where chat_messages.thread_id = chat_threads.id
+  order by chat_messages.created_at desc
+  limit 1
+) as latest_message on true;
+
+alter view public.chat_threads_with_participants owner to postgres;
+
+revoke all on table public.chat_threads_with_participants
+  from anon, authenticated, service_role;
+
+grant select on table public.chat_threads_with_participants
+  to authenticated, service_role;

--- a/supabase/migrations/20260424091500_optimize_chat_thread_previews_and_unread_thread_lookup.sql
+++ b/supabase/migrations/20260424091500_optimize_chat_thread_previews_and_unread_thread_lookup.sql
@@ -1,0 +1,77 @@
+create or replace view public.chat_threads_with_participants
+with (security_invoker = on) as
+select
+  chat_threads.id,
+  chat_threads.created_at,
+  chat_threads.listing_id,
+  chat_threads.initiator_id,
+  chat_threads.owner_id,
+  initiator.first_name as initiator_first_name,
+  owner.first_name as owner_first_name,
+  listings.slug as listing_slug,
+  listings.avatar as listing_avatar,
+  listings.name as listing_name,
+  listings.type as listing_type,
+  listings.area_name as listing_area_name,
+  owner.avatar as owner_avatar,
+  initiator.avatar as initiator_avatar,
+  exists (
+    select 1
+    from public.listings as owner_listings
+    where owner_listings.owner_id = chat_threads.owner_id
+      and owner_listings.type in ('community', 'business')
+    offset 1
+    limit 1
+  ) as owner_has_multiple_non_residential_listings,
+  latest_message.id as latest_message_id,
+  latest_message.content as latest_message_content,
+  latest_message.created_at as latest_message_created_at,
+  latest_message.read_at as latest_message_read_at,
+  latest_message.sender_id as latest_message_sender_id
+from public.chat_threads
+join public.profiles as initiator on chat_threads.initiator_id = initiator.id
+join public.profiles as owner on chat_threads.owner_id = owner.id
+join public.listings on chat_threads.listing_id = listings.id
+left join lateral (
+  select
+    chat_messages.id,
+    chat_messages.content,
+    chat_messages.created_at,
+    chat_messages.read_at,
+    chat_messages.sender_id
+  from public.chat_messages
+  where chat_messages.thread_id = chat_threads.id
+  order by chat_messages.created_at desc, chat_messages.id desc
+  limit 1
+) as latest_message on true;
+
+alter view public.chat_threads_with_participants owner to postgres;
+
+revoke all on table public.chat_threads_with_participants
+  from anon, authenticated, service_role;
+
+grant select on table public.chat_threads_with_participants
+  to authenticated, service_role;
+
+create or replace function public.unread_chat_thread_ids(thread_ids uuid[])
+returns table(thread_id uuid)
+language sql
+security invoker
+stable
+set search_path = public
+as $$
+  select distinct chat_messages.thread_id
+  from public.chat_messages
+  where auth.uid() is not null
+    and chat_messages.thread_id = any(thread_ids)
+    and chat_messages.sender_id <> auth.uid()
+    and chat_messages.read_at is null
+$$;
+
+alter function public.unread_chat_thread_ids(uuid[]) owner to postgres;
+
+revoke all on function public.unread_chat_thread_ids(uuid[])
+  from anon, authenticated, service_role;
+
+grant execute on function public.unread_chat_thread_ids(uuid[])
+  to authenticated, service_role;


### PR DESCRIPTION
## Summary
- harden the signed-in listing and chat flows around one consistent inline mutation pattern
- fix the Turbopack/Next Yak build regression by moving the shared Yak theme entrypoint to a JavaScript module that Turbopack can evaluate
- add small test/docs guardrails so production Playwright uses its own server and the local seeded Supabase expectation is clearer

## What Changed
- extracted typed client-side controllers for `ListingWrite` and `ChatWindow`, plus a shared `useInlineMutation` hook
- standardised listing create, update, and delete handling on `InlineActionResult<T>` with one pending/message path
- tightened chat send and read-state handling, removed the full reload send path, and preserved draft text on failure
- added targeted `loading.tsx` and `error.tsx` boundaries for listing create/edit and chat routes
- extended listing and chat Playwright coverage for pending, success, and failure behaviour
- renamed `src/styles/theme.yak.ts` to `src/styles/theme.yak.js` so Next Yak can resolve the shared theme during Turbopack builds
- set production Playwright to start its own `next start` server instead of reusing an existing local dev server
- documented that the smoke suite expects the local seeded Supabase stack and local anon key

## Why
The next roadmap slice was to harden the member flows with the biggest real-user impact: listing write/edit and chat. While validating that work, Turbopack builds were failing because Next Yak was trying to evaluate the shared `theme.yak.ts` file directly in Node and choking on the TypeScript extension. The local prod Playwright path also turned out to be too easy to run against a hosted `.env.local` or a stray `next dev` server, which produced misleading failures.

## Impact
- signed-in listing and chat UX now share a more consistent pending/error/success pattern
- chat sending is more predictable and no longer depends on a thread reload after each message
- Turbopack builds are green again without falling back to webpack
- the local production-like Playwright path is less surprising because it will always boot its own production server

## Validation
- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npm run test:e2e:prod` was not rerun end-to-end in this checkout because the current `.env.local` points at hosted Supabase and I stopped short of pulling the full local Supabase image set in this session
