### PR TITLE
fix signed-in locale precedence

### DIFF
--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -69,3 +69,42 @@ test("profile locale change persists after refresh", async ({ page }) => {
     timeout: 15_000,
   });
 });
+
+test("signed-in preference overrides guest footer locale cookie", async ({
+  page,
+}) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+  await page.getByTestId("profile-account-language-edit").click();
+  await page.getByTestId("profile-account-language-input").selectOption("en");
+  await page.getByTestId("profile-account-language-submit").click();
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    localeLabels.en
+  );
+
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("lang", "en", {
+    timeout: 15_000,
+  });
+
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === "/"),
+    page.getByRole("button", { name: /sign out/i }).click(),
+  ]);
+
+  const localeSelect = page.getByTestId("locale-picker-select");
+  await expect(localeSelect).toBeVisible();
+  await localeSelect.selectOption("de");
+  await expect(page.locator("html")).toHaveAttribute("lang", "de", {
+    timeout: 15_000,
+  });
+
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "en", {
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    localeLabels.en
+  );
+});

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import {
   HOST_EMAIL,
   delayProfileActionRequests,
@@ -6,6 +6,31 @@ import {
   signIn,
 } from "./helpers";
 import { isValidLocale, localeLabels, type Locale } from "../src/i18n/config";
+
+async function submitProfileLocaleForm(page: Page, locale: Locale) {
+  await page.getByTestId("profile-account-language-input").selectOption(locale);
+
+  const languageSubmit = page.getByTestId("profile-account-language-submit");
+  const languageClick = languageSubmit.click();
+  await expect(languageSubmit).toBeDisabled();
+  await expect(languageSubmit).toHaveAttribute("aria-busy", "true");
+  await languageClick;
+  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+    localeLabels[locale]
+  );
+}
+
+async function saveProfileLocale(page: Page, locale: Locale) {
+  const languageInput = page.getByTestId("profile-account-language-input");
+
+  if (await languageInput.isVisible().catch(() => false)) {
+    await submitProfileLocaleForm(page, locale);
+    return;
+  }
+
+  await page.getByTestId("profile-account-language-edit").click();
+  await submitProfileLocaleForm(page, locale);
+}
 
 test("public footer locale switch refreshes the page locale", async ({
   page,
@@ -40,30 +65,14 @@ test("profile locale change persists after refresh", async ({ page }) => {
   const originalLocale: Locale = originalLanguage;
   const updatedLanguage: Locale = originalLocale === "de" ? "en" : "de";
 
-  await languageInput.selectOption(updatedLanguage);
-
-  const languageSubmit = page.getByTestId("profile-account-language-submit");
-  const languageClick = languageSubmit.click();
-  await expect(languageSubmit).toBeDisabled();
-  await expect(languageSubmit).toHaveAttribute("aria-busy", "true");
-  await languageClick;
-  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    localeLabels[updatedLanguage]
-  );
+  await submitProfileLocaleForm(page, updatedLanguage);
 
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", updatedLanguage, {
     timeout: 15_000,
   });
 
-  await page.getByTestId("profile-account-language-edit").click();
-  await page
-    .getByTestId("profile-account-language-input")
-    .selectOption(originalLocale);
-  await page.getByTestId("profile-account-language-submit").click();
-  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    localeLabels[originalLocale]
-  );
+  await saveProfileLocale(page, originalLocale);
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", originalLocale, {
     timeout: 15_000,
@@ -73,38 +82,57 @@ test("profile locale change persists after refresh", async ({ page }) => {
 test("signed-in preference overrides guest footer locale cookie", async ({
   page,
 }) => {
-  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
-
-  await page.getByTestId("profile-account-language-edit").click();
-  await page.getByTestId("profile-account-language-input").selectOption("en");
-  await page.getByTestId("profile-account-language-submit").click();
-  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    localeLabels.en
-  );
-
-  await page.reload();
-  await expect(page.locator("html")).toHaveAttribute("lang", "en", {
-    timeout: 15_000,
-  });
-
-  await Promise.all([
-    page.waitForURL((url) => url.pathname === "/"),
-    page.getByRole("button", { name: /sign out/i }).click(),
-  ]);
-
-  const localeSelect = page.getByTestId("locale-picker-select");
-  await expect(localeSelect).toBeVisible();
-  await localeSelect.selectOption("de");
-  await expect(page.locator("html")).toHaveAttribute("lang", "de", {
-    timeout: 15_000,
-  });
+  let originalLocale: Locale | null = null;
 
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+  await delayProfileActionRequests(page);
 
-  await expect(page.locator("html")).toHaveAttribute("lang", "en", {
-    timeout: 15_000,
-  });
-  await expect(page.getByTestId("profile-account-language-value")).toHaveText(
-    localeLabels.en
-  );
+  try {
+    await page.getByTestId("profile-account-language-edit").click();
+    const languageInput = page.getByTestId("profile-account-language-input");
+    const originalLanguage = await languageInput.inputValue();
+
+    if (!isValidLocale(originalLanguage)) {
+      throw new Error(`Unexpected profile language value: ${originalLanguage}`);
+    }
+
+    originalLocale = originalLanguage;
+    await submitProfileLocaleForm(page, "en");
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("lang", "en", {
+      timeout: 15_000,
+    });
+
+    await Promise.all([
+      page.waitForURL((url) => url.pathname === "/"),
+      page.getByRole("button", { name: /sign out/i }).click(),
+    ]);
+
+    const localeSelect = page.getByTestId("locale-picker-select");
+    await expect(localeSelect).toBeVisible();
+    await localeSelect.selectOption("de");
+    await expect(page.locator("html")).toHaveAttribute("lang", "de", {
+      timeout: 15_000,
+    });
+
+    await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "en", {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("profile-account-language-value")).toHaveText(
+      localeLabels.en
+    );
+  } finally {
+    if (originalLocale && originalLocale !== "en") {
+      await page.goto("/profile");
+
+      if (new URL(page.url()).pathname === "/sign-in") {
+        await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+      }
+
+      await saveProfileLocale(page, originalLocale);
+    }
+  }
 });

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -19,17 +19,13 @@ export async function getUserLocale() {
     cookieStore.get(localeCookieName)?.value ?? null
   );
 
-  if (cookieLocale) {
-    return cookieLocale;
-  }
-
   const headersList = await headers();
   const acceptedLocales = parseAcceptLanguageHeader(
     headersList.get("accept-language")
   );
 
   if (!hasSupabaseAuthCookie(cookieStore.getAll())) {
-    return acceptedLocales[0] ?? defaultLocale;
+    return cookieLocale ?? acceptedLocales[0] ?? defaultLocale;
   }
 
   const supabase = await createClient();
@@ -38,15 +34,6 @@ export async function getUserLocale() {
   } = await supabase.auth.getUser();
 
   if (user?.id) {
-    const metadataLocale = normaliseLocale(
-      typeof user.user_metadata?.preferred_locale === "string"
-        ? user.user_metadata.preferred_locale
-        : null
-    );
-    if (metadataLocale) {
-      return metadataLocale;
-    }
-
     const { data: profile, error: profileError } = await supabase
       .from("profiles")
       .select("preferred_locale")
@@ -64,13 +51,18 @@ export async function getUserLocale() {
     if (profileLocale) {
       return profileLocale;
     }
+
+    const metadataLocale = normaliseLocale(
+      typeof user.user_metadata?.preferred_locale === "string"
+        ? user.user_metadata.preferred_locale
+        : null
+    );
+    if (metadataLocale) {
+      return metadataLocale;
+    }
   }
 
-  if (acceptedLocales.length > 0) {
-    return acceptedLocales[0];
-  }
-
-  return defaultLocale;
+  return cookieLocale ?? acceptedLocales[0] ?? defaultLocale;
 }
 
 // Used in an explicit component, like a language picker:

--- a/src/i18n/services/locale.ts
+++ b/src/i18n/services/locale.ts
@@ -23,9 +23,10 @@ export async function getUserLocale() {
   const acceptedLocales = parseAcceptLanguageHeader(
     headersList.get("accept-language")
   );
+  const fallbackLocale = cookieLocale ?? acceptedLocales[0] ?? defaultLocale;
 
   if (!hasSupabaseAuthCookie(cookieStore.getAll())) {
-    return cookieLocale ?? acceptedLocales[0] ?? defaultLocale;
+    return fallbackLocale;
   }
 
   const supabase = await createClient();
@@ -62,7 +63,7 @@ export async function getUserLocale() {
     }
   }
 
-  return cookieLocale ?? acceptedLocales[0] ?? defaultLocale;
+  return fallbackLocale;
 }
 
 // Used in an explicit component, like a language picker:


### PR DESCRIPTION
## Summary
- make signed-in locale resolution prefer the saved profile language before auth metadata, guest cookie, browser headers, or the default locale
- keep guest language switching unchanged for logged-out visitors
- add production e2e coverage for the guest German cookie vs signed-in English preference regression

## Root cause

`getUserLocale()` returned the `NEXT_LOCALE` cookie before checking whether the request belonged to a signed-in user. That meant a language chosen while logged out could keep taking precedence after sign-in, even when the account had a saved preferred language.

## Validation
- `npm run i18n:check`
- `npm run check`
- `npm run test:e2e:prod -- e2e/i18n.spec.ts`