### PR TITLE
restore curated homepage drop-off hosts

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -70,3 +70,32 @@ test("homepage hydrates without chat date mismatches", async ({
     )
   ).toBeFalsy();
 });
+
+test("homepage drop-off only shows curated featured hosts", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByTestId("homepage-featured-hosts")).toBeVisible();
+
+  const featuredHostCards = page.locator(
+    '[data-testid^="homepage-featured-host-"]'
+  );
+
+  await expect(featuredHostCards).toHaveCount(3);
+  await expect(
+    page.getByTestId("homepage-featured-host-demo-marrickville-compost")
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("homepage-featured-host-demo-inner-west-cafe")
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("homepage-featured-host-demo-tempe-share-shed")
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("homepage-featured-host-demo-stanmore-bakery")
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("homepage-featured-host-demo-newtown-worm-farm")
+  ).toHaveCount(0);
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -81,17 +81,26 @@ test("homepage drop-off only shows curated featured hosts", async ({
   const featuredHostCards = page.locator(
     '[data-testid^="homepage-featured-host-"]'
   );
+  const allowedFeaturedHosts = new Set([
+    "homepage-featured-host-demo-marrickville-compost",
+    "homepage-featured-host-demo-inner-west-cafe",
+    "homepage-featured-host-demo-tempe-share-shed",
+  ]);
 
   await expect(featuredHostCards).toHaveCount(3);
-  await expect(
-    page.getByTestId("homepage-featured-host-demo-marrickville-compost")
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("homepage-featured-host-demo-inner-west-cafe")
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("homepage-featured-host-demo-tempe-share-shed")
-  ).toBeVisible();
+
+  const renderedFeaturedHosts = await featuredHostCards.evaluateAll(
+    (elements) => elements.map((element) => element.getAttribute("data-testid"))
+  );
+
+  expect(renderedFeaturedHosts).toHaveLength(3);
+  expect(new Set(renderedFeaturedHosts).size).toBe(3);
+  expect(
+    renderedFeaturedHosts.every(
+      (testId): testId is string =>
+        typeof testId === "string" && allowedFeaturedHosts.has(testId)
+    )
+  ).toBeTruthy();
   await expect(
     page.getByTestId("homepage-featured-host-demo-stanmore-bakery")
   ).toHaveCount(0);

--- a/src/components/PeelsFeaturedHostsPhotos/PeelsFeaturedHostsPhotos.tsx
+++ b/src/components/PeelsFeaturedHostsPhotos/PeelsFeaturedHostsPhotos.tsx
@@ -44,16 +44,7 @@ function selectHomepagePhotoIndex(listing: ListingPublicData): number | null {
     ];
   }
 
-  const eligibleIndexes = Array.from(
-    { length: photos.length },
-    (_, index) => index
-  );
-
-  if (eligibleIndexes.length === 0) {
-    return null;
-  }
-
-  return eligibleIndexes[Math.floor(Math.random() * eligibleIndexes.length)];
+  return Math.floor(Math.random() * photos.length);
 }
 
 const PhotoRow = styled.ul`

--- a/src/components/PeelsFeaturedHostsPhotos/PeelsFeaturedHostsPhotos.tsx
+++ b/src/components/PeelsFeaturedHostsPhotos/PeelsFeaturedHostsPhotos.tsx
@@ -10,6 +10,9 @@ interface ListingPublicData {
   name: string;
   photos: string[] | null;
   type: string;
+  is_stub: boolean | null;
+  homepage_featured: boolean;
+  homepage_featured_photo_indexes: number[] | null;
 }
 
 interface ListingWithPhotoIndex extends ListingPublicData {
@@ -18,6 +21,40 @@ interface ListingWithPhotoIndex extends ListingPublicData {
 }
 
 const MAX_PHOTOS_TO_SHOW = 3;
+
+function selectHomepagePhotoIndex(listing: ListingPublicData): number | null {
+  if (!Array.isArray(listing.photos) || listing.photos.length === 0) {
+    return null;
+  }
+
+  const photos = listing.photos;
+  const configuredIndexes = listing.homepage_featured_photo_indexes ?? [];
+
+  if (configuredIndexes.length > 0) {
+    const validConfiguredIndexes = configuredIndexes.filter(
+      (index) => Number.isInteger(index) && index >= 0 && index < photos.length
+    );
+
+    if (validConfiguredIndexes.length === 0) {
+      return null;
+    }
+
+    return validConfiguredIndexes[
+      Math.floor(Math.random() * validConfiguredIndexes.length)
+    ];
+  }
+
+  const eligibleIndexes = Array.from(
+    { length: photos.length },
+    (_, index) => index
+  );
+
+  if (eligibleIndexes.length === 0) {
+    return null;
+  }
+
+  return eligibleIndexes[Math.floor(Math.random() * eligibleIndexes.length)];
+}
 
 const PhotoRow = styled.ul`
   margin: 2rem 0;
@@ -61,7 +98,11 @@ function PeelsFeaturedHostsPhotos() {
     const loadListings = async () => {
       const { data, error } = await supabase
         .from("listings_public_data")
-        .select("slug, name, photos, type")
+        .select(
+          "slug, name, photos, type, is_stub, homepage_featured, homepage_featured_photo_indexes"
+        )
+        .eq("homepage_featured", true)
+        .eq("is_stub", false)
         .neq("type", "residential")
         .not("photos", "is", null);
 
@@ -71,14 +112,22 @@ function PeelsFeaturedHostsPhotos() {
       }
 
       const validListingsWithPhotos = (data as ListingPublicData[])
+        .map((listing) => {
+          const photoIndex = selectHomepagePhotoIndex(listing);
+
+          if (!Array.isArray(listing.photos) || photoIndex === null) {
+            return null;
+          }
+
+          return {
+            ...listing,
+            photos: listing.photos,
+            photoIndex,
+          };
+        })
         .filter(
-          (listing): listing is ListingPublicData & { photos: string[] } =>
-            Array.isArray(listing.photos) && listing.photos.length > 0
-        )
-        .map((listing) => ({
-          ...listing,
-          photoIndex: Math.floor(Math.random() * listing.photos.length),
-        }));
+          (listing): listing is ListingWithPhotoIndex => listing !== null
+        );
 
       const shuffledData = [...validListingsWithPhotos].sort(
         () => Math.random() - 0.5
@@ -90,7 +139,7 @@ function PeelsFeaturedHostsPhotos() {
   }, []);
 
   return (
-    <PhotoRow>
+    <PhotoRow data-testid="homepage-featured-hosts">
       {featuredListings.slice(0, MAX_PHOTOS_TO_SHOW).map((listing) => {
         return (
           <PhotoThumbnail
@@ -98,6 +147,7 @@ function PeelsFeaturedHostsPhotos() {
             fileName={listing.photos[listing.photoIndex]}
             listingId={listing.slug}
             caption={listing.name}
+            testId={`homepage-featured-host-${listing.slug}`}
           />
         );
       })}

--- a/src/components/PhotoThumbnail/PhotoThumbnail.tsx
+++ b/src/components/PhotoThumbnail/PhotoThumbnail.tsx
@@ -55,14 +55,19 @@ function PhotoThumbnail({
   fileName,
   listingId,
   caption,
+  testId,
 }: {
   fileName: string;
   listingId: string;
   caption?: string;
+  testId?: string;
 }) {
   return (
     <li>
-      <PhotoThumbnailContainer href={`/map?listing=${listingId}`}>
+      <PhotoThumbnailContainer
+        href={`/map?listing=${listingId}`}
+        data-testid={testId}
+      >
         <ListingPhotoRemoteImage
           bucket="listing_photos"
           filename={fileName}

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -77,6 +77,8 @@ export interface Listing {
   country_code: string | null;
   area_name: string | null;
   is_stub: boolean | null;
+  homepage_featured?: boolean | null;
+  homepage_featured_photo_indexes?: number[] | null;
   owner_has_multiple_non_residential_listings: boolean | null;
   // Private view only
   owner_id?: string | null;

--- a/supabase/migrations/20260424113000_add_homepage_featured_listing_metadata.sql
+++ b/supabase/migrations/20260424113000_add_homepage_featured_listing_metadata.sql
@@ -1,0 +1,115 @@
+alter table public.listings
+  add column homepage_featured boolean not null default false,
+  add column homepage_featured_photo_indexes integer[] not null default '{}'::integer[];
+
+update public.listings
+set
+  homepage_featured = true,
+  homepage_featured_photo_indexes = case slug
+    when 'oLbJwGqRQrzo' then array[0]
+    when 'KX5eqmXGadu2' then array[0]
+    when 'NPISVZDjJYsl' then array[0]
+    when 'HOaEy5gxgrvc' then array[0]
+    when 'itKrzEbLPDPf' then array[0, 2]
+    when 'B030fsqGqMzt' then array[0]
+    when 'iFtK9KoxxID9' then array[1]
+    when 'FjABURjzHDMW' then array[0, 1]
+    when 'MG92x2GOAeXj' then array[0]
+    when 'zUJ2ukqP4VbS' then array[4]
+    when 'RbAsf8OqLrPf' then array[0]
+    when 'oFvkhgiPvzGJ' then array[3]
+    when 'vmobuio1RAD5' then array[0]
+    when 'MJXTt4x5n9ag' then array[0]
+    when 'rK1zNtjl2orh' then array[0]
+    when 'GmtjmYnNeQu5' then array[2]
+  end
+where slug in (
+  'oLbJwGqRQrzo',
+  'KX5eqmXGadu2',
+  'NPISVZDjJYsl',
+  'HOaEy5gxgrvc',
+  'itKrzEbLPDPf',
+  'B030fsqGqMzt',
+  'iFtK9KoxxID9',
+  'FjABURjzHDMW',
+  'MG92x2GOAeXj',
+  'zUJ2ukqP4VbS',
+  'RbAsf8OqLrPf',
+  'oFvkhgiPvzGJ',
+  'vmobuio1RAD5',
+  'MJXTt4x5n9ag',
+  'rK1zNtjl2orh',
+  'GmtjmYnNeQu5'
+);
+
+create or replace view public.listings_private_data with (security_invoker = 'on') as
+select
+  listings.id,
+  listings.owner_id,
+  listings.name,
+  listings.description,
+  listings.accepted_items,
+  listings.rejected_items,
+  listings.photos,
+  listings.links,
+  listings.visibility,
+  listings.type,
+  listings.avatar,
+  listings.slug,
+  jsonb_build_object(
+    'latitude', extensions.st_y(listings.location::extensions.geometry),
+    'longitude', extensions.st_x(listings.location::extensions.geometry)
+  ) as coordinates,
+  listings.country_code,
+  listings.area_name,
+  listings.is_stub,
+  profiles.first_name as owner_first_name,
+  profiles.avatar as owner_avatar,
+  (
+    select count(*) >= 2
+    from public.listings as owner_listings
+    where owner_listings.owner_id = listings.owner_id
+      and owner_listings.type in ('community', 'business')
+  ) as owner_has_multiple_non_residential_listings,
+  listings.homepage_featured,
+  listings.homepage_featured_photo_indexes
+from public.listings
+left join public.profiles on listings.owner_id = profiles.id;
+
+alter view public.listings_private_data owner to postgres;
+
+create or replace view public.listings_public_data with (security_invoker = 'on') as
+select
+  id,
+  created_at,
+  name,
+  description,
+  accepted_items,
+  rejected_items,
+  case
+    when type = any (array['business'::text, 'community'::text]) then photos
+    else null::text[]
+  end as photos,
+  links,
+  type,
+  avatar,
+  slug,
+  jsonb_build_object(
+    'latitude', extensions.st_y(location::extensions.geometry),
+    'longitude', extensions.st_x(location::extensions.geometry)
+  ) as coordinates,
+  country_code,
+  area_name,
+  is_stub,
+  (
+    select count(*) >= 2
+    from public.listings as other_listings
+    where other_listings.owner_id = listings.owner_id
+      and other_listings.type in ('community', 'business')
+  ) as owner_has_multiple_non_residential_listings,
+  homepage_featured,
+  homepage_featured_photo_indexes
+from public.listings
+where visibility = true;
+
+alter view public.listings_public_data owner to postgres;

--- a/supabase/migrations/20260424121500_add_homepage_featured_listing_index.sql
+++ b/supabase/migrations/20260424121500_add_homepage_featured_listing_index.sql
@@ -1,0 +1,7 @@
+create index if not exists listings_homepage_featured_public_idx
+  on public.listings (id)
+  where visibility = true
+    and homepage_featured = true
+    and is_stub = false
+    and type in ('community', 'business')
+    and photos is not null;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -176,7 +176,9 @@ insert into public.listings (
   avatar,
   country_code,
   area_name,
-  is_stub
+  is_stub,
+  homepage_featured,
+  homepage_featured_photo_indexes
 )
 values
   (
@@ -194,7 +196,9 @@ values
     'demo/farm.jpg',
     'AU',
     'Marrickville',
-    false
+    false,
+    true,
+    array[0, 2]
   ),
   (
     1002,
@@ -211,7 +215,9 @@ values
     'demo/brewery.jpg',
     'AU',
     'Enmore',
-    false
+    false,
+    true,
+    array[0]
   ),
   (
     1003,
@@ -228,7 +234,47 @@ values
     null,
     'AU',
     'Newtown',
-    false
+    false,
+    false,
+    '{}'::integer[]
+  ),
+  (
+    1004,
+    '9a0c62fc-bf50-4f45-ba6c-5b9051c2712a',
+    'Tempe Share Shed',
+    'A neighbourhood drop-off spot sharing compost space and practical know-how for nearby growers.',
+    extensions.st_setsrid(extensions.st_makepoint(151.1578, -33.9242), 4326)::extensions.geography,
+    array['Fruit scraps', 'Coffee grounds', 'Leafy greens'],
+    array['Meat', 'Plastic packaging'],
+    array['demo/tumbler.jpg', 'demo/garden.jpg'],
+    array['https://www.peels.app/about'],
+    true,
+    'community',
+    'demo/farm.jpg',
+    'AU',
+    'Tempe',
+    false,
+    true,
+    array[1]
+  ),
+  (
+    1005,
+    '2c9ae20c-2469-4e60-84b3-39268697717c',
+    'Stanmore Bakery Scraps',
+    'A public business listing that should stay off the homepage featured strip unless explicitly curated.',
+    extensions.st_setsrid(extensions.st_makepoint(151.1631, -33.8940), 4326)::extensions.geography,
+    array['Coffee grounds', 'Fruit scraps'],
+    array['Plastic', 'Packaging'],
+    array['demo/wheelbarrow.jpg'],
+    array['https://www.peels.app/faq'],
+    true,
+    'business',
+    'demo/brewery.jpg',
+    'AU',
+    'Stanmore',
+    false,
+    false,
+    '{}'::integer[]
   )
 on conflict (id) do update
 set
@@ -245,17 +291,21 @@ set
   avatar = excluded.avatar,
   country_code = excluded.country_code,
   area_name = excluded.area_name,
-  is_stub = excluded.is_stub;
+  is_stub = excluded.is_stub,
+  homepage_featured = excluded.homepage_featured,
+  homepage_featured_photo_indexes = excluded.homepage_featured_photo_indexes;
 
 update public.listings
 set slug = case id
   when 1001 then 'demo-marrickville-compost'
   when 1002 then 'demo-inner-west-cafe'
   when 1003 then 'demo-newtown-worm-farm'
+  when 1004 then 'demo-tempe-share-shed'
+  when 1005 then 'demo-stanmore-bakery'
 end
-where id in (1001, 1002, 1003);
+where id in (1001, 1002, 1003, 1004, 1005);
 
-select setval('public.listings_id_seq', 1003, true);
+select setval('public.listings_id_seq', 1005, true);
 
 insert into public.chat_threads (
   id,


### PR DESCRIPTION
## Summary
- restore the homepage Drop-off strip to a curated subset backed by listing metadata in Supabase
- support pinned featured photo indices while keeping the existing client-side hydration-safe loading path
- extend local seed data and homepage Playwright coverage for featured and excluded hosts

## Testing
- npm run supabase:reset
- npm run check
- npm run test:e2e:prod -- e2e/home.spec.ts