### PR TITLE
modernise form submit typing and polish listing edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ These instructions apply to the whole repository.
 - Prefer Server Components by default. Only add `"use client"` when the component needs browser-only APIs, state/effects, event handlers, or client-only libraries.
 - When touching JS/JSX components, convert them to TS/TSX when it is reasonable and scoped to the change.
 - Keep shared presentational components server-safe where possible. For translated labels or suffixes, prefer passing translated text from the caller instead of adding `useTranslations` to a shared component.
+- For React form submit handlers, use the shared `FormSubmitEvent` / `FormSubmitHandler` types from `src/types/events.ts`, which wrap React 19's `SubmitEvent`. Avoid deprecated `FormEvent`, `FormEventHandler`, and `React.FormEvent`; keep `ChangeEvent` for input/select/textarea change handlers.
 - In MDX prose, if an inline component inside a Markdown list item is formatted onto multiple lines and changes rendered spacing, use a targeted `{/* prettier-ignore */}` before that list rather than disabling formatting for the whole file.
 
 ## Testing

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  DONOR_EMAIL,
   HOST_EMAIL,
   PROFILE_RENDER_TIMEOUT_MS,
   delayServerActionRequests,
@@ -7,6 +8,8 @@ import {
 } from "./helpers";
 
 const BUSINESS_LISTING_EDIT_PATH = "/profile/listings/demo-inner-west-cafe";
+const RESIDENTIAL_LISTING_EDIT_PATH =
+  "/profile/listings/demo-newtown-worm-farm";
 const ALTERNATE_BUSINESS_DESCRIPTION =
   "A demo business listing with a slightly different description for e2e coverage.";
 
@@ -76,6 +79,9 @@ test("listing edit saves and restores seeded business fields", async ({
     redirectTo: BUSINESS_LISTING_EDIT_PATH,
   });
   await expect(page.getByTestId("listing-write-form")).toBeVisible();
+  const formWidth = await page
+    .getByTestId("listing-write-form")
+    .evaluate((form) => form.getBoundingClientRect().width);
   const descriptionInput = page.locator("#description");
   const visibilityInput = page.locator("#visibility");
   const originalDescription = await descriptionInput.inputValue();
@@ -91,6 +97,11 @@ test("listing edit saves and restores seeded business fields", async ({
   await delayServerActionRequests(page);
 
   const submitButton = page.getByTestId("listing-write-submit");
+  const submitWidth = await submitButton.evaluate(
+    (button) => button.getBoundingClientRect().width
+  );
+  expect(Math.abs(submitWidth - formWidth)).toBeLessThanOrEqual(2);
+
   const updateNavigation = page.waitForURL(
     /\/listings\/demo-inner-west-cafe\?status=updated$/
   );
@@ -114,4 +125,19 @@ test("listing edit saves and restores seeded business fields", async ({
   await page.goto(BUSINESS_LISTING_EDIT_PATH);
   await expect(page.locator("#description")).toHaveValue(originalDescription);
   await expect(page.locator("#visibility")).toHaveValue(originalVisibility);
+});
+
+test("residential listing edit leaves avatar management on the profile page", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: RESIDENTIAL_LISTING_EDIT_PATH,
+  });
+
+  await expect(page.getByTestId("listing-write-form")).toBeVisible();
+  await expect(page.getByTestId("avatar-upload-avatars")).toHaveCount(0);
+  await expect(page.getByTestId("avatar-upload-listing_avatars")).toHaveCount(
+    0
+  );
 });

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -79,9 +79,6 @@ test("listing edit saves and restores seeded business fields", async ({
     redirectTo: BUSINESS_LISTING_EDIT_PATH,
   });
   await expect(page.getByTestId("listing-write-form")).toBeVisible();
-  const formWidth = await page
-    .getByTestId("listing-write-form")
-    .evaluate((form) => form.getBoundingClientRect().width);
   const descriptionInput = page.locator("#description");
   const visibilityInput = page.locator("#visibility");
   const originalDescription = await descriptionInput.inputValue();
@@ -97,10 +94,7 @@ test("listing edit saves and restores seeded business fields", async ({
   await delayServerActionRequests(page);
 
   const submitButton = page.getByTestId("listing-write-submit");
-  const submitWidth = await submitButton.evaluate(
-    (button) => button.getBoundingClientRect().width
-  );
-  expect(Math.abs(submitWidth - formWidth)).toBeLessThanOrEqual(2);
+  await expect(submitButton).toHaveAttribute("data-button-width", "full");
 
   const updateNavigation = page.waitForURL(
     /\/listings\/demo-inner-west-cafe\?status=updated$/

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -8,6 +8,7 @@ test("profile account actions show pending feedback and update the read view", a
   await delayProfileActionRequests(page);
 
   const profileAccountSettings = page.getByTestId("profile-account-settings");
+  await expect(page.getByTestId("avatar-upload-avatars")).toBeVisible();
   await expect(profileAccountSettings).toBeVisible();
   await expect(profileAccountSettings).toHaveAttribute("data-hydrated", "true");
 

--- a/src/app/(forms)/profile/listings/[slug]/page.tsx
+++ b/src/app/(forms)/profile/listings/[slug]/page.tsx
@@ -18,9 +18,7 @@ export const metadata: Metadata = {
 export default async function EditListingPage({
   params,
 }: EditListingPageProps) {
-  const t = await getTranslations();
-  const { slug } = await params;
-  const supabase = await createClient();
+  const [{ slug }, supabase] = await Promise.all([params, createClient()]);
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -30,9 +28,11 @@ export default async function EditListingPage({
   }
 
   const [
+    t,
     { data: profile, error: profileError },
     { data: listing, error: listingError },
   ] = await Promise.all([
+    getTranslations(),
     supabase
       .from("profiles")
       .select("first_name, avatar, is_admin")

--- a/src/app/(forms)/profile/listings/[slug]/page.tsx
+++ b/src/app/(forms)/profile/listings/[slug]/page.tsx
@@ -18,7 +18,9 @@ export const metadata: Metadata = {
 export default async function EditListingPage({
   params,
 }: EditListingPageProps) {
-  const [{ slug }, supabase] = await Promise.all([params, createClient()]);
+  const supabasePromise = createClient();
+  const { slug } = await params;
+  const supabase = await supabasePromise;
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -66,11 +68,15 @@ export default async function EditListingPage({
   ]);
 
   if (profileError) {
-    throw new Error(profileError.message);
+    throw new Error(
+      `Failed to fetch profile for user "${user.id}": ${profileError.message}`
+    );
   }
 
   if (listingError) {
-    throw new Error(listingError.message);
+    throw new Error(
+      `Failed to fetch listing for slug "${slug}" and user "${user.id}": ${listingError.message}`
+    );
   }
 
   if (!listing) {

--- a/src/app/(forms)/profile/listings/[slug]/page.tsx
+++ b/src/app/(forms)/profile/listings/[slug]/page.tsx
@@ -29,18 +29,49 @@ export default async function EditListingPage({
     redirect(`/sign-in?redirect_to=/profile/listings/${slug}`);
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select()
-    .eq("id", user.id)
-    .single();
+  const [
+    { data: profile, error: profileError },
+    { data: listing, error: listingError },
+  ] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("first_name, avatar, is_admin")
+      .eq("id", user.id)
+      .single(),
+    supabase
+      .from("listings_private_data")
+      .select(
+        `
+          id,
+          avatar,
+          name,
+          description,
+          coordinates,
+          country_code,
+          area_name,
+          accepted_items,
+          rejected_items,
+          photos,
+          links,
+          type,
+          slug,
+          is_stub,
+          visibility,
+          owner_has_multiple_non_residential_listings
+        `
+      )
+      .eq("owner_id", user.id)
+      .match({ slug })
+      .maybeSingle(),
+  ]);
 
-  const { data: listing } = await supabase
-    .from("listings_private_data")
-    .select()
-    .eq("owner_id", user.id)
-    .match({ slug })
-    .single();
+  if (profileError) {
+    throw new Error(profileError.message);
+  }
+
+  if (listingError) {
+    throw new Error(listingError.message);
+  }
 
   if (!listing) {
     return <div>{t("Listings.edit.notFound")}</div>;

--- a/src/components/AvatarUploadView/AvatarUploadView.tsx
+++ b/src/components/AvatarUploadView/AvatarUploadView.tsx
@@ -112,7 +112,7 @@ function AvatarUploadView({
   };
 
   return (
-    <Fieldset>
+    <Fieldset data-testid={`avatar-upload-${bucket}`}>
       <StyledField>
         {/* Hidden file input */}
         <input

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -420,6 +420,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
           tabIndex={isDisabled ? -1 : tabIndex}
           aria-disabled={isDisabled || undefined}
           aria-busy={isLoading || undefined}
+          data-button-width={allProps.width ?? "contained"}
           onClick={handleLinkClick}
           {...linkProps}
           rel={rel}
@@ -445,6 +446,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
         tabIndex={isDisabled ? -1 : tabIndex}
         aria-disabled={isDisabled || undefined}
         aria-busy={isLoading || undefined}
+        data-button-width={allProps.width ?? "contained"}
         onClick={onClick}
         {...buttonProps}
       >

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -6,8 +6,9 @@ import Button from "@/components/Button";
 import SubmitButton from "@/components/SubmitButton";
 
 import { styled } from "next-yak";
-import { useState, type ReactNode } from "react";
+import { useState, type FormHTMLAttributes, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
+import type { FormSubmitHandler } from "@/types/events";
 
 const DialogContent = styled(Dialog.Content)`
   background: ${theme.colors.background.top};
@@ -68,9 +69,9 @@ type ButtonToDialogProps = {
   confirmButtonText?: ReactNode;
   confirmLoadingText?: string;
   cancelButtonText?: ReactNode;
-  action?: React.FormHTMLAttributes<HTMLFormElement>["action"];
+  action?: FormHTMLAttributes<HTMLFormElement>["action"];
   disabled?: boolean;
-  onSubmit?: React.FormEventHandler<HTMLFormElement>;
+  onSubmit?: FormSubmitHandler;
   pending?: boolean;
 };
 
@@ -97,22 +98,21 @@ function ButtonToDialog({
   const resolvedCancelButtonText = cancelButtonText || t("Actions.noCancel");
   const isPending = pending || isSubmitting;
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> | undefined =
-    onSubmit
-      ? async (event) => {
-          if (isPending) {
-            event.preventDefault();
-            return;
-          }
-
-          setIsSubmitting(true);
-          try {
-            await onSubmit(event);
-          } finally {
-            setIsSubmitting(false);
-          }
+  const handleSubmit: FormSubmitHandler | undefined = onSubmit
+    ? async (event) => {
+        if (isPending) {
+          event.preventDefault();
+          return;
         }
-      : undefined;
+
+        setIsSubmitting(true);
+        try {
+          await onSubmit(event);
+        } finally {
+          setIsSubmitting(false);
+        }
+      }
+    : undefined;
 
   return (
     <Dialog.Root>

--- a/src/components/ChatComposer/ChatComposer.tsx
+++ b/src/components/ChatComposer/ChatComposer.tsx
@@ -6,6 +6,7 @@ import IconButton from "@/components/IconButton";
 import { styled } from "next-yak";
 import FormMessage from "@/components/FormMessage";
 import { useTranslations } from "next-intl";
+import type { FormSubmitHandler } from "@/types/events";
 
 const ChatComposerForm = styled.div`
   display: flex;
@@ -33,7 +34,7 @@ const StyledIconButton = styled(IconButton)`
 const TextareaComponent = Textarea as React.ComponentType<any>;
 
 type ChatComposerProps = {
-  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onSubmit: FormSubmitHandler;
   message: string;
   handleMessageChange: React.ChangeEventHandler<HTMLTextAreaElement>;
   error?: string | null;

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -38,6 +38,8 @@ type ChatWindowProps = {
   isDemo?: boolean;
 };
 
+const DIRECTIONS_FOR_DEMO = ["sent", "received"] as const;
+
 const StyledChatWindow = styled.div`
   height: 100%;
   flex: 1;
@@ -199,9 +201,10 @@ const ChatWindow = memo(function ChatWindow({
 
       const { readAt, readMessageIds } = result.data;
 
+      const readMessageIdsSet = new Set(readMessageIds);
       setMessages((previousMessages) =>
         previousMessages.map((chatMessage) =>
-          readMessageIds.includes(chatMessage.id)
+          readMessageIdsSet.has(chatMessage.id)
             ? { ...chatMessage, read_at: readAt }
             : chatMessage
         )
@@ -300,7 +303,6 @@ const ChatWindow = memo(function ChatWindow({
     setMessage(event.target.value);
   };
 
-  const directionsForDemo = ["sent", "received"] as const;
   const role = isDemo
     ? "initiator"
     : existingThread
@@ -365,7 +367,7 @@ const ChatWindow = memo(function ChatWindow({
               <ChatMessage
                 direction={
                   isDemo
-                    ? directionsForDemo[index % 2]
+                    ? DIRECTIONS_FOR_DEMO[index % 2]
                     : chatMessage.sender_id === user?.id
                       ? "sent"
                       : "received"

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -28,6 +28,7 @@ import type {
   ChatThreadView,
 } from "@/types/chat";
 import type { DemoListing } from "@/types/listing";
+import type { FormSubmitEvent } from "@/types/events";
 
 type ChatWindowProps = {
   isDrawer?: boolean;
@@ -224,7 +225,7 @@ const ChatWindow = memo(function ChatWindow({
     user?.id,
   ]);
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormSubmitEvent) {
     event.preventDefault();
 
     const messageToSend = message.trim();

--- a/src/components/ListingTypeChooser.tsx
+++ b/src/components/ListingTypeChooser.tsx
@@ -6,6 +6,7 @@ import SubmitButton from "@/components/SubmitButton";
 import Form from "@/components/Form";
 import RadioGroup from "@/components/RadioGroup";
 import Radio from "@/components/Radio";
+import type { FormSubmitEvent } from "@/types/events";
 
 type ListingTypeOption = {
   key: string;
@@ -49,7 +50,7 @@ export default function ListingTypeChooser({
     return "/profile/listings/new?type=host";
   }, [mode, selectedOption]);
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: FormSubmitEvent) {
     event.preventDefault();
 
     if (!nextHref) return;

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -6,7 +6,6 @@ import {
   useState,
   type ChangeEvent,
   type ComponentType,
-  type FormEvent,
   type InputHTMLAttributes,
 } from "react";
 import { useRouter } from "next/navigation";
@@ -53,6 +52,7 @@ import type {
   ListingWriteFieldErrors,
   ListingWriteProfile,
 } from "@/types/listing";
+import type { FormSubmitEvent } from "@/types/events";
 
 const DESCRIPTION_MAX_CHARACTERS = 640;
 
@@ -166,7 +166,7 @@ export default function ListingWrite({
         })
       : null);
 
-  async function handleDeleteListing(event: FormEvent<HTMLFormElement>) {
+  async function handleDeleteListing(event: FormSubmitEvent) {
     event.preventDefault();
 
     if (!initialListing || isMutating) {
@@ -196,7 +196,7 @@ export default function ListingWrite({
     }
   }
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormSubmitEvent) {
     event.preventDefault();
 
     if (isMutating) {
@@ -321,16 +321,7 @@ export default function ListingWrite({
         data-hydrated={isHydrated ? "true" : "false"}
       >
         <DisabledFieldset disabled={isMutating}>
-          {listingType === "residential" ? (
-            <AvatarUploadManager
-              initialAvatar={profile?.avatar || ""}
-              bucket="avatars"
-              entityId={user?.id ?? ""}
-              onAvatarChange={setAvatar}
-              inputHintShown={profile?.avatar ? undefined : true}
-              listingType={listingType}
-            />
-          ) : (
+          {listingType !== "residential" && (
             <AvatarUploadManager
               initialAvatar={avatar}
               bucket="listing_avatars"
@@ -617,6 +608,7 @@ export default function ListingWrite({
           <SubmitButton
             data-testid="listing-write-submit"
             variant="primary"
+            width="full"
             pending={submitMutation.isPending}
             pendingText={
               initialListing ? t("Status.saving") : t("Status.adding")

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -282,33 +282,39 @@ export default function ListingWrite({
   }
 
   const addAcceptedItem = () => {
-    setAcceptedItems([...acceptedItems, ""]);
+    setAcceptedItems((currentItems) => [...currentItems, ""]);
   };
 
   const addRejectedItem = () => {
-    setRejectedItems([...rejectedItems, ""]);
+    setRejectedItems((currentItems) => [...currentItems, ""]);
   };
 
   const addLink = () => {
-    setLinks([...links, ""]);
+    setLinks((currentLinks) => [...currentLinks, ""]);
   };
 
   const handleAcceptedItemChange = (index: number, value: string) => {
-    const nextItems = [...acceptedItems];
-    nextItems[index] = value;
-    setAcceptedItems(nextItems);
+    setAcceptedItems((currentItems) => {
+      const nextItems = [...currentItems];
+      nextItems[index] = value;
+      return nextItems;
+    });
   };
 
   const handleRejectedItemChange = (index: number, value: string) => {
-    const nextItems = [...rejectedItems];
-    nextItems[index] = value;
-    setRejectedItems(nextItems);
+    setRejectedItems((currentItems) => {
+      const nextItems = [...currentItems];
+      nextItems[index] = value;
+      return nextItems;
+    });
   };
 
   const handleLinksChange = (index: number, value: string) => {
-    const nextLinks = [...links];
-    nextLinks[index] = value;
-    setLinks(nextLinks);
+    setLinks((currentLinks) => {
+      const nextLinks = [...currentLinks];
+      nextLinks[index] = value;
+      return nextLinks;
+    });
   };
 
   return (

--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -18,6 +18,7 @@ import { isTurnstileEnabled } from "@/utils/utils";
 import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FormSubmitEvent } from "@/types/events";
 
 interface SignUpFormProps {
   defaultValues?: {
@@ -169,7 +170,7 @@ export default function SignUpForm({
     setIsTurnstileInteractive(false);
   }, []);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormSubmitEvent) => {
     event.preventDefault();
     if (isSubmitting || isWaitingForToken) return;
 

--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -257,22 +257,33 @@ export default function SignUpForm({
     }
   };
 
-  const turnstileProps = {
-    ref: turnstileRef,
-    siteKey: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY!,
-    onSuccess: handleTurnstileSuccess,
-    onError: handleTurnstileError,
-    onExpire: handleTurnstileExpire,
-    onTimeout: handleTurnstileTimeout,
-    onUnsupported: handleTurnstileUnsupported,
-    onBeforeInteractive: handleTurnstileBeforeInteractive,
-    onAfterInteractive: handleTurnstileAfterInteractive,
-    options: {
-      appearance: "interaction-only",
-      execution: "execute",
-      responseField: false,
-    } as const,
-  };
+  const turnstileProps = useMemo(
+    () => ({
+      ref: turnstileRef,
+      siteKey: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY!,
+      onSuccess: handleTurnstileSuccess,
+      onError: handleTurnstileError,
+      onExpire: handleTurnstileExpire,
+      onTimeout: handleTurnstileTimeout,
+      onUnsupported: handleTurnstileUnsupported,
+      onBeforeInteractive: handleTurnstileBeforeInteractive,
+      onAfterInteractive: handleTurnstileAfterInteractive,
+      options: {
+        appearance: "interaction-only",
+        execution: "execute",
+        responseField: false,
+      } as const,
+    }),
+    [
+      handleTurnstileAfterInteractive,
+      handleTurnstileBeforeInteractive,
+      handleTurnstileError,
+      handleTurnstileExpire,
+      handleTurnstileSuccess,
+      handleTurnstileTimeout,
+      handleTurnstileUnsupported,
+    ]
+  );
 
   const turnstileContainerStyle = useMemo(
     () =>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,6 +1,6 @@
 import type { SyntheticEvent } from "react";
 
-export type FormSubmitEvent = SyntheticEvent<HTMLFormElement, SubmitEvent>;
+export type FormSubmitEvent = SyntheticEvent<HTMLFormElement>;
 export type FormSubmitHandler = (
   event: FormSubmitEvent
 ) => void | Promise<void>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,6 @@
+import type { SyntheticEvent } from "react";
+
+export type FormSubmitEvent = SyntheticEvent<HTMLFormElement, SubmitEvent>;
+export type FormSubmitHandler = (
+  event: FormSubmitEvent
+) => void | Promise<void>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,6 +1,6 @@
-import type { SyntheticEvent } from "react";
+import type { SubmitEvent as ReactSubmitEvent } from "react";
 
-export type FormSubmitEvent = SyntheticEvent<HTMLFormElement>;
+export type FormSubmitEvent = ReactSubmitEvent<HTMLFormElement>;
 export type FormSubmitHandler = (
   event: FormSubmitEvent
 ) => void | Promise<void>;


### PR DESCRIPTION
## Summary
- replace explicit deprecated React form submit typings with shared precise submit-event types
- speed up listing edit data loading with narrower selects and parallel server work
- remove residential listing avatar editing from listing forms while keeping profile avatar editing on the profile page
- apply a focused React/Vercel best-practices grooming pass to the touched form and chat surfaces

## Validation
- npm run typecheck
- npm run check
- npm run build
- CI=1 npm run test:e2e:prod

## Notes
- homepage hydration investigation is intentionally out of scope for this PR
- residential avatars remain owned by profile editing rather than listing editing