### PR TITLE
add simple photo viewer

### DIFF
--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "./helpers";
 
 const BUSINESS_LISTING_EDIT_PATH = "/profile/listings/demo-inner-west-cafe";
+const MAP_MULTI_PHOTO_LISTING_PATH = "/map?listing=demo-marrickville-compost";
+const PUBLIC_MULTI_PHOTO_LISTING_PATH = "/listings/demo-marrickville-compost";
 const RESIDENTIAL_LISTING_EDIT_PATH =
   "/profile/listings/demo-newtown-worm-farm";
 const ALTERNATE_BUSINESS_DESCRIPTION =
@@ -148,4 +150,58 @@ test("residential listing edit leaves avatar management on the profile page", as
   await expect(page.getByTestId("avatar-upload-listing_avatars")).toHaveCount(
     0
   );
+});
+
+test("listing photos open in a dedicated photo tab", async ({ page }) => {
+  await page.goto(PUBLIC_MULTI_PHOTO_LISTING_PATH);
+
+  const firstThumbnail = page.getByTestId("listing-photo-thumbnail-1");
+  await expect(firstThumbnail).toBeVisible();
+  await expect(firstThumbnail).toHaveAttribute("target", "_blank");
+
+  const href = await firstThumbnail.getAttribute("href");
+  expect(href).toBe(
+    "/listings/demo-marrickville-compost/photos/demo/garden.jpg"
+  );
+
+  const photoPage = await page.context().newPage();
+  await photoPage.goto(`http://127.0.0.1:3000${href}`);
+  await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
+  await expect(photoPage.getByRole("navigation")).toHaveCount(0);
+  await expect(page).toHaveURL(PUBLIC_MULTI_PHOTO_LISTING_PATH);
+
+  await photoPage.close();
+});
+
+test("direct photo page close falls back to the listing page", async ({
+  page,
+}) => {
+  await page.goto("/listings/demo-marrickville-compost/photos/demo/garden.jpg");
+
+  await expect(page.getByTestId("listing-photo-tab-viewer")).toBeVisible();
+  await page.getByTestId("listing-photo-tab-viewer-close").click();
+  await expect(page).toHaveURL(PUBLIC_MULTI_PHOTO_LISTING_PATH);
+});
+
+test("map listing photos open in a dedicated photo tab without disturbing the drawer", async ({
+  page,
+}) => {
+  await page.goto(MAP_MULTI_PHOTO_LISTING_PATH);
+
+  const firstThumbnail = page.getByTestId("listing-photo-thumbnail-1");
+  await expect(firstThumbnail).toBeVisible();
+  await expect(firstThumbnail).toHaveAttribute("target", "_blank");
+
+  const href = await firstThumbnail.getAttribute("href");
+  expect(href).toBe(
+    "/listings/demo-marrickville-compost/photos/demo/garden.jpg"
+  );
+
+  const photoPage = await page.context().newPage();
+  await photoPage.goto(`http://127.0.0.1:3000${href}`);
+  await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
+  await expect(page).toHaveURL(MAP_MULTI_PHOTO_LISTING_PATH);
+  await expect(firstThumbnail).toBeVisible();
+
+  await photoPage.close();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "maplibre-gl": "^4.7.1",
         "next": "16.2.4",
         "next-intl": "^4.9.1",
-        "photoswipe": "^5.4.4",
         "pmtiles": "^4.4.1",
         "prettier": "^3.8.3",
         "protomaps-themes-base": "^4.5.0",
@@ -40,7 +39,6 @@
         "react-dom": "19.2.5",
         "react-dropzone": "^14.4.1",
         "react-map-gl": "^7.1.9",
-        "react-photoswipe-gallery": "^3.1.1",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -4942,15 +4940,6 @@
         "pbf": "bin/pbf"
       }
     },
-    "node_modules/photoswipe": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
-      "integrity": "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5233,17 +5222,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
       "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
       "license": "MIT"
-    },
-    "node_modules/react-photoswipe-gallery": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-photoswipe-gallery/-/react-photoswipe-gallery-3.1.1.tgz",
-      "integrity": "sha512-2hQkUkELwGDSnxdXeOGCySOLiK5vlUFZn9HhwmCXZz0jTqQwG6zy09M6M/JypYFa3md9zd/XW0aUD39dqltzsw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "photoswipe": ">= 5.2.2",
-        "prop-types": ">= 15.7.0",
-        "react": ">= 16.8.0"
-      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "maplibre-gl": "^4.7.1",
     "next": "16.2.4",
     "next-intl": "^4.9.1",
-    "photoswipe": "^5.4.4",
     "pmtiles": "^4.4.1",
     "prettier": "^3.8.3",
     "protomaps-themes-base": "^4.5.0",
@@ -59,7 +58,6 @@
     "react-dom": "19.2.5",
     "react-dropzone": "^14.4.1",
     "react-map-gl": "^7.1.9",
-    "react-photoswipe-gallery": "^3.1.1",
     "vaul": "^1.1.2"
   },
   "devDependencies": {

--- a/src/app/(photo)/layout.tsx
+++ b/src/app/(photo)/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/(photo)/layout.tsx
+++ b/src/app/(photo)/layout.tsx
@@ -1,4 +1,10 @@
+import type { Viewport } from "next";
 import type { ReactNode } from "react";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+  colorScheme: "dark",
+};
 
 export default function Layout({ children }: { children: ReactNode }) {
   return children;

--- a/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
+++ b/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from "next/navigation";
 import { cache } from "react";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import StandaloneListingPhotoPage from "@/components/StandaloneListingPhotoPage";
+import { getListingDisplayName } from "@/utils/listingUtils";
 import { createClient } from "@/utils/supabase/server";
 import { getStoragePublicUrl } from "@/utils/storage";
 import { parseListingPhotoPath } from "@/utils/listingPhotoRoute";
@@ -25,6 +27,35 @@ const getListingData = cache(async (slug: string) => {
 
   return { user, listing };
 });
+
+export async function generateMetadata({
+  params,
+}: {
+  params: ListingPhotoPageParams;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const { user, listing } = await getListingData(slug);
+
+  if (!listing) {
+    return {
+      title: "Photo",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const listingDisplayName = getListingDisplayName(listing, user);
+
+  return {
+    title: listingDisplayName ? `Photo · ${listingDisplayName}` : "Photo",
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default async function ListingPhotoPage({
   params,

--- a/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
+++ b/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { getTranslations } from "next-intl/server";
+
+import StandaloneListingPhotoPage from "@/components/StandaloneListingPhotoPage";
+import { createClient } from "@/utils/supabase/server";
+import { getStoragePublicUrl } from "@/utils/storage";
+import { parseListingPhotoPath } from "@/utils/listingPhotoRoute";
+
+type ListingPhotoPageParams = Promise<{
+  photoPath?: string[];
+  slug: string;
+}>;
+
+const getListingData = cache(async (slug: string) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const { data: listing } = await supabase
+    .from(user ? "listings_private_data" : "listings_public_data")
+    .select()
+    .match({ slug })
+    .single();
+
+  return { user, listing };
+});
+
+export default async function ListingPhotoPage({
+  params,
+}: {
+  params: ListingPhotoPageParams;
+}) {
+  const { photoPath, slug } = await params;
+  const photo = parseListingPhotoPath(photoPath);
+  const { user, listing } = await getListingData(slug);
+  const t = await getTranslations();
+
+  if (!listing || !photo) {
+    notFound();
+  }
+
+  if (!Array.isArray(listing.photos) || !listing.photos.includes(photo)) {
+    notFound();
+  }
+
+  if (!user && listing.type === "residential") {
+    notFound();
+  }
+
+  const src = getStoragePublicUrl("listing_photos", photo);
+
+  if (!src) {
+    notFound();
+  }
+
+  return (
+    <StandaloneListingPhotoPage
+      alt={`Listing photo ${listing.photos.indexOf(photo) + 1}`}
+      backHref={`/listings/${slug}`}
+      closeLabel={t("Actions.close")}
+      src={src}
+    />
+  );
+}

--- a/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
+++ b/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import StandaloneListingPhotoPage from "@/components/StandaloneListingPhotoPage";
+import type { Listing } from "@/types/listing";
 import { getListingDisplayName } from "@/utils/listingUtils";
 import { createClient } from "@/utils/supabase/server";
 import { getStoragePublicUrl } from "@/utils/storage";
@@ -14,18 +15,26 @@ type ListingPhotoPageParams = Promise<{
   slug: string;
 }>;
 
+type ListingPhotoPageListing = Pick<
+  Listing,
+  "name" | "owner_first_name" | "photos" | "type"
+>;
+
 const getListingData = cache(async (slug: string) => {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  const { data: listing } = await supabase
+  const { data: listingData } = await supabase
     .from(user ? "listings_private_data" : "listings_public_data")
-    .select()
+    .select("name, owner_first_name, photos, type")
     .match({ slug })
     .single();
 
-  return { user, listing };
+  return {
+    user,
+    listing: (listingData as ListingPhotoPageListing | null) ?? null,
+  };
 });
 
 export async function generateMetadata({

--- a/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
+++ b/src/app/(photo)/listings/[slug]/photos/[...photoPath]/page.tsx
@@ -25,9 +25,13 @@ const getListingData = cache(async (slug: string) => {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const tableName = user ? "listings_private_data" : "listings_public_data";
+  const selectColumns = user
+    ? "name, owner_first_name, photos, type"
+    : "name, photos, type";
   const { data: listingData } = await supabase
-    .from(user ? "listings_private_data" : "listings_public_data")
-    .select("name, owner_first_name, photos, type")
+    .from(tableName)
+    .select(selectColumns)
     .match({ slug })
     .single();
 

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -11,9 +11,6 @@ const fullPresentationStyles = css`
   }
 `;
 
-const zoomCursor =
-  'url("data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724%27 height=%2724%27 viewBox=%270 0 24 24%27%3E%3Ccircle cx=%2710%27 cy=%2710%27 r=%276.25%27 fill=%27white%27 fill-opacity=%270.92%27 stroke=%27%231f1f1f%27 stroke-width=%271.5%27/%3E%3Cpath d=%27M14.75 14.75 20 20%27 stroke=%27%231f1f1f%27 stroke-width=%272%27 stroke-linecap=%27round%27/%3E%3Cpath d=%27M10 7.25v5.5M7.25 10h5.5%27 stroke=%27%231f1f1f%27 stroke-width=%271.5%27 stroke-linecap=%27round%27/%3E%3C/svg%3E") 10 10, zoom-in';
-
 type ListingPhotoGalleryPresentation = "full" | "demo" | "read" | string;
 
 const PhotosList = styled.ul<{
@@ -25,11 +22,11 @@ const PhotosList = styled.ul<{
   padding: 0 1rem;
 
   & li {
-    cursor: ${zoomCursor};
+    cursor: pointer;
     flex-shrink: 0;
     border-radius: 0.25rem;
     background-color: ${theme.colors.background.sunk};
-    border: 3px solid ${theme.colors.border.elevated};
+    border: 2px solid ${theme.colors.border.elevated};
     overflow: hidden;
     transition:
       transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
@@ -42,19 +39,19 @@ const PhotosList = styled.ul<{
   }
 
   & li * {
-    cursor: ${zoomCursor};
+    cursor: pointer;
   }
 
   ${({ $presentation }) => $presentation === "full" && fullPresentationStyles}
 `;
 
 const ThumbnailLink = styled(Link)`
-  cursor: ${zoomCursor};
+  cursor: pointer;
   display: block;
 
   &,
   & * {
-    cursor: ${zoomCursor};
+    cursor: pointer;
   }
 
   &:focus-visible {

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -2,6 +2,10 @@ import Link from "next/link";
 import { css, styled } from "next-yak";
 
 import RemoteImage from "@/components/RemoteImage";
+import {
+  sharedMediaFrameImageStyles,
+  sharedMediaFrameStyles,
+} from "@/styles/mediaFrame";
 import { theme } from "@/styles/theme.yak";
 import { buildListingPhotoHref } from "@/utils/listingPhotoRoute";
 
@@ -22,12 +26,10 @@ const PhotosList = styled.ul<{
   padding: 0 1rem;
 
   & li {
+    ${sharedMediaFrameStyles}
     cursor: pointer;
     flex-shrink: 0;
-    border-radius: 0.25rem;
     background-color: ${theme.colors.background.sunk};
-    border: 2px solid ${theme.colors.border.elevated};
-    overflow: hidden;
     transition:
       transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
       opacity 200ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -61,9 +63,8 @@ const ThumbnailLink = styled(Link)`
 `;
 
 const ThumbnailImage = styled(RemoteImage)`
+  ${sharedMediaFrameImageStyles}
   object-fit: cover;
-  background-color: ${theme.colors.background.sunk};
-  display: block;
 `;
 
 function ListingPhotoGallery({

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -11,6 +11,9 @@ const fullPresentationStyles = css`
   }
 `;
 
+const zoomCursor =
+  'url("data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724%27 height=%2724%27 viewBox=%270 0 24 24%27%3E%3Ccircle cx=%2710%27 cy=%2710%27 r=%276.25%27 fill=%27white%27 fill-opacity=%270.92%27 stroke=%27%231f1f1f%27 stroke-width=%271.5%27/%3E%3Cpath d=%27M14.75 14.75 20 20%27 stroke=%27%231f1f1f%27 stroke-width=%272%27 stroke-linecap=%27round%27/%3E%3Cpath d=%27M10 7.25v5.5M7.25 10h5.5%27 stroke=%27%231f1f1f%27 stroke-width=%271.5%27 stroke-linecap=%27round%27/%3E%3C/svg%3E") 10 10, zoom-in';
+
 type ListingPhotoGalleryPresentation = "full" | "demo" | "read" | string;
 
 const PhotosList = styled.ul<{
@@ -22,11 +25,11 @@ const PhotosList = styled.ul<{
   padding: 0 1rem;
 
   & li {
-    cursor: zoom-in;
+    cursor: ${zoomCursor};
     flex-shrink: 0;
     border-radius: 0.25rem;
     background-color: ${theme.colors.background.sunk};
-    border: 1px solid ${theme.colors.border.elevated};
+    border: 3px solid ${theme.colors.border.elevated};
     overflow: hidden;
     transition:
       transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
@@ -39,19 +42,19 @@ const PhotosList = styled.ul<{
   }
 
   & li * {
-    cursor: zoom-in;
+    cursor: ${zoomCursor};
   }
 
   ${({ $presentation }) => $presentation === "full" && fullPresentationStyles}
 `;
 
 const ThumbnailLink = styled(Link)`
-  cursor: zoom-in;
+  cursor: ${zoomCursor};
   display: block;
 
   &,
   & * {
-    cursor: zoom-in;
+    cursor: ${zoomCursor};
   }
 
   &:focus-visible {

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -1,20 +1,9 @@
-import "photoswipe/dist/photoswipe.css";
-import { Gallery, Item } from "react-photoswipe-gallery";
-
-// import { getListingPhotoUrl } from "@/utils/mediaUtils";
+import Link from "next/link";
+import { css, styled } from "next-yak";
 
 import RemoteImage from "@/components/RemoteImage";
-// import IconButton from "@/components/IconButton";
-
-import { css, styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
-import type { PreparedPhotoSwipeOptions } from "photoswipe";
-
-// const GalleryCloseButton = styled(IconButton)(({ theme }) => ({
-//   position: "absolute",
-//   top: "0.5rem",
-//   right: "0.5rem",
-// }));
+import { buildListingPhotoHref } from "@/utils/listingPhotoRoute";
 
 const fullPresentationStyles = css`
   @media (min-width: 768px) {
@@ -50,83 +39,51 @@ const PhotosList = styled.ul<{
   ${({ $presentation }) => $presentation === "full" && fullPresentationStyles}
 `;
 
-const ListingPhotoRemoteImageThumbnail = styled(RemoteImage)`
+const ThumbnailLink = styled(Link)`
+  display: block;
+
+  &:focus-visible {
+    outline: 3px solid ${theme.colors.focus.outline};
+    outline-offset: 2px;
+  }
+`;
+
+const ThumbnailImage = styled(RemoteImage)`
   mix-blend-mode: multiply;
   object-fit: cover;
   background-color: ${theme.colors.background.map};
   cursor: zoom-in;
+  display: block;
 `;
-
-const ListingPhotoRemoteImageEnlarged = styled(RemoteImage)`
-  border-radius: 0.25rem;
-  background-color: rgba(0, 0, 0, 0.2);
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-`;
-
-const options: Partial<PreparedPhotoSwipeOptions> = {
-  bgOpacity: 0.82,
-  padding: { top: 16, bottom: 16, left: 0, right: 0 },
-  counter: false,
-  // Animation
-  // easing: "cubic-bezier(0.4, 0, 0.2, 1)",
-  hideAnimationDuration: 300,
-  showAnimationDuration: 300,
-  zoomAnimationDuration: 300,
-  preloaderDelay: 0, // Should show loading spinner?
-  //
-  trapFocus: true, // TODO: Mobile doesn't seem to respect this
-  returnFocus: false, // TODO: Mobile doesn't seem to respect this, but only on map view
-  // Click actions
-  bgClickAction: "close" as const,
-};
 
 function ListingPhotoGallery({
+  listingSlug,
   presentation,
   photos,
 }: {
+  listingSlug: string;
   presentation?: ListingPhotoGalleryPresentation;
   photos: string[];
 }) {
   return (
     <PhotosList $presentation={presentation}>
-      <Gallery options={options}>
-        {/* <GalleryCloseButton variant="close" /> */}
-        {photos.map((photo, index) => (
-          <Item
-            key={index}
-            // original={getListingPhotoUrl(photo, "listing_photos")}
-            // thumbnail={getListingPhotoUrl(photo, "listing_photos")}
-            width={1024}
-            height={768}
-            content={
-              // Approach explained in https://github.com/dimsemenov/PhotoSwipe/issues/2105#issuecomment-2614198664
-              <ListingPhotoRemoteImageEnlarged
-                bucket="listing_photos"
-                filename={photo}
-                alt={`Listing photo ${index + 1}`}
-                width={1024}
-                height={768}
-              />
-            }
+      {photos.map((photo, index) => (
+        <li key={photo}>
+          <ThumbnailLink
+            data-testid={`listing-photo-thumbnail-${index + 1}`}
+            href={buildListingPhotoHref(listingSlug, photo)}
+            target="_blank"
           >
-            {({ ref, open }) => (
-              // Thumbnail
-              <li key={index} ref={ref} onClick={open}>
-                <ListingPhotoRemoteImageThumbnail
-                  bucket="listing_photos"
-                  filename={photo}
-                  alt={`Listing photo ${index + 1}`}
-                  width={280}
-                  height={210}
-                />
-              </li>
-            )}
-          </Item>
-        ))}
-      </Gallery>
+            <ThumbnailImage
+              bucket="listing_photos"
+              filename={photo}
+              alt={`Listing photo ${index + 1}`}
+              width={280}
+              height={210}
+            />
+          </ThumbnailLink>
+        </li>
+      ))}
     </PhotosList>
   );
 }

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -72,6 +72,7 @@ function ListingPhotoGallery({
           <ThumbnailLink
             data-testid={`listing-photo-thumbnail-${index + 1}`}
             href={buildListingPhotoHref(listingSlug, photo)}
+            prefetch={false}
             rel="noopener"
             target="_blank"
           >

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -22,6 +22,7 @@ const PhotosList = styled.ul<{
   padding: 0 1rem;
 
   & li {
+    cursor: zoom-in;
     flex-shrink: 0;
     border-radius: 0.25rem;
     box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
@@ -34,6 +35,10 @@ const PhotosList = styled.ul<{
   & li:hover {
     transform: scale(0.98);
     opacity: 0.86;
+  }
+
+  & li * {
+    cursor: zoom-in;
   }
 
   ${({ $presentation }) => $presentation === "full" && fullPresentationStyles}

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -72,6 +72,7 @@ function ListingPhotoGallery({
           <ThumbnailLink
             data-testid={`listing-photo-thumbnail-${index + 1}`}
             href={buildListingPhotoHref(listingSlug, photo)}
+            rel="noopener"
             target="_blank"
           >
             <ThumbnailImage

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -43,6 +43,11 @@ const ThumbnailLink = styled(Link)`
   cursor: zoom-in;
   display: block;
 
+  &,
+  & * {
+    cursor: zoom-in;
+  }
+
   &:focus-visible {
     outline: 3px solid ${theme.colors.focus.outline};
     outline-offset: 2px;

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -40,6 +40,7 @@ const PhotosList = styled.ul<{
 `;
 
 const ThumbnailLink = styled(Link)`
+  cursor: zoom-in;
   display: block;
 
   &:focus-visible {
@@ -52,7 +53,6 @@ const ThumbnailImage = styled(RemoteImage)`
   mix-blend-mode: multiply;
   object-fit: cover;
   background-color: ${theme.colors.background.map};
-  cursor: zoom-in;
   display: block;
 `;
 

--- a/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
+++ b/src/components/ListingPhotoGallery/ListingPhotoGallery.tsx
@@ -25,7 +25,8 @@ const PhotosList = styled.ul<{
     cursor: zoom-in;
     flex-shrink: 0;
     border-radius: 0.25rem;
-    box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
+    background-color: ${theme.colors.background.sunk};
+    border: 1px solid ${theme.colors.border.elevated};
     overflow: hidden;
     transition:
       transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
@@ -60,9 +61,8 @@ const ThumbnailLink = styled(Link)`
 `;
 
 const ThumbnailImage = styled(RemoteImage)`
-  mix-blend-mode: multiply;
   object-fit: cover;
-  background-color: ${theme.colors.background.map};
+  background-color: ${theme.colors.background.sunk};
   display: block;
 `;
 

--- a/src/components/ListingRead/ListingRead.tsx
+++ b/src/components/ListingRead/ListingRead.tsx
@@ -322,6 +322,7 @@ const ListingRead = memo(function Listing({
                 </p>
               ) : (
                 <ListingPhotoGallery
+                  listingSlug={realListing.slug}
                   presentation={presentation}
                   photos={realListing.photos}
                 />

--- a/src/components/MapThumbnail/MapThumbnail.tsx
+++ b/src/components/MapThumbnail/MapThumbnail.tsx
@@ -1,5 +1,10 @@
 "use client";
 import { theme } from "@/styles/theme.yak";
+import {
+  sharedMediaFrameBorderStyles,
+  sharedMediaFrameRadius,
+  sharedMediaFrameShapeStyles,
+} from "@/styles/mediaFrame";
 import { useEffect, useState, useCallback, useRef } from "react";
 
 import Map, { AttributionControl } from "react-map-gl/maplibre";
@@ -11,23 +16,11 @@ import layers from "protomaps-themes-base";
 import { styled } from "next-yak";
 import type { ComponentProps, ReactNode } from "react";
 
-const RADIUS = "0.375rem";
-
 const MapContainer = styled.div`
-  border-radius: ${RADIUS};
-  box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
+  ${sharedMediaFrameShapeStyles}
+  ${sharedMediaFrameBorderStyles}
   background-color: ${theme.colors.background.map};
   position: relative;
-`;
-
-//  Could use mixBlendMode: "multiply" on parent but that requires managing a white background fill
-// So instead setting a separate border div with the same dimensions
-const MapBorder = styled.div`
-  border-radius: ${RADIUS};
-  box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
 `;
 
 export default function MapThumbnail({
@@ -66,13 +59,16 @@ export default function MapThumbnail({
           layers: (layers as any)("protomaps", "light"),
         }}
         renderWorldCopies={true}
-        style={{ width: "100%", height: height, borderRadius: RADIUS }}
+        style={{
+          width: "100%",
+          height: height,
+          borderRadius: sharedMediaFrameRadius,
+        }}
         {...props}
       >
         <AttributionControl compact={true} />
         {children}
       </Map>
-      <MapBorder />
     </MapContainer>
   );
 }

--- a/src/components/NewsletterImage/NewsletterImage.tsx
+++ b/src/components/NewsletterImage/NewsletterImage.tsx
@@ -1,7 +1,11 @@
 import RemoteImage from "@/components/RemoteImage";
 import NewsletterImageFigcaption from "@/components/NewsletterImageFigcaption";
 import { css, styled } from "next-yak";
-import { theme } from "@/styles/theme.yak";
+import {
+  sharedMediaFrameBorderStyles,
+  sharedMediaFrameImageStyles,
+  sharedMediaFrameShapeStyles,
+} from "@/styles/mediaFrame";
 import type { ReactNode } from "react";
 import type { RemoteImageProps } from "@/components/RemoteImage/RemoteImage";
 
@@ -17,11 +21,13 @@ function NewsletterImage({
   border = true,
   ...props
 }: NewsletterImageProps) {
+  const Frame = border ? BorderedThumbnailContainer : ThumbnailContainer;
+
   return (
     <Figure $margin={margin}>
-      <ThumbnailContainer>
-        <StyledRemoteImage $border={border} {...props} />
-      </ThumbnailContainer>
+      <Frame>
+        <StyledRemoteImage {...props} />
+      </Frame>
       {caption && (
         <NewsletterImageFigcaption>{caption}</NewsletterImageFigcaption>
       )}
@@ -40,21 +46,15 @@ const Figure = styled.figure<{ $margin?: boolean }>`
 `;
 
 const ThumbnailContainer = styled.div`
-  box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
-  overflow: hidden;
-  border-radius: ${theme.corners.thumbnail};
+  ${sharedMediaFrameShapeStyles}
 `;
 
-const StyledRemoteImage = styled(RemoteImage)<{ $border?: boolean }>`
+const BorderedThumbnailContainer = styled(ThumbnailContainer)`
+  ${sharedMediaFrameBorderStyles}
+`;
+
+const StyledRemoteImage = styled(RemoteImage)`
+  ${sharedMediaFrameImageStyles}
   width: 100%;
   object-fit: cover;
-  background-color: ${theme.colors.background.sunk};
-  border-radius: ${theme.corners.thumbnail};
-
-  @media (prefers-color-scheme: light) {
-    mix-blend-mode: multiply;
-  }
-
-  ${({ $border }) =>
-    $border && `border: 1px solid ${theme.colors.border.base};`}
 `;

--- a/src/components/PhotoThumbnail/PhotoThumbnail.tsx
+++ b/src/components/PhotoThumbnail/PhotoThumbnail.tsx
@@ -1,18 +1,19 @@
 import Link from "next/link";
 import RemoteImage from "@/components/RemoteImage";
 import { styled } from "next-yak";
-import { theme } from "@/styles/theme.yak";
+import {
+  sharedMediaFrameImageStyles,
+  sharedMediaFrameStyles,
+} from "@/styles/mediaFrame";
 
 const PHOTO_THUMBNAIL_WIDTH = 360;
 const PHOTO_THUMBNAIL_HEIGHT = 240;
 
 const PhotoThumbnailContainer = styled(Link)`
+  ${sharedMediaFrameStyles}
   display: block;
   position: relative;
   flex-shrink: 0;
-  border-radius: 0.375rem;
-  box-shadow: 0 0 0 2px ${theme.colors.border.elevated} inset;
-  overflow: hidden;
   width: calc(${PHOTO_THUMBNAIL_WIDTH}px * 0.65);
   height: calc(${PHOTO_THUMBNAIL_HEIGHT}px * 0.65);
   @media (min-width: 768px) {
@@ -22,9 +23,8 @@ const PhotoThumbnailContainer = styled(Link)`
 `;
 
 const ListingPhotoRemoteImage = styled(RemoteImage)`
-  mix-blend-mode: multiply;
+  ${sharedMediaFrameImageStyles}
   object-fit: cover;
-  background-color: ${theme.colors.background.map};
 `;
 
 const Caption = styled.div`

--- a/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
+++ b/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { styled } from "next-yak";
+import { useRouter } from "next/navigation";
+
+import IconButton from "@/components/IconButton";
+import { theme } from "@/styles/theme.yak";
+
+const ViewerPage = styled.main`
+  background: #000;
+  color: #fff;
+  min-height: 100dvh;
+  padding: max(1rem, env(safe-area-inset-top))
+    max(1rem, env(safe-area-inset-right)) max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
+  position: relative;
+`;
+
+const ViewerToolbar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  left: 0;
+  padding: 0.5rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  @media (min-width: 768px) {
+    padding: 1rem;
+  }
+`;
+
+const CloseButton = styled(IconButton)`
+  backdrop-filter: blur(16px);
+  background: rgba(17, 17, 17, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.92);
+
+  &:visited {
+    color: rgba(255, 255, 255, 0.92);
+  }
+
+  &:hover:not([disabled]):not([aria-disabled="true"]) {
+    background: rgba(28, 28, 28, 0.9);
+    border-color: rgba(255, 255, 255, 0.24);
+    color: #fff;
+  }
+
+  &:focus,
+  &[data-focus] {
+    outline: 3px solid rgba(255, 255, 255, 0.94);
+    outline-offset: 2px;
+  }
+`;
+
+const ViewerBody = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: calc(100dvh - 2rem);
+
+  @media (min-width: 768px) {
+    min-height: calc(100dvh - 3rem);
+  }
+`;
+
+const ViewerImage = styled.img`
+  border-radius: 0.5rem;
+  display: block;
+  margin: 0 auto;
+  max-height: calc(100dvh - 7rem);
+  max-width: 100%;
+  object-fit: contain;
+  outline: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 0 0 2px ${theme.colors.border.elevated},
+    0 24px 80px rgba(0, 0, 0, 0.45);
+
+  @media (min-width: 768px) {
+    max-height: calc(100dvh - 9rem);
+  }
+`;
+
+export default function StandaloneListingPhotoPage({
+  alt,
+  backHref,
+  closeLabel,
+  src,
+}: {
+  alt: string;
+  backHref: string;
+  closeLabel: string;
+  src: string;
+}) {
+  const router = useRouter();
+
+  return (
+    <ViewerPage data-testid="listing-photo-tab-viewer">
+      <ViewerToolbar>
+        <CloseButton
+          aria-label={closeLabel}
+          data-testid="listing-photo-tab-viewer-close"
+          icon="close"
+          onClick={() => {
+            window.close();
+            window.setTimeout(() => {
+              router.replace(backHref);
+            }, 150);
+          }}
+          title={closeLabel}
+          variant="subtle"
+        />
+      </ViewerToolbar>
+
+      <ViewerBody>
+        <ViewerImage
+          alt={alt}
+          data-testid="listing-photo-tab-viewer-image"
+          src={src}
+        />
+      </ViewerBody>
+    </ViewerPage>
+  );
+}

--- a/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
+++ b/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
@@ -4,15 +4,11 @@ import { styled } from "next-yak";
 import { useRouter } from "next/navigation";
 
 import IconButton from "@/components/IconButton";
-import { theme } from "@/styles/theme.yak";
 
 const ViewerPage = styled.main`
   background: #000;
   color: #fff;
   min-height: 100dvh;
-  padding: max(1rem, env(safe-area-inset-top))
-    max(1rem, env(safe-area-inset-right)) max(1rem, env(safe-area-inset-bottom))
-    max(1rem, env(safe-area-inset-left));
   position: relative;
 `;
 
@@ -20,7 +16,9 @@ const ViewerToolbar = styled.div`
   display: flex;
   justify-content: flex-end;
   left: 0;
-  padding: 0.5rem;
+  padding: max(0.75rem, env(safe-area-inset-top))
+    max(0.75rem, env(safe-area-inset-right)) 0
+    max(0.75rem, env(safe-area-inset-left));
   position: absolute;
   right: 0;
   top: 0;
@@ -57,27 +55,36 @@ const ViewerBody = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  min-height: calc(100dvh - 2rem);
+  min-height: 100dvh;
+  padding: max(3.75rem, calc(env(safe-area-inset-top) + 2.75rem))
+    max(0.5rem, env(safe-area-inset-right))
+    max(0.5rem, env(safe-area-inset-bottom))
+    max(0.5rem, env(safe-area-inset-left));
 
   @media (min-width: 768px) {
-    min-height: calc(100dvh - 3rem);
+    padding: max(4.5rem, calc(env(safe-area-inset-top) + 3.25rem))
+      max(1rem, env(safe-area-inset-right))
+      max(1rem, env(safe-area-inset-bottom))
+      max(1rem, env(safe-area-inset-left));
   }
 `;
 
 const ViewerImage = styled.img`
   border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   display: block;
   margin: 0 auto;
-  max-height: calc(100dvh - 7rem);
-  max-width: 100%;
+  max-height: calc(100dvh - 4.75rem);
+  max-width: calc(100vw - 1rem);
   object-fit: contain;
-  outline: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
   box-shadow:
-    0 0 0 2px ${theme.colors.border.elevated},
+    0 0 0 1px rgba(255, 255, 255, 0.04),
     0 24px 80px rgba(0, 0, 0, 0.45);
 
   @media (min-width: 768px) {
-    max-height: calc(100dvh - 9rem);
+    max-height: calc(100dvh - 6.5rem);
+    max-width: calc(100vw - 2rem);
   }
 `;
 

--- a/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
+++ b/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
@@ -4,6 +4,10 @@ import { styled } from "next-yak";
 import { useRouter } from "next/navigation";
 
 import IconButton from "@/components/IconButton";
+import {
+  sharedMediaFrameBorderWidth,
+  sharedMediaFrameRadius,
+} from "@/styles/mediaFrame";
 
 const ViewerPage = styled.main`
   background: #000;
@@ -66,8 +70,8 @@ const ViewerBody = styled.div`
 `;
 
 const ViewerImage = styled.img`
-  border-radius: 0.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: ${sharedMediaFrameRadius};
+  border: ${sharedMediaFrameBorderWidth} solid rgba(255, 255, 255, 0.16);
   display: block;
   margin: 0 auto;
   max-height: calc(100dvh - 4.75rem);

--- a/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
+++ b/src/components/StandaloneListingPhotoPage/StandaloneListingPhotoPage.tsx
@@ -56,15 +56,11 @@ const ViewerBody = styled.div`
   display: flex;
   justify-content: center;
   min-height: 100dvh;
-  padding: max(3.75rem, calc(env(safe-area-inset-top) + 2.75rem))
-    max(0.5rem, env(safe-area-inset-right))
-    max(0.5rem, env(safe-area-inset-bottom))
+  padding: 0 max(0.5rem, env(safe-area-inset-right)) 0
     max(0.5rem, env(safe-area-inset-left));
 
   @media (min-width: 768px) {
-    padding: max(4.5rem, calc(env(safe-area-inset-top) + 3.25rem))
-      max(1rem, env(safe-area-inset-right))
-      max(1rem, env(safe-area-inset-bottom))
+    padding: 0 max(1rem, env(safe-area-inset-right)) 0
       max(1rem, env(safe-area-inset-left));
   }
 `;

--- a/src/components/StandaloneListingPhotoPage/index.ts
+++ b/src/components/StandaloneListingPhotoPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StandaloneListingPhotoPage";

--- a/src/styles/mediaFrame.ts
+++ b/src/styles/mediaFrame.ts
@@ -1,0 +1,25 @@
+import { css } from "next-yak";
+
+import { theme } from "@/styles/theme.yak";
+
+export const sharedMediaFrameRadius = "0.375rem";
+export const sharedMediaFrameBorderWidth = "2px";
+
+export const sharedMediaFrameShapeStyles = css`
+  border-radius: ${sharedMediaFrameRadius};
+  overflow: hidden;
+`;
+
+export const sharedMediaFrameBorderStyles = css`
+  border: ${sharedMediaFrameBorderWidth} solid ${theme.colors.border.elevated};
+`;
+
+export const sharedMediaFrameStyles = css`
+  ${sharedMediaFrameShapeStyles}
+  ${sharedMediaFrameBorderStyles}
+`;
+
+export const sharedMediaFrameImageStyles = css`
+  background-color: ${theme.colors.background.sunk};
+  display: block;
+`;

--- a/src/utils/listingPhotoRoute.ts
+++ b/src/utils/listingPhotoRoute.ts
@@ -10,5 +10,9 @@ export function buildListingPhotoHref(listingSlug: string, photo: string) {
 export function parseListingPhotoPath(photoPath: string[] | undefined) {
   if (!photoPath || photoPath.length === 0) return null;
 
-  return photoPath.map((segment) => decodeURIComponent(segment)).join("/");
+  try {
+    return photoPath.map((segment) => decodeURIComponent(segment)).join("/");
+  } catch {
+    return null;
+  }
 }

--- a/src/utils/listingPhotoRoute.ts
+++ b/src/utils/listingPhotoRoute.ts
@@ -1,0 +1,14 @@
+export function buildListingPhotoHref(listingSlug: string, photo: string) {
+  const encodedPhotoPath = photo
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `/listings/${encodeURIComponent(listingSlug)}/photos/${encodedPhotoPath}`;
+}
+
+export function parseListingPhotoPath(photoPath: string[] | undefined) {
+  if (!photoPath || photoPath.length === 0) return null;
+
+  return photoPath.map((segment) => decodeURIComponent(segment)).join("/");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", "supabase", ".next/dev/types/**/*.ts"]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "allowImportingTsExtensions": true
-  },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", "supabase", ".next/dev/types/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #29.

## Summary
- replace the lightbox spike with a dedicated photo page that opens in a new tab by default
- give the photo page its own stripped-back layout, separate from the main app chrome
- rely on browser-native zoom and tab behaviour instead of a gesture-heavy in-app lightbox
- keep the page intentionally minimal, with a floating close control and a larger, less inset photo treatment
- add a meaningful photo tab title and mark photo pages as non-indexable

## Verification
- npm run typecheck
- npm run check
- npx playwright test e2e/listings.spec.ts --config=playwright.prod.config.ts --grep "listing photos open in a dedicated photo tab|direct photo page close falls back to the listing page|map listing photos open in a dedicated photo tab"