### PR TITLE
harden auth account and locale mutation UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # next.js
 /.next/
 /out/
+/.swc/
 
 # production
 /build

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { HOST_EMAIL, SEEDED_THREAD_ID, signIn } from "./helpers";
+import {
+  HOST_EMAIL,
+  SEEDED_PASSWORD,
+  SEEDED_THREAD_ID,
+  delayServerActionRequests,
+  signIn,
+} from "./helpers";
 
 test("public listing shows the seeded public listing and guest contact gate", async ({
   page,
@@ -44,4 +50,44 @@ test("guest chats redirect preserves the requested chat path", async ({
     new RegExp(`/sign-in\\?redirect_to=/?chats/${SEEDED_THREAD_ID}$`)
   );
   await expect(page.getByTestId("sign-in-form")).toBeVisible();
+});
+
+test("sign-up shows client validation feedback before submitting", async ({
+  page,
+}) => {
+  await page.goto("/sign-up");
+
+  await page.locator('input[name="first_name"]').fill("@@");
+  await page.locator('input[name="email"]').fill("new-person@example.com");
+  await page.locator('input[name="password"]').fill(SEEDED_PASSWORD);
+  await page.locator('input[name="legal_agreement"]').check();
+  await page.getByTestId("sign-up-submit").click();
+
+  await expect(page.getByTestId("sign-up-first-name-error")).toBeVisible();
+  await expect(page.getByTestId("sign-up-form")).toContainText(
+    /Please fix the above error/
+  );
+});
+
+test("sign-up shows pending feedback and preserves server errors", async ({
+  page,
+}) => {
+  await delayServerActionRequests(page);
+  await page.goto("/sign-up");
+
+  await page.locator('input[name="first_name"]').fill("Avery");
+  await page.locator('input[name="email"]').fill(HOST_EMAIL);
+  await page.locator('input[name="password"]').fill(SEEDED_PASSWORD);
+  await page.locator('input[name="legal_agreement"]').check();
+
+  const submitButton = page.getByTestId("sign-up-submit");
+  const submitClick = submitButton.click();
+  await expect(submitButton).toBeDisabled();
+  await expect(submitButton).toHaveAttribute("aria-busy", "true");
+  await submitClick;
+
+  await expect(page).toHaveURL(/\/sign-up\?.*error=/);
+  await expect(page.getByTestId("sign-up-form")).toContainText(
+    /already exists/i
+  );
 });

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -5,14 +5,7 @@ import {
   delayServerActionRequests,
   signIn,
 } from "./helpers";
-
-const languageLabels: Record<string, string> = {
-  de: "Deutsch",
-  en: "English",
-  es: "Español",
-  fr: "Français",
-  "pt-BR": "Português (Brasil)",
-};
+import { isValidLocale, localeLabels, type Locale } from "../src/i18n/config";
 
 test("public footer locale switch refreshes the page locale", async ({
   page,
@@ -39,7 +32,13 @@ test("profile locale change persists after refresh", async ({ page }) => {
   await page.getByTestId("profile-account-language-edit").click();
   const languageInput = page.getByTestId("profile-account-language-input");
   const originalLanguage = await languageInput.inputValue();
-  const updatedLanguage = originalLanguage === "de" ? "en" : "de";
+
+  if (!isValidLocale(originalLanguage)) {
+    throw new Error(`Unexpected profile language value: ${originalLanguage}`);
+  }
+
+  const originalLocale: Locale = originalLanguage;
+  const updatedLanguage: Locale = originalLocale === "de" ? "en" : "de";
 
   await languageInput.selectOption(updatedLanguage);
 
@@ -49,7 +48,7 @@ test("profile locale change persists after refresh", async ({ page }) => {
   await expect(languageSubmit).toHaveAttribute("aria-busy", "true");
   await languageClick;
   await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    languageLabels[updatedLanguage]
+    localeLabels[updatedLanguage]
   );
 
   await page.reload();
@@ -60,13 +59,13 @@ test("profile locale change persists after refresh", async ({ page }) => {
   await page.getByTestId("profile-account-language-edit").click();
   await page
     .getByTestId("profile-account-language-input")
-    .selectOption(originalLanguage);
+    .selectOption(originalLocale);
   await page.getByTestId("profile-account-language-submit").click();
   await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    languageLabels[originalLanguage]
+    localeLabels[originalLocale]
   );
   await page.reload();
-  await expect(page.locator("html")).toHaveAttribute("lang", originalLanguage, {
+  await expect(page.locator("html")).toHaveAttribute("lang", originalLocale, {
     timeout: 15_000,
   });
 });

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,23 +1,40 @@
 import { expect, test } from "@playwright/test";
-import { HOST_EMAIL, delayProfileActionRequests, signIn } from "./helpers";
+import {
+  HOST_EMAIL,
+  delayProfileActionRequests,
+  delayServerActionRequests,
+  signIn,
+} from "./helpers";
+
+const languageLabels: Record<string, string> = {
+  de: "Deutsch",
+  en: "English",
+  es: "Español",
+  fr: "Français",
+  "pt-BR": "Português (Brasil)",
+};
 
 test("public footer locale switch refreshes the page locale", async ({
   page,
 }) => {
+  await delayServerActionRequests(page);
   await page.goto("/");
 
   await expect(page.locator("html")).toHaveAttribute("lang", "en");
-  await page.getByTestId("locale-picker-select").selectOption("de");
+  const localeSelect = page.getByTestId("locale-picker-select");
+  const localeChange = localeSelect.selectOption("de");
+  await expect(localeSelect).toBeDisabled();
+  await expect(localeSelect).toHaveAttribute("aria-busy", "true");
+  await localeChange;
   await expect(page.locator("html")).toHaveAttribute("lang", "de", {
     timeout: 15_000,
   });
-  await expect(page.getByTestId("locale-picker-select")).toHaveValue("de");
+  await expect(localeSelect).toHaveValue("de");
 });
 
 test("profile locale change persists after refresh", async ({ page }) => {
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
   await delayProfileActionRequests(page);
-  await page.waitForTimeout(3_000);
 
   await page.getByTestId("profile-account-language-edit").click();
   const languageInput = page.getByTestId("profile-account-language-input");
@@ -31,7 +48,9 @@ test("profile locale change persists after refresh", async ({ page }) => {
   await expect(languageSubmit).toBeDisabled();
   await expect(languageSubmit).toHaveAttribute("aria-busy", "true");
   await languageClick;
-  await page.waitForTimeout(2_000);
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    languageLabels[updatedLanguage]
+  );
 
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", updatedLanguage, {
@@ -43,7 +62,9 @@ test("profile locale change persists after refresh", async ({ page }) => {
     .getByTestId("profile-account-language-input")
     .selectOption(originalLanguage);
   await page.getByTestId("profile-account-language-submit").click();
-  await page.waitForTimeout(2_000);
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    languageLabels[originalLanguage]
+  );
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", originalLanguage, {
     timeout: 15_000,

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -68,3 +68,34 @@ test("profile account actions show pending feedback and update the read view", a
   ).toHaveValue(originalNewsletterPreference);
   await page.getByRole("button", { name: /cancel|abbrechen/i }).click();
 });
+
+test("profile email edit shows pending and inline error feedback", async ({
+  page,
+}) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+  await delayProfileActionRequests(page);
+
+  await page.getByTestId("profile-account-email-edit").click();
+  const emailInput = page.getByTestId("profile-account-email-input");
+  await emailInput.fill(HOST_EMAIL);
+
+  const emailSubmit = page.getByTestId("profile-account-email-submit");
+  const emailClick = emailSubmit.click();
+  await expect(emailSubmit).toBeDisabled();
+  await expect(emailSubmit).toHaveAttribute("aria-busy", "true");
+  await emailClick;
+
+  await expect(page.getByTestId("profile-account-email-message")).toContainText(
+    /already.*email/i
+  );
+  await expect(page.getByTestId("profile-account-email-form")).toBeVisible();
+});
+
+test("danger dialogs focus the safe cancel action first", async ({ page }) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+  await page.getByRole("button", { name: "Delete account" }).click();
+
+  await expect(page.getByTestId("dialog-cancel-button")).toBeFocused();
+  await expect(page.getByTestId("dialog-confirm-button")).not.toBeFocused();
+});

--- a/messages/de.json
+++ b/messages/de.json
@@ -235,6 +235,7 @@
     },
     "turnstile": {
       "expired": "Die Verifizierung ist abgelaufen. Bitte schließe sie erneut ab.",
+      "notReady": "Die Sicherheitsverifizierung wird noch geladen. Bitte versuche es gleich erneut.",
       "timeout": "Die Sicherheitsprüfung wurde nicht abgeschlossen. Deaktiviere Werbeblocker und versuche es erneut. Wenn es weiterhin fehlschlägt, probiere einen anderen Browser oder ein anderes Netzwerk.",
       "unsupported": "Dieser Browser kann die Sicherheitsprüfung nicht abschließen. Bitte probiere einen anderen Browser oder ein anderes Netzwerk.",
       "failed": "Die Sicherheitsverifizierung ist mit Fehler #{code} fehlgeschlagen. Bitte versuche es erneut oder nutze einen anderen Browser."

--- a/messages/en.json
+++ b/messages/en.json
@@ -235,6 +235,7 @@
     },
     "turnstile": {
       "expired": "Verification expired. Please complete it again.",
+      "notReady": "Security verification is still loading. Please try again in a moment.",
       "timeout": "Security check didn’t complete. Try disabling ad blockers and then try again. If it still fails, try a different browser or network.",
       "unsupported": "This browser can’t complete the security check. Please try a different browser or network.",
       "failed": "Security verification failed with error #{code}. Please try again or use a different browser."

--- a/messages/es.json
+++ b/messages/es.json
@@ -235,6 +235,7 @@
     },
     "turnstile": {
       "expired": "La verificación caducó. Complétala de nuevo.",
+      "notReady": "La verificación de seguridad todavía se está cargando. Inténtalo de nuevo en un momento.",
       "timeout": "La comprobación de seguridad no se completó. Prueba desactivar bloqueadores de anuncios y vuelve a intentarlo. Si sigue fallando, prueba otro navegador o red.",
       "unsupported": "Este navegador no puede completar la comprobación de seguridad. Prueba otro navegador o red.",
       "failed": "La verificación de seguridad falló con el error #{code}. Inténtalo de nuevo o usa otro navegador."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -235,6 +235,7 @@
     },
     "turnstile": {
       "expired": "La vérification a expiré. Veuillez la terminer de nouveau.",
+      "notReady": "La vérification de sécurité est encore en cours de chargement. Veuillez réessayer dans un instant.",
       "timeout": "Le contrôle de sécurité ne s’est pas terminé. Essayez de désactiver les bloqueurs de publicité puis réessayez. Si cela échoue encore, essayez un autre navigateur ou un autre réseau.",
       "unsupported": "Ce navigateur ne peut pas effectuer le contrôle de sécurité. Veuillez essayer un autre navigateur ou un autre réseau.",
       "failed": "La vérification de sécurité a échoué avec l’erreur n°{code}. Veuillez réessayer ou utiliser un autre navigateur."

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -235,6 +235,7 @@
     },
     "turnstile": {
       "expired": "A verificação expirou. Conclua-a novamente.",
+      "notReady": "A verificação de segurança ainda está carregando. Tente novamente em instantes.",
       "timeout": "A verificação de segurança não foi concluída. Tente desativar bloqueadores de anúncios e tente de novo. Se continuar falhando, use outro navegador ou outra rede.",
       "unsupported": "Este navegador não consegue concluir a verificação de segurança. Tente outro navegador ou outra rede.",
       "failed": "A verificação de segurança falhou com o erro #{code}. Tente novamente ou use outro navegador."

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -67,6 +67,10 @@ type UpdatePreferredLocaleActionData = {
   preferredLocale: Locale;
 };
 
+type SetDisplayLocaleActionData = {
+  locale: Locale;
+};
+
 function getActionFormData<T>(
   previousStateOrFormData: FormData | InlineActionResult<T>,
   maybeFormData?: FormData
@@ -458,17 +462,22 @@ export async function updateNewsletterPreferenceAction(
   });
 }
 
-export const setDisplayLocaleAction = async (formData: FormData) => {
+export const setDisplayLocaleAction = async (
+  formData: FormData
+): Promise<InlineActionResult<SetDisplayLocaleActionData>> => {
+  const t = await getTranslations("Errors");
   const nextLocale = normaliseLocale(formData.get("locale")?.toString());
 
   if (!nextLocale) {
-    return { error: "Invalid locale" };
+    return actionError<SetDisplayLocaleActionData>(t("generic"));
   }
 
   await setUserLocale(nextLocale);
   revalidatePath("/", "layout");
 
-  return { success: true };
+  return actionSuccess<SetDisplayLocaleActionData>({
+    locale: nextLocale,
+  });
 };
 
 export async function updatePreferredLocaleAction(

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -6,7 +6,13 @@ import Button from "@/components/Button";
 import SubmitButton from "@/components/SubmitButton";
 
 import { styled } from "next-yak";
-import { useState, type FormHTMLAttributes, type ReactNode } from "react";
+import {
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type FormHTMLAttributes,
+  type ReactNode,
+} from "react";
 import { useTranslations } from "next-intl";
 import type { FormSubmitHandler } from "@/types/events";
 
@@ -92,11 +98,24 @@ function ButtonToDialog({
 }: ButtonToDialogProps) {
   const t = useTranslations();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const cancelButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
   const resolvedConfirmLoadingText =
     confirmLoadingText ||
     (variant === "danger" ? t("Status.deleting") : t("Status.working"));
   const resolvedCancelButtonText = cancelButtonText || t("Actions.noCancel");
   const isPending = pending || isSubmitting;
+  const handleOpenAutoFocus: ComponentPropsWithoutRef<
+    typeof Dialog.Content
+  >["onOpenAutoFocus"] = (event) => {
+    if (variant !== "danger") {
+      return;
+    }
+
+    event.preventDefault();
+    requestAnimationFrame(() => {
+      cancelButtonRef.current?.focus();
+    });
+  };
 
   const handleSubmit: FormSubmitHandler | undefined = onSubmit
     ? async (event) => {
@@ -127,7 +146,7 @@ function ButtonToDialog({
         </Button>
       </Dialog.Trigger>
       <DialogOverlay />
-      <DialogContent>
+      <DialogContent onOpenAutoFocus={handleOpenAutoFocus}>
         <Text>
           <Dialog.Title>{dialogTitle}</Dialog.Title>
           <Dialog.Description>{children}</Dialog.Description>
@@ -141,8 +160,7 @@ function ButtonToDialog({
                 disabled={disabled || isPending}
                 pending={isPending}
                 pendingText={resolvedConfirmLoadingText}
-                // tabIndex={undefined} // Doesn't work. See below.
-                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
+                data-testid="dialog-confirm-button"
               >
                 {confirmButtonText}
               </SubmitButton>
@@ -155,15 +173,20 @@ function ButtonToDialog({
                 disabled={disabled || isPending}
                 loading={isPending}
                 loadingText={resolvedConfirmLoadingText}
-                // tabIndex={undefined} // Doesn't work. See below.
-                autoFocus={variant === "danger" ? false : undefined} // Doesn't work. TODO: Make it so this button isn't tabbed to by default (but can be for accessibility)
+                data-testid="dialog-confirm-button"
               >
                 {confirmButtonText}
               </SubmitButton>
             </form>
           ) : null}
           <Dialog.Close asChild>
-            <Button variant="secondary" width="contained" disabled={isPending}>
+            <Button
+              ref={cancelButtonRef}
+              variant="secondary"
+              width="contained"
+              disabled={isPending}
+              data-testid="dialog-cancel-button"
+            >
               {resolvedCancelButtonText}
             </Button>
           </Dialog.Close>

--- a/src/components/FormMessage/FormMessage.tsx
+++ b/src/components/FormMessage/FormMessage.tsx
@@ -31,8 +31,14 @@ export type Message = {
 };
 
 export default function FormMessage({ message }: { message: Message }) {
+  const variant = "success" in message ? "success" : "error";
+
   return (
-    <StyledFormMessage $variant={"success" in message ? "success" : "error"}>
+    <StyledFormMessage
+      $variant={variant}
+      role={variant === "error" ? "alert" : "status"}
+      aria-live={variant === "error" ? "assertive" : "polite"}
+    >
       {"success" in message && <p>{message.success}</p>}
       {"error" in message && <p>{message.error}</p>}
     </StyledFormMessage>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,7 @@
-import { Input as HeadlessInput } from "@headlessui/react";
+import {
+  Input as HeadlessInput,
+  type InputProps as HeadlessInputProps,
+} from "@headlessui/react";
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 
@@ -29,6 +32,10 @@ const StyledInput = styled(HeadlessInput)`
   }
 `;
 
-export default function Input({ error = null, ...props }) {
+type InputProps = Omit<HeadlessInputProps, "invalid"> & {
+  error?: string | null;
+};
+
+export default function Input({ error = null, ...props }: InputProps) {
   return <StyledInput invalid={error ? true : undefined} {...props} />;
 }

--- a/src/components/InputHint/InputHint.tsx
+++ b/src/components/InputHint/InputHint.tsx
@@ -1,7 +1,7 @@
 import { Description as HeadlessDescription } from "@headlessui/react";
 import { css, styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
-import type { ReactNode } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
 
 const errorHintStyles = css`
   color: ${theme.colors.input.invalid.text};
@@ -26,14 +26,14 @@ const StyledInputHint = styled(HeadlessDescription)<{
   ${({ $variant }) => $variant === "centered" && centredHintStyles}
 `;
 
-type InputHintProps = {
+type InputHintProps = HTMLAttributes<HTMLElement> & {
   variant?: InputHintVariant;
   children?: ReactNode;
 };
 
-function InputHint({ variant, children }: InputHintProps) {
+function InputHint({ variant, children, ...props }: InputHintProps) {
   return (
-    <StyledInputHint $variant={variant ? variant : undefined}>
+    <StyledInputHint $variant={variant ? variant : undefined} {...props}>
       {children}
     </StyledInputHint>
   );

--- a/src/components/LocalePicker/LocalePicker.tsx
+++ b/src/components/LocalePicker/LocalePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { localeLabels, locales, type Locale } from "@/i18n/config";
 import { setDisplayLocaleAction } from "@/app/actions";
@@ -32,31 +32,42 @@ export default function LocalePicker({
 }: LocalePickerProps) {
   const t = useTranslations();
   const locale = useLocale() as Locale;
-  const [isPending, startTransition] = useTransition();
+  const [selectedLocale, setSelectedLocale] = useState(locale);
+  const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (nextLocale: Locale) => {
-    startTransition(() => {
-      void (async () => {
-        setError(null);
+  useEffect(() => {
+    setSelectedLocale(locale);
+  }, [locale]);
 
-        try {
-          const formData = new FormData();
-          formData.set("locale", nextLocale);
-          const result = await setDisplayLocaleAction(formData);
+  const handleChange = async (nextLocale: Locale) => {
+    if (isPending) {
+      return;
+    }
 
-          if (result?.error) {
-            setError(t("Errors.genericLater"));
-            return;
-          }
+    setSelectedLocale(nextLocale);
+    setError(null);
+    setIsPending(true);
 
-          window.location.reload();
-        } catch (error) {
-          console.error("Error updating display locale:", error);
-          setError(t("Errors.genericLater"));
-        }
-      })();
-    });
+    try {
+      const formData = new FormData();
+      formData.set("locale", nextLocale);
+      const result = await setDisplayLocaleAction(formData);
+
+      if (!result.success || result.error) {
+        setSelectedLocale(locale);
+        setError(result.error || t("Errors.genericLater"));
+        setIsPending(false);
+        return;
+      }
+
+      window.location.reload();
+    } catch (error) {
+      console.error("Error updating display locale:", error);
+      setSelectedLocale(locale);
+      setError(t("Errors.genericLater"));
+      setIsPending(false);
+    }
   };
 
   return (
@@ -65,9 +76,9 @@ export default function LocalePicker({
         <Select
           variant={compact ? "compact" : "default"}
           name="locale"
-          value={locale}
+          value={selectedLocale}
           onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-            handleChange(event.target.value as Locale)
+            void handleChange(event.target.value as Locale)
           }
           disabled={isPending}
           aria-busy={isPending || undefined}
@@ -81,9 +92,13 @@ export default function LocalePicker({
           ))}
         </Select>
         {error ? (
-          <InputHint variant="error">{error}</InputHint>
+          <InputHint variant="error" data-testid="locale-picker-message">
+            {error}
+          </InputHint>
         ) : showHint ? (
-          <InputHint variant="default">{t("Common.languageHint")}</InputHint>
+          <InputHint variant="default" data-testid="locale-picker-message">
+            {t("Common.languageHint")}
+          </InputHint>
         ) : null}
       </Field>
     </Container>

--- a/src/components/LocalePicker/LocalePicker.tsx
+++ b/src/components/LocalePicker/LocalePicker.tsx
@@ -57,7 +57,6 @@ export default function LocalePicker({
       if (!result.success || result.error) {
         setSelectedLocale(locale);
         setError(result.error || t("Errors.genericLater"));
-        setIsPending(false);
         return;
       }
 
@@ -66,6 +65,7 @@ export default function LocalePicker({
       console.error("Error updating display locale:", error);
       setSelectedLocale(locale);
       setError(t("Errors.genericLater"));
+    } finally {
       setIsPending(false);
     }
   };

--- a/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
+++ b/src/components/ProfileAccountSettings/ProfileAccountSettings.tsx
@@ -71,7 +71,6 @@ const PasswordPreview = styled.p`
   user-select: none;
 `;
 
-const InputComponent = Input as React.ComponentType<any>;
 const nestedFormStyle = {
   width: "100%",
   display: "flex",
@@ -200,17 +199,29 @@ function FirstNameEditor({
   }, [onSaved, state.data?.firstName, state.success]);
 
   return (
-    <form style={nestedFormStyle} data-testid="profile-account-first-name-form">
+    <form
+      style={nestedFormStyle}
+      aria-busy={isPending || undefined}
+      data-testid="profile-account-first-name-form"
+    >
       <Field>
         <Label>{t("Profile.account.firstName")}</Label>
-        <InputComponent
+        <Input
           name="first_name"
           {...FIELD_CONFIGS.firstName}
           defaultValue={currentFirstName}
           error={state.error}
+          disabled={isPending}
           data-testid="profile-account-first-name-input"
         />
-        {state.error && <InputHint variant="error">{state.error}</InputHint>}
+        {state.error && (
+          <InputHint
+            variant="error"
+            data-testid="profile-account-first-name-message"
+          >
+            {state.error}
+          </InputHint>
+        )}
       </Field>
 
       <ButtonGroup>
@@ -243,18 +254,24 @@ function EmailEditor({
   );
 
   return (
-    <form style={nestedFormStyle} data-testid="profile-account-email-form">
+    <form
+      style={nestedFormStyle}
+      aria-busy={isPending || undefined}
+      data-testid="profile-account-email-form"
+    >
       <input type="hidden" name="locale" value={currentLocale} />
       <Field>
         <Label>{t("Common.email")}</Label>
-        <InputComponent
+        <Input
           name="email"
           defaultValue={currentEmail}
           {...FIELD_CONFIGS.email}
           error={state.error}
+          disabled={isPending}
           data-testid="profile-account-email-input"
         />
         <InputHint
+          data-testid="profile-account-email-message"
           variant={
             state.error ? "error" : state.success ? "success" : "default"
           }
@@ -305,7 +322,11 @@ function NewsletterPreferenceEditor({
   }, [onSaved, state.data?.newsletterPreference, state.success]);
 
   return (
-    <form style={nestedFormStyle} data-testid="profile-account-newsletter-form">
+    <form
+      style={nestedFormStyle}
+      aria-busy={isPending || undefined}
+      data-testid="profile-account-newsletter-form"
+    >
       <Field>
         <Label>{t("Common.newsletter")}</Label>
         <Select
@@ -321,7 +342,10 @@ function NewsletterPreferenceEditor({
           <option value="false">{t("Common.notSubscribed")}</option>
           <option value="true">{t("Common.subscribed")}</option>
         </Select>
-        <InputHint variant={state.error ? "error" : "default"}>
+        <InputHint
+          variant={state.error ? "error" : "default"}
+          data-testid="profile-account-newsletter-message"
+        >
           {state.error
             ? state.error
             : currentPreference
@@ -367,7 +391,11 @@ function PreferredLocaleEditor({
   }, [onSaved, state.data?.preferredLocale, state.success]);
 
   return (
-    <form style={nestedFormStyle} data-testid="profile-account-language-form">
+    <form
+      style={nestedFormStyle}
+      aria-busy={isPending || undefined}
+      data-testid="profile-account-language-form"
+    >
       <Field>
         <Label>{t("Common.language")}</Label>
         <Select
@@ -386,7 +414,10 @@ function PreferredLocaleEditor({
             </option>
           ))}
         </Select>
-        <InputHint variant={state.error ? "error" : "default"}>
+        <InputHint
+          variant={state.error ? "error" : "default"}
+          data-testid="profile-account-language-message"
+        >
           {state.error ? state.error : t("Profile.account.languageHint")}
         </InputHint>
       </Field>

--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -49,6 +49,7 @@ export default function SignUpForm({
     enabled: turnstileEnabled,
     expiredMessage: t("Auth.turnstile.expired"),
     failedMessage,
+    notReadyMessage: t("Auth.turnstile.notReady"),
     siteKey: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY ?? "",
     timeoutMessage,
     unsupportedMessage: t("Auth.turnstile.unsupported"),

--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -1,4 +1,9 @@
 "use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Turnstile } from "@marsidev/react-turnstile";
+import { useTranslations } from "next-intl";
+
 import { signUpAction } from "@/app/actions";
 import Button from "@/components/Button";
 import CheckboxCluster from "@/components/CheckboxCluster";
@@ -11,14 +16,12 @@ import Input from "@/components/Input";
 import InputHint from "@/components/InputHint";
 import Label from "@/components/Label";
 import LegalAgreement from "@/components/LegalAgreement";
+import { useTurnstileToken } from "@/components/SignUpForm/useTurnstileToken";
 import { siteConfig } from "@/config/site";
 import { FIELD_CONFIGS, validateFirstName } from "@/lib/formValidation";
+import type { FormSubmitEvent } from "@/types/events";
 import { getStoredAttributionParams } from "@/utils/attributionUtils";
 import { isTurnstileEnabled } from "@/utils/utils";
-import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
-import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { FormSubmitEvent } from "@/types/events";
 
 interface SignUpFormProps {
   defaultValues?: {
@@ -29,160 +32,48 @@ interface SignUpFormProps {
   error?: string;
 }
 
-const BACKGROUND_TOKEN_TIMEOUT = 10000;
-const INTERACTIVE_TOKEN_TIMEOUT = 120000;
-
 export default function SignUpForm({
   defaultValues = {},
   error,
 }: SignUpFormProps) {
   const t = useTranslations();
-  const expiredMessage = t("Auth.turnstile.expired");
   const timeoutMessage = t("Auth.turnstile.timeout");
-  const unsupportedMessage = t("Auth.turnstile.unsupported");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [firstNameError, setFirstNameError] = useState<string | null>(null);
-
-  const [captchaError, setCaptchaError] = useState<string | null>(null);
-  const [isWaitingForToken, setIsWaitingForToken] = useState(false);
-  const [isTurnstileInteractive, setIsTurnstileInteractive] = useState(false);
-
-  const turnstileRef = useRef<TurnstileInstance>(null);
-  const tokenResolverRef = useRef<((token: string) => void) | null>(null);
-  const tokenRejecterRef = useRef<((error: Error) => void) | null>(null);
-  const tokenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const turnstileEnabled = isTurnstileEnabled();
+  const failedMessage = useCallback(
+    (code: string) => t("Auth.turnstile.failed", { code }),
+    [t]
+  );
+  const turnstile = useTurnstileToken({
+    enabled: turnstileEnabled,
+    expiredMessage: t("Auth.turnstile.expired"),
+    failedMessage,
+    siteKey: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY ?? "",
+    timeoutMessage,
+    unsupportedMessage: t("Auth.turnstile.unsupported"),
+  });
+  const captchaError = turnstile.error;
+  const isBusy = isSubmitting || turnstile.isWaitingForToken;
   const fieldErrorCount =
     Number(Boolean(firstNameError)) + Number(Boolean(captchaError));
   const hasFieldErrors = fieldErrorCount > 0;
 
-  const clearTokenTimeout = useCallback(() => {
-    if (tokenTimeoutRef.current) {
-      clearTimeout(tokenTimeoutRef.current);
-      tokenTimeoutRef.current = null;
-    }
-  }, []);
-
-  const clearTokenPromise = useCallback(() => {
-    tokenResolverRef.current = null;
-    tokenRejecterRef.current = null;
-    clearTokenTimeout();
-  }, [clearTokenTimeout]);
-
-  const rejectTokenPromise = useCallback(
-    (errorMessage: string) => {
-      if (tokenRejecterRef.current) {
-        tokenRejecterRef.current(new Error(errorMessage));
-      }
-      clearTokenPromise();
-    },
-    [clearTokenPromise]
-  );
-
-  const scheduleTokenTimeout = useCallback(
-    (timeout: number, errorMessage = timeoutMessage) => {
-      clearTokenTimeout();
-      tokenTimeoutRef.current = setTimeout(() => {
-        rejectTokenPromise(errorMessage);
-      }, timeout);
-    },
-    [clearTokenTimeout, rejectTokenPromise, timeoutMessage]
-  );
-
-  // Promise-based token wait mechanism with timeout
-  const waitForToken = useCallback(
-    (timeout = BACKGROUND_TOKEN_TIMEOUT): Promise<string> => {
-      return new Promise((resolve, reject) => {
-        // Store resolvers for onSuccess/onError callbacks
-        tokenResolverRef.current = resolve;
-        tokenRejecterRef.current = reject;
-
-        scheduleTokenTimeout(timeout);
-      });
-    },
-    [scheduleTokenTimeout]
-  );
-
-  const resolveTokenPromise = useCallback(
-    (token: string) => {
-      if (tokenResolverRef.current) {
-        tokenResolverRef.current(token);
-      }
-      clearTokenPromise();
-    },
-    [clearTokenPromise]
-  );
-
-  useEffect(() => clearTokenTimeout, [clearTokenTimeout]);
-
-  const handleTurnstileSuccess = useCallback(
-    (token: string) => {
-      setCaptchaError(null);
-      setIsWaitingForToken(false);
-      setIsTurnstileInteractive(false);
-      resolveTokenPromise(token);
-    },
-    [resolveTokenPromise]
-  );
-
-  const handleTurnstileError = useCallback(
-    (error: string) => {
-      setIsWaitingForToken(false);
-      setIsTurnstileInteractive(false);
-
-      const errorMessage = t("Auth.turnstile.failed", { code: error });
-
-      setCaptchaError(errorMessage);
-      rejectTokenPromise(errorMessage);
-    },
-    [rejectTokenPromise, t]
-  );
-
-  const handleTurnstileExpire = useCallback(() => {
-    setIsWaitingForToken(false);
-    setIsTurnstileInteractive(false);
-    setCaptchaError(expiredMessage);
-    rejectTokenPromise(expiredMessage);
-  }, [expiredMessage, rejectTokenPromise]);
-
-  const handleTurnstileTimeout = useCallback(() => {
-    setIsWaitingForToken(false);
-    setIsTurnstileInteractive(false);
-    setCaptchaError(timeoutMessage);
-    rejectTokenPromise(timeoutMessage);
-  }, [rejectTokenPromise, timeoutMessage]);
-
-  const handleTurnstileUnsupported = useCallback(() => {
-    setIsWaitingForToken(false);
-    setIsTurnstileInteractive(false);
-    setCaptchaError(unsupportedMessage);
-    rejectTokenPromise(unsupportedMessage);
-  }, [rejectTokenPromise, unsupportedMessage]);
-
-  const handleTurnstileBeforeInteractive = useCallback(() => {
-    setCaptchaError(null);
-    setIsTurnstileInteractive(true);
-    scheduleTokenTimeout(INTERACTIVE_TOKEN_TIMEOUT);
-  }, [scheduleTokenTimeout]);
-
-  const handleTurnstileAfterInteractive = useCallback(() => {
-    setIsTurnstileInteractive(false);
-  }, []);
-
   const handleSubmit = async (event: FormSubmitEvent) => {
     event.preventDefault();
-    if (isSubmitting || isWaitingForToken) return;
 
-    // Reset validation errors
+    if (isBusy) {
+      return;
+    }
+
     setFirstNameError(null);
-    setCaptchaError(null);
+    turnstile.resetError();
 
-    // Client-side validation
     const formData = new FormData(event.currentTarget);
     const validation = validateFirstName(
       formData.get("first_name")?.toString()
     );
+
     if (!validation.isValid) {
       switch (validation.error) {
         case "empty":
@@ -207,44 +98,21 @@ export default function SignUpForm({
       return;
     }
 
-    // Handle Turnstile token generation if enabled
-    // Always get a fresh token as they are single-use and never reused
     let tokenToUse: string | undefined;
-    if (turnstileEnabled) {
-      // Reset any existing token to ensure we get a fresh one
-      turnstileRef.current?.reset();
-
-      setIsWaitingForToken(true);
-      try {
-        // Start waiting before execution so a fast success callback cannot race us.
-        const tokenPromise = waitForToken(BACKGROUND_TOKEN_TIMEOUT);
-
-        turnstileRef.current?.execute();
-
-        // Wait for token with timeout
-        tokenToUse = await tokenPromise;
-
-        // Token obtained, proceed with submission
-        setIsWaitingForToken(false);
-        setIsSubmitting(true);
-      } catch (error) {
-        setIsWaitingForToken(false);
-        setCaptchaError(
-          error instanceof Error ? error.message : timeoutMessage
-        );
-        return;
-      }
-    } else {
-      setIsSubmitting(true);
-    }
 
     try {
-      // Add captcha token to form data if available
+      tokenToUse = await turnstile.requestToken();
+    } catch {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
       if (tokenToUse) {
         formData.append("captcha_token", tokenToUse);
       }
 
-      // Add stored UTM parameters to form data
       const utmParams = getStoredAttributionParams();
       Object.entries(utmParams).forEach(([key, value]) => {
         if (value && typeof value === "string") formData.append(key, value);
@@ -257,37 +125,9 @@ export default function SignUpForm({
     }
   };
 
-  const turnstileProps = useMemo(
-    () => ({
-      ref: turnstileRef,
-      siteKey: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY!,
-      onSuccess: handleTurnstileSuccess,
-      onError: handleTurnstileError,
-      onExpire: handleTurnstileExpire,
-      onTimeout: handleTurnstileTimeout,
-      onUnsupported: handleTurnstileUnsupported,
-      onBeforeInteractive: handleTurnstileBeforeInteractive,
-      onAfterInteractive: handleTurnstileAfterInteractive,
-      options: {
-        appearance: "interaction-only",
-        execution: "execute",
-        responseField: false,
-      } as const,
-    }),
-    [
-      handleTurnstileAfterInteractive,
-      handleTurnstileBeforeInteractive,
-      handleTurnstileError,
-      handleTurnstileExpire,
-      handleTurnstileSuccess,
-      handleTurnstileTimeout,
-      handleTurnstileUnsupported,
-    ]
-  );
-
   const turnstileContainerStyle = useMemo(
     () =>
-      isTurnstileInteractive || captchaError
+      turnstile.isInteractive || captchaError
         ? undefined
         : ({
             position: "absolute",
@@ -296,22 +136,28 @@ export default function SignUpForm({
             overflow: "hidden",
             clipPath: "inset(50%)",
           } as const),
-    [captchaError, isTurnstileInteractive]
+    [captchaError, turnstile.isInteractive]
   );
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form
+      onSubmit={handleSubmit}
+      aria-busy={isBusy || undefined}
+      data-testid="sign-up-form"
+    >
       <Field>
         <Label htmlFor="first_name">{t("Auth.signUp.firstName")}</Label>
         <Input
           name="first_name"
           {...FIELD_CONFIGS.firstName}
           defaultValue={defaultValues.first_name}
-          // @ts-expect-error: Input accepts any truthy value at runtime for error, but type is inferred as null | undefined
           error={firstNameError}
+          disabled={isBusy}
         />
         {firstNameError && (
-          <InputHint variant="error">{firstNameError}</InputHint>
+          <InputHint variant="error" data-testid="sign-up-first-name-error">
+            {firstNameError}
+          </InputHint>
         )}
       </Field>
 
@@ -321,6 +167,7 @@ export default function SignUpForm({
           name="email"
           {...FIELD_CONFIGS.email}
           defaultValue={defaultValues.email}
+          disabled={isBusy}
         />
       </Field>
 
@@ -330,15 +177,17 @@ export default function SignUpForm({
           name="password"
           {...FIELD_CONFIGS.password}
           placeholder={t("Auth.signUp.newPassword")}
+          disabled={isBusy}
         />
       </Field>
 
       <CheckboxCluster>
-        <LegalAgreement required={true} />
+        <LegalAgreement required={true} disabled={isBusy} />
         <CheckboxRow
           name="newsletter_preference"
           required={false}
           defaultChecked={defaultValues.newsletter_preference}
+          disabled={isBusy}
         >
           {t("Auth.signUp.newsletterOptIn")}
         </CheckboxRow>
@@ -346,9 +195,11 @@ export default function SignUpForm({
 
       {turnstileEnabled && (
         <Field style={turnstileContainerStyle}>
-          <Turnstile {...turnstileProps} />
+          <Turnstile {...turnstile.turnstileProps} />
           {captchaError && (
-            <InputHint variant="error">{captchaError}</InputHint>
+            <InputHint variant="error" data-testid="sign-up-captcha-error">
+              {captchaError}
+            </InputHint>
           )}
         </Field>
       )}
@@ -376,11 +227,14 @@ export default function SignUpForm({
         type="submit"
         variant="primary"
         width="full"
-        loading={isSubmitting || isWaitingForToken}
+        loading={isBusy}
         loadingText={
-          isWaitingForToken ? t("Status.verifying") : t("Status.signingUp")
+          turnstile.isWaitingForToken
+            ? t("Status.verifying")
+            : t("Status.signingUp")
         }
-        disabled={isSubmitting || isWaitingForToken}
+        disabled={isBusy}
+        data-testid="sign-up-submit"
       >
         {t("Actions.signUp")}
       </Button>

--- a/src/components/SignUpForm/useTurnstileToken.ts
+++ b/src/components/SignUpForm/useTurnstileToken.ts
@@ -1,0 +1,183 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
+
+const BACKGROUND_TOKEN_TIMEOUT = 10000;
+const INTERACTIVE_TOKEN_TIMEOUT = 120000;
+
+type UseTurnstileTokenOptions = {
+  enabled: boolean;
+  failedMessage: (code: string) => string;
+  siteKey: string;
+  timeoutMessage: string;
+  expiredMessage: string;
+  unsupportedMessage: string;
+};
+
+export function useTurnstileToken({
+  enabled,
+  failedMessage,
+  siteKey,
+  timeoutMessage,
+  expiredMessage,
+  unsupportedMessage,
+}: UseTurnstileTokenOptions) {
+  const turnstileRef = useRef<TurnstileInstance>(null);
+  const tokenResolverRef = useRef<((token: string) => void) | null>(null);
+  const tokenRejecterRef = useRef<((error: Error) => void) | null>(null);
+  const tokenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isWaitingForToken, setIsWaitingForToken] = useState(false);
+  const [isInteractive, setIsInteractive] = useState(false);
+
+  const clearTokenTimeout = useCallback(() => {
+    if (tokenTimeoutRef.current) {
+      clearTimeout(tokenTimeoutRef.current);
+      tokenTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearTokenPromise = useCallback(() => {
+    tokenResolverRef.current = null;
+    tokenRejecterRef.current = null;
+    clearTokenTimeout();
+  }, [clearTokenTimeout]);
+
+  const rejectTokenPromise = useCallback(
+    (errorMessage: string) => {
+      tokenRejecterRef.current?.(new Error(errorMessage));
+      clearTokenPromise();
+    },
+    [clearTokenPromise]
+  );
+
+  const scheduleTokenTimeout = useCallback(
+    (timeout: number, errorMessage = timeoutMessage) => {
+      clearTokenTimeout();
+      tokenTimeoutRef.current = setTimeout(() => {
+        setIsWaitingForToken(false);
+        setError(errorMessage);
+        rejectTokenPromise(errorMessage);
+      }, timeout);
+    },
+    [clearTokenTimeout, rejectTokenPromise, timeoutMessage]
+  );
+
+  const waitForToken = useCallback(
+    (timeout = BACKGROUND_TOKEN_TIMEOUT) =>
+      new Promise<string>((resolve, reject) => {
+        tokenResolverRef.current = resolve;
+        tokenRejecterRef.current = reject;
+        scheduleTokenTimeout(timeout);
+      }),
+    [scheduleTokenTimeout]
+  );
+
+  const resolveTokenPromise = useCallback(
+    (token: string) => {
+      tokenResolverRef.current?.(token);
+      clearTokenPromise();
+    },
+    [clearTokenPromise]
+  );
+
+  const requestToken = useCallback(async () => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    setError(null);
+    setIsWaitingForToken(true);
+    turnstileRef.current?.reset();
+
+    try {
+      const tokenPromise = waitForToken(BACKGROUND_TOKEN_TIMEOUT);
+      turnstileRef.current?.execute();
+      return await tokenPromise;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : timeoutMessage;
+      setError(errorMessage);
+      throw error;
+    } finally {
+      setIsWaitingForToken(false);
+    }
+  }, [enabled, timeoutMessage, waitForToken]);
+
+  const resetError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  useEffect(() => clearTokenPromise, [clearTokenPromise]);
+
+  const turnstileProps = useMemo(
+    () => ({
+      ref: turnstileRef,
+      siteKey,
+      onSuccess: (token: string) => {
+        setError(null);
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+        resolveTokenPromise(token);
+      },
+      onError: (code: string) => {
+        const errorMessage = failedMessage(code);
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+        setError(errorMessage);
+        rejectTokenPromise(errorMessage);
+      },
+      onExpire: () => {
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+        setError(expiredMessage);
+        rejectTokenPromise(expiredMessage);
+      },
+      onTimeout: () => {
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+        setError(timeoutMessage);
+        rejectTokenPromise(timeoutMessage);
+      },
+      onUnsupported: () => {
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+        setError(unsupportedMessage);
+        rejectTokenPromise(unsupportedMessage);
+      },
+      onBeforeInteractive: () => {
+        setError(null);
+        setIsInteractive(true);
+        scheduleTokenTimeout(INTERACTIVE_TOKEN_TIMEOUT);
+      },
+      onAfterInteractive: () => {
+        setIsInteractive(false);
+      },
+      options: {
+        appearance: "interaction-only",
+        execution: "execute",
+        responseField: false,
+      } as const,
+    }),
+    [
+      expiredMessage,
+      failedMessage,
+      rejectTokenPromise,
+      resolveTokenPromise,
+      scheduleTokenTimeout,
+      siteKey,
+      timeoutMessage,
+      unsupportedMessage,
+    ]
+  );
+
+  return {
+    error,
+    isInteractive,
+    isWaitingForToken,
+    requestToken,
+    resetError,
+    turnstileProps,
+  };
+}

--- a/src/components/SignUpForm/useTurnstileToken.ts
+++ b/src/components/SignUpForm/useTurnstileToken.ts
@@ -24,6 +24,7 @@ export function useTurnstileToken({
   unsupportedMessage,
 }: UseTurnstileTokenOptions) {
   const turnstileRef = useRef<TurnstileInstance>(null);
+  const isMountedRef = useRef(false);
   const tokenResolverRef = useRef<((token: string) => void) | null>(null);
   const tokenRejecterRef = useRef<((error: Error) => void) | null>(null);
   const tokenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -98,10 +99,14 @@ export function useTurnstileToken({
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : timeoutMessage;
-      setError(errorMessage);
+      if (isMountedRef.current) {
+        setError(errorMessage);
+      }
       throw error;
     } finally {
-      setIsWaitingForToken(false);
+      if (isMountedRef.current) {
+        setIsWaitingForToken(false);
+      }
     }
   }, [enabled, timeoutMessage, waitForToken]);
 
@@ -109,7 +114,16 @@ export function useTurnstileToken({
     setError(null);
   }, []);
 
-  useEffect(() => clearTokenPromise, [clearTokenPromise]);
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      rejectTokenPromise(
+        "Turnstile token request was cancelled because the component unmounted."
+      );
+    };
+  }, [rejectTokenPromise]);
 
   const turnstileProps = useMemo(
     () => ({

--- a/src/components/SignUpForm/useTurnstileToken.ts
+++ b/src/components/SignUpForm/useTurnstileToken.ts
@@ -6,12 +6,20 @@ import type { TurnstileInstance } from "@marsidev/react-turnstile";
 const BACKGROUND_TOKEN_TIMEOUT = 10000;
 const INTERACTIVE_TOKEN_TIMEOUT = 120000;
 
+class TokenRequestCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TokenRequestCancelledError";
+  }
+}
+
 type UseTurnstileTokenOptions = {
   enabled: boolean;
   failedMessage: (code: string) => string;
   siteKey: string;
   timeoutMessage: string;
   expiredMessage: string;
+  notReadyMessage: string;
   unsupportedMessage: string;
 };
 
@@ -21,10 +29,12 @@ export function useTurnstileToken({
   siteKey,
   timeoutMessage,
   expiredMessage,
+  notReadyMessage,
   unsupportedMessage,
 }: UseTurnstileTokenOptions) {
   const turnstileRef = useRef<TurnstileInstance>(null);
   const isMountedRef = useRef(false);
+  const activeRequestIdRef = useRef(0);
   const tokenResolverRef = useRef<((token: string) => void) | null>(null);
   const tokenRejecterRef = useRef<((error: Error) => void) | null>(null);
   const tokenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -46,33 +56,51 @@ export function useTurnstileToken({
   }, [clearTokenTimeout]);
 
   const rejectTokenPromise = useCallback(
-    (errorMessage: string) => {
-      tokenRejecterRef.current?.(new Error(errorMessage));
+    (error: Error) => {
+      tokenRejecterRef.current?.(error);
       clearTokenPromise();
     },
     [clearTokenPromise]
   );
 
+  const cancelTokenPromise = useCallback(
+    (message: string) => {
+      rejectTokenPromise(new TokenRequestCancelledError(message));
+    },
+    [rejectTokenPromise]
+  );
+
   const scheduleTokenTimeout = useCallback(
-    (timeout: number, errorMessage = timeoutMessage) => {
+    (timeout: number, requestId: number, errorMessage = timeoutMessage) => {
       clearTokenTimeout();
       tokenTimeoutRef.current = setTimeout(() => {
-        setIsWaitingForToken(false);
-        setError(errorMessage);
-        rejectTokenPromise(errorMessage);
+        if (isMountedRef.current && requestId === activeRequestIdRef.current) {
+          setIsWaitingForToken(false);
+          setError(errorMessage);
+        }
+        rejectTokenPromise(new Error(errorMessage));
       }, timeout);
     },
     [clearTokenTimeout, rejectTokenPromise, timeoutMessage]
   );
 
   const waitForToken = useCallback(
-    (timeout = BACKGROUND_TOKEN_TIMEOUT) =>
-      new Promise<string>((resolve, reject) => {
+    (timeout = BACKGROUND_TOKEN_TIMEOUT) => {
+      const requestId = activeRequestIdRef.current + 1;
+      activeRequestIdRef.current = requestId;
+
+      const promise = new Promise<string>((resolve, reject) => {
+        cancelTokenPromise(
+          "Turnstile token request was cancelled because a newer request started."
+        );
         tokenResolverRef.current = resolve;
         tokenRejecterRef.current = reject;
-        scheduleTokenTimeout(timeout);
-      }),
-    [scheduleTokenTimeout]
+        scheduleTokenTimeout(timeout, requestId);
+      });
+
+      return { promise, requestId };
+    },
+    [cancelTokenPromise, scheduleTokenTimeout]
   );
 
   const resolveTokenPromise = useCallback(
@@ -89,26 +117,44 @@ export function useTurnstileToken({
     }
 
     setError(null);
+
+    const turnstile = turnstileRef.current;
+    if (!turnstile) {
+      if (isMountedRef.current) {
+        setError(notReadyMessage);
+        setIsWaitingForToken(false);
+        setIsInteractive(false);
+      }
+      throw new Error(notReadyMessage);
+    }
+
     setIsWaitingForToken(true);
-    turnstileRef.current?.reset();
+    turnstile.reset();
+
+    let requestId = activeRequestIdRef.current;
 
     try {
-      const tokenPromise = waitForToken(BACKGROUND_TOKEN_TIMEOUT);
-      turnstileRef.current?.execute();
-      return await tokenPromise;
+      const tokenRequest = waitForToken(BACKGROUND_TOKEN_TIMEOUT);
+      requestId = tokenRequest.requestId;
+      turnstile.execute();
+      return await tokenRequest.promise;
     } catch (error) {
+      if (error instanceof TokenRequestCancelledError) {
+        throw error;
+      }
+
       const errorMessage =
         error instanceof Error ? error.message : timeoutMessage;
-      if (isMountedRef.current) {
+      if (isMountedRef.current && requestId === activeRequestIdRef.current) {
         setError(errorMessage);
       }
       throw error;
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && requestId === activeRequestIdRef.current) {
         setIsWaitingForToken(false);
       }
     }
-  }, [enabled, timeoutMessage, waitForToken]);
+  }, [enabled, notReadyMessage, timeoutMessage, waitForToken]);
 
   const resetError = useCallback(() => {
     setError(null);
@@ -119,54 +165,71 @@ export function useTurnstileToken({
 
     return () => {
       isMountedRef.current = false;
-      rejectTokenPromise(
+      cancelTokenPromise(
         "Turnstile token request was cancelled because the component unmounted."
       );
     };
-  }, [rejectTokenPromise]);
+  }, [cancelTokenPromise]);
 
   const turnstileProps = useMemo(
     () => ({
       ref: turnstileRef,
       siteKey,
       onSuccess: (token: string) => {
-        setError(null);
-        setIsWaitingForToken(false);
-        setIsInteractive(false);
+        if (isMountedRef.current) {
+          setError(null);
+          setIsWaitingForToken(false);
+          setIsInteractive(false);
+        }
         resolveTokenPromise(token);
       },
       onError: (code: string) => {
         const errorMessage = failedMessage(code);
-        setIsWaitingForToken(false);
-        setIsInteractive(false);
-        setError(errorMessage);
-        rejectTokenPromise(errorMessage);
+        if (isMountedRef.current) {
+          setIsWaitingForToken(false);
+          setIsInteractive(false);
+          setError(errorMessage);
+        }
+        rejectTokenPromise(new Error(errorMessage));
       },
       onExpire: () => {
-        setIsWaitingForToken(false);
-        setIsInteractive(false);
-        setError(expiredMessage);
-        rejectTokenPromise(expiredMessage);
+        if (isMountedRef.current) {
+          setIsWaitingForToken(false);
+          setIsInteractive(false);
+          setError(expiredMessage);
+        }
+        rejectTokenPromise(new Error(expiredMessage));
       },
       onTimeout: () => {
-        setIsWaitingForToken(false);
-        setIsInteractive(false);
-        setError(timeoutMessage);
-        rejectTokenPromise(timeoutMessage);
+        if (isMountedRef.current) {
+          setIsWaitingForToken(false);
+          setIsInteractive(false);
+          setError(timeoutMessage);
+        }
+        rejectTokenPromise(new Error(timeoutMessage));
       },
       onUnsupported: () => {
-        setIsWaitingForToken(false);
-        setIsInteractive(false);
-        setError(unsupportedMessage);
-        rejectTokenPromise(unsupportedMessage);
+        if (isMountedRef.current) {
+          setIsWaitingForToken(false);
+          setIsInteractive(false);
+          setError(unsupportedMessage);
+        }
+        rejectTokenPromise(new Error(unsupportedMessage));
       },
       onBeforeInteractive: () => {
-        setError(null);
-        setIsInteractive(true);
-        scheduleTokenTimeout(INTERACTIVE_TOKEN_TIMEOUT);
+        if (isMountedRef.current) {
+          setError(null);
+          setIsInteractive(true);
+        }
+        scheduleTokenTimeout(
+          INTERACTIVE_TOKEN_TIMEOUT,
+          activeRequestIdRef.current
+        );
       },
       onAfterInteractive: () => {
-        setIsInteractive(false);
+        if (isMountedRef.current) {
+          setIsInteractive(false);
+        }
       },
       options: {
         appearance: "interaction-only",


### PR DESCRIPTION
## Summary
- extract SignUpForm Turnstile orchestration into a focused hook and align sign-up busy/error feedback
- return typed InlineActionResult data from display locale mutations and make LocalePicker pending/error behaviour explicit
- tighten profile account editor feedback, destructive dialog focus, and shared form feedback announcements
- expand production e2e coverage for sign-up validation, locale changes, profile email errors, and destructive-dialog focus

## Validation
- npm run typecheck
- npm run check
- npm run build
- CI=1 npm run test:e2e:prod

## Notes
- no public API, database schema, or Supabase migration changes
- homepage hydration and broader use-client/TODO sweeps remain out of scope