### PR TITLE
fix map first load

### DIFF
--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { STORED_MAP_VIEW_KEY } from "../src/features/map/lib/mapStorageConstants";
+
+type StoredMapView = {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+};
+
+async function readStoredMapView(page: Page) {
+  const value = await page.evaluate(
+    (storageKey) => window.localStorage.getItem(storageKey),
+    STORED_MAP_VIEW_KEY
+  );
+
+  return value ? (JSON.parse(value) as StoredMapView) : null;
+}
+
+function expectStoredMapViewToMatch(
+  actual: StoredMapView | null,
+  expected: StoredMapView
+) {
+  expect(actual).not.toBeNull();
+  expect(actual?.latitude).toBeCloseTo(expected.latitude, 5);
+  expect(actual?.longitude).toBeCloseTo(expected.longitude, 5);
+  expect(actual?.zoom).toBeCloseTo(expected.zoom, 2);
+}
+
+test("map mounts when IP location is unavailable and restores the last view", async ({
+  page,
+}) => {
+  let geolocationRequests = 0;
+
+  await page.route(/api\.maptiler\.com\/geolocation/i, async (route) => {
+    geolocationRequests += 1;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await route.abort("failed");
+  });
+
+  try {
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+
+    const mapView = page.getByTestId("map-view");
+    await expect(mapView.locator(".maplibregl-canvas")).toBeVisible({
+      timeout: 10_000,
+    });
+    expect(await readStoredMapView(page)).toBeNull();
+
+    await page.getByRole("button", { name: /zoom in/i }).click();
+
+    await expect
+      .poll(
+        async () => {
+          const storedView = await readStoredMapView(page);
+          return storedView?.zoom ?? null;
+        },
+        { timeout: 5000 }
+      )
+      .toBeGreaterThan(1.5);
+    const storedAfterMove = await readStoredMapView(page);
+    expect(storedAfterMove).not.toBeNull();
+    if (!storedAfterMove) throw new Error("Expected stored map view");
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await expect(mapView.locator(".maplibregl-canvas")).toBeVisible({
+      timeout: 10_000,
+    });
+    expectStoredMapViewToMatch(await readStoredMapView(page), storedAfterMove);
+
+    await page.getByRole("button", { name: /zoom in/i }).click();
+    await expect
+      .poll(async () => {
+        const storedView = await readStoredMapView(page);
+        return storedView?.zoom ?? null;
+      })
+      .toBeGreaterThan(storedAfterMove.zoom + 0.5);
+    const storedAfterRestoredZoom = await readStoredMapView(page);
+    expect(storedAfterRestoredZoom?.latitude).toBeCloseTo(
+      storedAfterMove.latitude,
+      5
+    );
+    expect(storedAfterRestoredZoom?.longitude).toBeCloseTo(
+      storedAfterMove.longitude,
+      5
+    );
+    expect(storedAfterRestoredZoom?.zoom).toBeGreaterThan(
+      storedAfterMove.zoom + 0.5
+    );
+    expect(geolocationRequests).toBeGreaterThanOrEqual(1);
+  } finally {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  }
+});

--- a/src/features/map/components/MapView.tsx
+++ b/src/features/map/components/MapView.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { theme } from "@/styles/theme.yak";
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { ComponentType, CSSProperties } from "react";
 
 import Map, {
@@ -18,25 +18,27 @@ import { useLocale, useTranslations } from "next-intl";
 import { styled } from "next-yak";
 
 import Button from "@/components/Button";
-import type {
-  ListingCoordinates,
-  ListingMarker,
-  SelectedListing,
-} from "@/types/listing";
+import type { ListingMarker, SelectedListing } from "@/types/listing";
 
 import MapPinLayer from "./MapPinLayer";
 import MapSearch from "./MapSearch";
 import {
-  DEFAULT_COORDINATES,
+  MAP_MAX_ZOOM,
   ZOOM_LEVEL_DEFAULT,
   ZOOM_LEVEL_SELECTED,
   getListingCoordinates,
   hasValidCoordinates,
+  wrapLongitude,
 } from "../lib/mapUtils";
 import { useListingsInView } from "../hooks/useListingsInView";
 import { useMapCenter } from "../hooks/useMapCenter";
 import { usePreferredMapFlavor } from "../hooks/usePreferredMapFlavor";
 import { createProtomapsStyle } from "../lib/protomapsStyle";
+import {
+  NEUTRAL_INITIAL_COORDINATES,
+  saveStoredInitialMapCoordinates,
+  type InitialMapCoordinates,
+} from "../lib/mapInitialView";
 
 type GeocodingPickEvent = {
   feature?: { center?: [number, number] };
@@ -47,7 +49,7 @@ type MapViewProps = {
   selectedListingId: number | null;
   listingSlug: string | null;
   isListingSelected: boolean;
-  initialCoordinates: (ListingCoordinates & { zoom: number }) | null;
+  initialCoordinates: InitialMapCoordinates | null;
   onMapClick: () => void;
   onMarkerClick: (listing: ListingMarker) => void;
   DrawerTrigger: ComponentType<{ children?: React.ReactNode }>;
@@ -111,9 +113,13 @@ const searchStyle: CSSProperties = {
   zIndex: 1,
 };
 
+const STORE_MAP_VIEW_DELAY_MS = 300;
+const STORE_MAP_VIEW_DELTA = 0.000001;
+const STORE_MAP_ZOOM_DELTA = 0.01;
+
 function resolveInitialViewState(
   selectedListing: SelectedListing | null,
-  initialCoordinates: (ListingCoordinates & { zoom: number }) | null
+  initialCoordinates: InitialMapCoordinates | null
 ) {
   const selectedCoords = getListingCoordinates(selectedListing);
   const isSelected =
@@ -123,14 +129,14 @@ function resolveInitialViewState(
     longitude:
       (isSelected ? selectedCoords!.longitude : undefined) ??
       initialCoordinates?.longitude ??
-      DEFAULT_COORDINATES.longitude,
+      NEUTRAL_INITIAL_COORDINATES.longitude,
     latitude:
       (isSelected ? selectedCoords!.latitude : undefined) ??
       initialCoordinates?.latitude ??
-      DEFAULT_COORDINATES.latitude,
+      NEUTRAL_INITIAL_COORDINATES.latitude,
     zoom: isSelected
       ? ZOOM_LEVEL_SELECTED
-      : (initialCoordinates?.zoom ?? ZOOM_LEVEL_DEFAULT),
+      : (initialCoordinates?.zoom ?? NEUTRAL_INITIAL_COORDINATES.zoom),
   };
 }
 
@@ -150,9 +156,19 @@ export default function MapView({
   const locale = useLocale();
   const mapFlavor = usePreferredMapFlavor();
   const mapRef = useRef<MapRef | null>(null);
+  const saveMapViewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const lastSavedMapViewRef = useRef<InitialMapCoordinates | null>(
+    initialCoordinates
+  );
   const mapStyle = useMemo(
     () => createProtomapsStyle({ flavorName: mapFlavor, locale }),
     [locale, mapFlavor]
+  );
+  const initialViewState = useMemo(
+    () => resolveInitialViewState(selectedListing, initialCoordinates),
+    [initialCoordinates, selectedListing]
   );
 
   const { listings, isFetching, requestBounds } = useListingsInView();
@@ -167,14 +183,6 @@ export default function MapView({
     mapRef,
     selectedListing,
   });
-
-  // MapLibre's `initialViewState` is only consumed once at mount, so we wait
-  // for either a selected listing or the IP-based (or fallback) initial
-  // centre to resolve before mounting the Map. `useIpInitialLocation`
-  // always resolves (to DEFAULT_COORDINATES on failure or when skipped), so
-  // this cannot stall indefinitely.
-  const hasInitialPosition =
-    hasValidCoordinates(selectedListing) || Boolean(initialCoordinates);
 
   const emitBoundsChange = useCallback(
     (bounds: LngLatBounds) => {
@@ -191,14 +199,63 @@ export default function MapView({
     }
   }, [emitBoundsChange, handleMapLoad]);
 
+  useEffect(() => {
+    if (initialCoordinates) {
+      lastSavedMapViewRef.current = initialCoordinates;
+    }
+  }, [initialCoordinates]);
+
+  const scheduleStoredMapViewSave = useCallback(() => {
+    if (saveMapViewTimeoutRef.current !== null) {
+      clearTimeout(saveMapViewTimeoutRef.current);
+    }
+
+    saveMapViewTimeoutRef.current = setTimeout(() => {
+      saveMapViewTimeoutRef.current = null;
+
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+
+      const center = map.getCenter();
+      const coordinates = {
+        latitude: center.lat,
+        longitude: wrapLongitude(center.lng),
+        zoom: map.getZoom(),
+      };
+      const lastSaved = lastSavedMapViewRef.current;
+      const hasMeaningfulChange =
+        !lastSaved ||
+        Math.abs(lastSaved.latitude - coordinates.latitude) >
+          STORE_MAP_VIEW_DELTA ||
+        Math.abs(lastSaved.longitude - coordinates.longitude) >
+          STORE_MAP_VIEW_DELTA ||
+        Math.abs(lastSaved.zoom - coordinates.zoom) > STORE_MAP_ZOOM_DELTA;
+
+      if (!hasMeaningfulChange) return;
+
+      saveStoredInitialMapCoordinates(coordinates);
+      lastSavedMapViewRef.current = coordinates;
+    }, STORE_MAP_VIEW_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (saveMapViewTimeoutRef.current !== null) {
+        clearTimeout(saveMapViewTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleMoveEnd = useCallback(
     (_event: ViewStateChangeEvent) => {
       const map = mapRef.current?.getMap();
       if (!map) return;
+
+      scheduleStoredMapViewSave();
       emitBoundsChange(map.getBounds());
       handleMapMoveEnd();
     },
-    [emitBoundsChange, handleMapMoveEnd]
+    [emitBoundsChange, handleMapMoveEnd, scheduleStoredMapViewSave]
   );
 
   const handleMapClickInternal = useCallback(
@@ -228,20 +285,20 @@ export default function MapView({
   const showReturnButton = Boolean(
     selectedListing && isListingSelected && !isSelectedInView
   );
+  const hasInitialPosition =
+    hasValidCoordinates(selectedListing) || initialCoordinates !== null;
 
   return (
-    <MapContainer>
-      {hasInitialPosition && (
+    <MapContainer data-testid="map-view">
+      {hasInitialPosition ? (
         <>
           <Map
             ref={mapRef}
             attributionControl={false}
             mapStyle={mapStyle}
+            maxZoom={MAP_MAX_ZOOM}
             renderWorldCopies={true}
-            initialViewState={resolveInitialViewState(
-              selectedListing,
-              initialCoordinates
-            )}
+            initialViewState={initialViewState}
             onMoveEnd={handleMoveEnd}
             onLoad={handleLoad}
             onClick={handleMapClickInternal}
@@ -271,20 +328,24 @@ export default function MapView({
             countryCode={countryCode}
             style={searchStyle}
           />
-
-          {isFetching && <LoadingChip>{t("loadingPins")}</LoadingChip>}
-
-          {showReturnButton && (
-            <ReturnToListingButton
-              onClick={flyToSelected}
-              variant="secondary"
-              size="small"
-              width="contained"
-            >
-              {t("returnToListing")}
-            </ReturnToListingButton>
-          )}
         </>
+      ) : (
+        <LoadingChip>{t("loadingPins")}</LoadingChip>
+      )}
+
+      {hasInitialPosition && isFetching && (
+        <LoadingChip>{t("loadingPins")}</LoadingChip>
+      )}
+
+      {showReturnButton && (
+        <ReturnToListingButton
+          onClick={flyToSelected}
+          variant="secondary"
+          size="small"
+          width="contained"
+        >
+          {t("returnToListing")}
+        </ReturnToListingButton>
       )}
     </MapContainer>
   );

--- a/src/features/map/hooks/useIpInitialLocation.ts
+++ b/src/features/map/hooks/useIpInitialLocation.ts
@@ -1,11 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { config, geolocation } from "@maptiler/client";
 
-import type { ListingCoordinates } from "@/types/listing";
-
-import { DEFAULT_COORDINATES, ZOOM_LEVEL_DEFAULT } from "../lib/mapUtils";
+import { ZOOM_LEVEL_DEFAULT } from "../lib/mapUtils";
+import {
+  NEUTRAL_INITIAL_COORDINATES,
+  readStoredInitialMapCoordinates,
+  type InitialMapCoordinates,
+} from "../lib/mapInitialView";
 
 type UseIpInitialLocationArgs = {
   // Skip when the page already has a listing slug (deep-linked selections
@@ -14,8 +17,14 @@ type UseIpInitialLocationArgs = {
 };
 
 type UseIpInitialLocationResult = {
-  initialCoordinates: (ListingCoordinates & { zoom: number }) | null;
+  initialCoordinates: InitialMapCoordinates | null;
   countryCode: string | null;
+};
+
+type MapTilerIpLocation = {
+  latitude?: number;
+  longitude?: number;
+  country_code?: string;
 };
 
 // Guarded one-time init so the key is only assigned in the browser (the hook
@@ -30,65 +39,89 @@ function ensureMapTilerConfig() {
   hasConfiguredMapTiler = true;
 }
 
-// One-time IP-based initial centre. On timeout, error, or when skipped we
-// still resolve to `DEFAULT_COORDINATES` so MapView, which gates on
-// `initialCoordinates` being set, always eventually mounts — including deep
-// links to listings with `coordinates: null` or that resolve to an error.
+const INITIAL_LOCATION_TIMEOUT_MS = 1500;
+
+// One-time initial centre. Prefer the user's last viewed map area, otherwise
+// wait briefly for IP location before falling back to a neutral world view.
 export function useIpInitialLocation({
   skip = false,
 }: UseIpInitialLocationArgs = {}): UseIpInitialLocationResult {
-  const [initialCoordinates, setInitialCoordinates] = useState<
-    (ListingCoordinates & { zoom: number }) | null
-  >(null);
+  const shouldApplyIpCoordinatesRef = useRef(false);
+  const [initialCoordinates, setInitialCoordinates] =
+    useState<InitialMapCoordinates | null>(() => {
+      if (skip) return NEUTRAL_INITIAL_COORDINATES;
+      const storedCoordinates = readStoredInitialMapCoordinates();
+      shouldApplyIpCoordinatesRef.current = storedCoordinates === null;
+      return storedCoordinates;
+    });
   const [countryCode, setCountryCode] = useState<string | null>(null);
 
   useEffect(() => {
     if (skip) {
-      // Deep-linked: we're not running the IP lookup, but MapView still
-      // needs a non-null initial centre in case the listing itself has no
-      // valid coordinates (error sentinel or coordinates: null).
-      setInitialCoordinates({
-        ...DEFAULT_COORDINATES,
-        zoom: ZOOM_LEVEL_DEFAULT,
-      });
+      // Deep-linked selections centre on the listing when possible. Otherwise
+      // the neutral fallback keeps the map mountable.
+      setInitialCoordinates(
+        (current) => current ?? NEUTRAL_INITIAL_COORDINATES
+      );
       return;
     }
 
     ensureMapTilerConfig();
 
     let cancelled = false;
+
+    if (!shouldApplyIpCoordinatesRef.current) {
+      async function initializeCountryCode() {
+        try {
+          const response = (await geolocation.info()) as MapTilerIpLocation;
+          if (!cancelled) {
+            setCountryCode(response.country_code ?? null);
+          }
+        } catch {
+          // The stored map view is enough to render; country-code narrowing is
+          // a best-effort enhancement for search.
+        }
+      }
+
+      initializeCountryCode();
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const applyFallback = () => {
       if (cancelled) return;
-      setInitialCoordinates({
-        ...DEFAULT_COORDINATES,
-        zoom: ZOOM_LEVEL_DEFAULT,
-      });
+      if (shouldApplyIpCoordinatesRef.current) {
+        setInitialCoordinates(NEUTRAL_INITIAL_COORDINATES);
+        shouldApplyIpCoordinatesRef.current = false;
+      }
     };
 
     async function initializeLocation() {
-      // Race the network call against a 3s timeout. We track the timeout id
-      // so we can clear it once the race settles — otherwise the losing
-      // branch can still fire and surface as an unhandled rejection.
-      const timeoutPromise = new Promise<never>((_, reject) => {
+      // Race the network call against a short timeout. We track the timeout id
+      // so a successful geolocation response can cancel the pending fallback
+      // work before it fires.
+      const timeoutPromise = new Promise<null>((resolve) => {
         timeoutId = setTimeout(() => {
           timeoutId = null;
-          reject(new Error("Location timeout"));
-        }, 3000);
+          resolve(null);
+        }, INITIAL_LOCATION_TIMEOUT_MS);
       });
 
       try {
         const response = (await Promise.race([
           geolocation.info(),
           timeoutPromise,
-        ])) as {
-          latitude?: number;
-          longitude?: number;
-          country_code?: string;
-        };
+        ])) as MapTilerIpLocation | null;
 
         if (cancelled) return;
+        if (!response) {
+          applyFallback();
+          return;
+        }
 
         const lat = response?.latitude;
         const lng = response?.longitude;
@@ -99,11 +132,14 @@ export function useIpInitialLocation({
           Number.isFinite(lng)
         ) {
           setCountryCode(response.country_code ?? null);
-          setInitialCoordinates({
-            latitude: lat,
-            longitude: lng,
-            zoom: ZOOM_LEVEL_DEFAULT,
-          });
+          if (shouldApplyIpCoordinatesRef.current) {
+            setInitialCoordinates({
+              latitude: lat,
+              longitude: lng,
+              zoom: ZOOM_LEVEL_DEFAULT,
+            });
+            shouldApplyIpCoordinatesRef.current = false;
+          }
         } else {
           applyFallback();
         }

--- a/src/features/map/lib/mapInitialView.ts
+++ b/src/features/map/lib/mapInitialView.ts
@@ -1,0 +1,72 @@
+import type { ListingCoordinates } from "@/types/listing";
+
+import { MAP_MAX_ZOOM, wrapLongitude } from "./mapUtils";
+import { STORED_MAP_VIEW_KEY } from "./mapStorageConstants";
+
+export type InitialMapCoordinates = ListingCoordinates & { zoom: number };
+
+export const NEUTRAL_INITIAL_COORDINATES: InitialMapCoordinates = {
+  latitude: 20,
+  longitude: 0,
+  zoom: 1.5,
+};
+
+function isValidInitialMapCoordinates(
+  value: Partial<InitialMapCoordinates> | null
+): value is InitialMapCoordinates {
+  return Boolean(
+    value &&
+    typeof value.latitude === "number" &&
+    Number.isFinite(value.latitude) &&
+    value.latitude >= -90 &&
+    value.latitude <= 90 &&
+    typeof value.longitude === "number" &&
+    Number.isFinite(value.longitude) &&
+    typeof value.zoom === "number" &&
+    Number.isFinite(value.zoom) &&
+    value.zoom >= 0
+  );
+}
+
+function normaliseInitialMapCoordinates(
+  value: Partial<InitialMapCoordinates> | null
+): InitialMapCoordinates | null {
+  if (!isValidInitialMapCoordinates(value)) return null;
+
+  return {
+    latitude: value.latitude,
+    longitude: wrapLongitude(value.longitude),
+    zoom: Math.min(value.zoom, MAP_MAX_ZOOM),
+  };
+}
+
+export function readStoredInitialMapCoordinates() {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const value = window.localStorage.getItem(STORED_MAP_VIEW_KEY);
+    if (!value) return null;
+
+    const parsed = JSON.parse(value) as Partial<InitialMapCoordinates> | null;
+    return normaliseInitialMapCoordinates(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredInitialMapCoordinates(
+  coordinates: InitialMapCoordinates
+) {
+  if (typeof window === "undefined") return;
+  const normalisedCoordinates = normaliseInitialMapCoordinates(coordinates);
+  if (!normalisedCoordinates) return;
+
+  try {
+    window.localStorage.setItem(
+      STORED_MAP_VIEW_KEY,
+      JSON.stringify(normalisedCoordinates)
+    );
+  } catch {
+    // Ignore storage failures, such as private browsing restrictions.
+  }
+}

--- a/src/features/map/lib/mapStorageConstants.ts
+++ b/src/features/map/lib/mapStorageConstants.ts
@@ -1,0 +1,1 @@
+export const STORED_MAP_VIEW_KEY = "peels.map.lastView.v1";

--- a/src/features/map/lib/mapUtils.ts
+++ b/src/features/map/lib/mapUtils.ts
@@ -15,16 +15,9 @@ export type BoundingBox = {
   east: number;
 };
 
-// Default coordinates for Brisbane, Australia — the absolute fallback when
-// IP-based geolocation is unavailable. Pair with `ZOOM_LEVEL_DEFAULT` for
-// the zoom level.
-export const DEFAULT_COORDINATES: ListingCoordinates = {
-  latitude: -27.4683,
-  longitude: 153.0322,
-};
-
 export const ZOOM_LEVEL_DEFAULT = 11;
 export const ZOOM_LEVEL_SELECTED = 14;
+export const MAP_MAX_ZOOM = 15;
 
 // Durations (ms) for the different fly-to flows
 export const FLY_DURATION = {
@@ -85,7 +78,7 @@ export function hasValidCoordinates(
 // the user has panned across the antimeridian), but the `listings_in_view`
 // RPC feeds them into PostGIS' `st_makeenvelope`, which expects canonical
 // longitudes.
-function wrapLongitude(lng: number): number {
+export function wrapLongitude(lng: number): number {
   return ((((lng + 180) % 360) + 360) % 360) - 180;
 }
 

--- a/src/features/map/lib/protomapsStyle.ts
+++ b/src/features/map/lib/protomapsStyle.ts
@@ -1,6 +1,11 @@
 import { layers, namedFlavor } from "@protomaps/basemaps";
 
+import { MAP_MAX_ZOOM } from "./mapUtils";
+
 type ProtomapsFlavorName = "light" | "dark";
+
+const PROTOMAPS_TILE_API_BASE_URL = "https://api.protomaps.com/tiles/v4";
+let hasWarnedMissingProtomapsApiKey = false;
 
 const PROTOMAPS_LANGUAGE_BY_LOCALE: Record<string, string> = {
   en: "en",
@@ -21,6 +26,16 @@ export function createProtomapsStyle({
   flavorName: ProtomapsFlavorName;
   locale: string;
 }) {
+  const apiKey = process.env.NEXT_PUBLIC_PROTOMAPS_API_KEY;
+  const tileUrl = `${PROTOMAPS_TILE_API_BASE_URL}/{z}/{x}/{y}.mvt${
+    apiKey ? `?key=${encodeURIComponent(apiKey)}` : ""
+  }`;
+
+  if (!apiKey && !hasWarnedMissingProtomapsApiKey) {
+    hasWarnedMissingProtomapsApiKey = true;
+    console.warn("NEXT_PUBLIC_PROTOMAPS_API_KEY is not configured.");
+  }
+
   return {
     version: 8 as const,
     glyphs:
@@ -29,8 +44,10 @@ export function createProtomapsStyle({
     sources: {
       protomaps: {
         type: "vector" as const,
-        url: `https://api.protomaps.com/tiles/v4.json?key=${process.env.NEXT_PUBLIC_PROTOMAPS_API_KEY}`,
-        attribution: '<a href="https://protomaps.com">Protomaps</a>',
+        maxzoom: MAP_MAX_ZOOM,
+        tiles: [tileUrl],
+        attribution:
+          '<a href="https://protomaps.com">Protomaps</a> | <a href="https://osm.org/copyright">OpenStreetMap</a>',
       },
     },
     layers: layers("protomaps", namedFlavor(flavorName), {


### PR DESCRIPTION
## What changed

- Switched the Protomaps source from the hosted TileJSON bootstrap URL to the direct ZXY vector tile template.
- Removed Brisbane as the immediate default for new `/map` visits.
- Added a short initial-location grace period: first-time visitors wait briefly for IP location, then fall back to a neutral world view if it is slow or unavailable.
- Persisted the last viewed map centre/zoom in `localStorage` so returning visitors open where they last were.
- Preserved the existing map instance across listing and browser-history changes so selected pins still animate with `flyTo` instead of snapping.

## Why

The production failure was happening before the map could properly load: MapLibre had to fetch `https://api.protomaps.com/tiles/v4.json?...` as a first step, and a transient failure there could leave the map blank. Separately, the map still had a nullable initial-position gate, so a first-load geolocation hiccup could leave only the blue shell.

The first version of this fix mounted immediately at Brisbane and then flew to the IP-derived location. That avoided a blank map, but felt wrong for global users. This version either mounts directly at the saved/IP-derived location or opens on a neutral world view, with no automatic long-distance flyover.

## Validation

- `npm run check`
- `npm run typecheck`
- `npm run build`
- Browser smoke test at `http://localhost:3000/map` with cleared saved map view confirmed the map rendered without console errors and saved the resolved view.
