### PR TITLE
improve map pin motion

### DIFF
--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { STORED_MAP_VIEW_KEY } from "../src/features/map/lib/mapStorageConstants";
 
@@ -7,6 +7,41 @@ type StoredMapView = {
   longitude: number;
   zoom: number;
 };
+
+const INNER_WEST_MAP_VIEW: StoredMapView = {
+  latitude: -33.91,
+  longitude: 151.16,
+  zoom: 7,
+};
+
+async function seedStoredMapView(page: Page, view: StoredMapView) {
+  await page.context().addCookies([
+    {
+      name: STORED_MAP_VIEW_KEY,
+      value: encodeURIComponent(JSON.stringify(view)),
+      url: "http://127.0.0.1:3000/map",
+    },
+  ]);
+
+  await page.addInitScript(
+    ([storageKey, storedView]) => {
+      window.localStorage.setItem(storageKey, JSON.stringify(storedView));
+    },
+    [STORED_MAP_VIEW_KEY, view] as const
+  );
+}
+
+async function seedStoredMapViewLocalStorageOnly(
+  page: Page,
+  view: StoredMapView
+) {
+  await page.addInitScript(
+    ([storageKey, storedView]) => {
+      window.localStorage.setItem(storageKey, JSON.stringify(storedView));
+    },
+    [STORED_MAP_VIEW_KEY, view] as const
+  );
+}
 
 async function readStoredMapView(page: Page) {
   const value = await page.evaluate(
@@ -17,6 +52,20 @@ async function readStoredMapView(page: Page) {
   return value ? (JSON.parse(value) as StoredMapView) : null;
 }
 
+async function readStoredMapViewCookie(page: Page) {
+  const cookies = await page.context().cookies("http://127.0.0.1:3000/map");
+  const cookie = cookies.find(({ name }) => name === STORED_MAP_VIEW_KEY);
+
+  return cookie
+    ? (JSON.parse(decodeURIComponent(cookie.value)) as StoredMapView)
+    : null;
+}
+
+function roundCookieExpectation(value: number) {
+  const roundedValue = Number(value.toFixed(2));
+  return Object.is(roundedValue, -0) ? 0 : roundedValue;
+}
+
 function expectStoredMapViewToMatch(
   actual: StoredMapView | null,
   expected: StoredMapView
@@ -25,6 +74,53 @@ function expectStoredMapViewToMatch(
   expect(actual?.latitude).toBeCloseTo(expected.latitude, 5);
   expect(actual?.longitude).toBeCloseTo(expected.longitude, 5);
   expect(actual?.zoom).toBeCloseTo(expected.zoom, 2);
+}
+
+async function expectMapPinDetailScale(page: Page, expectedScale: number) {
+  await expect
+    .poll(
+      async () =>
+        page.getByTestId("map-view").evaluate((element) => {
+          const value = getComputedStyle(element).getPropertyValue(
+            "--map-pin-detail-scale"
+          );
+
+          return Number.parseFloat(value);
+        }),
+      { timeout: 5000 }
+    )
+    .toBeCloseTo(expectedScale, 2);
+}
+
+async function expectMapPinVisualWidth(
+  locator: Locator,
+  expectedWidth: number
+) {
+  await expect
+    .poll(
+      async () =>
+        locator.evaluate((element) => element.getBoundingClientRect().width),
+      { timeout: 5000 }
+    )
+    .toBeCloseTo(expectedWidth, 1);
+}
+
+async function zoomInUntilMapPinsAreDetailed(page: Page) {
+  for (let i = 0; i < 5; i += 1) {
+    const detailScale = await page
+      .getByTestId("map-view")
+      .evaluate((element) =>
+        Number.parseFloat(
+          getComputedStyle(element).getPropertyValue("--map-pin-detail-scale")
+        )
+      );
+    if (detailScale >= 0.99) return;
+
+    await page.getByRole("button", { name: /zoom in/i }).click();
+    await page.waitForTimeout(500);
+  }
+
+  await expectMapPinDetailScale(page, 1);
 }
 
 test("map mounts when IP location is unavailable and restores the last view", async ({
@@ -61,6 +157,12 @@ test("map mounts when IP location is unavailable and restores the last view", as
     const storedAfterMove = await readStoredMapView(page);
     expect(storedAfterMove).not.toBeNull();
     if (!storedAfterMove) throw new Error("Expected stored map view");
+    const cookieAfterMove = await readStoredMapViewCookie(page);
+    expect(cookieAfterMove).toEqual({
+      latitude: roundCookieExpectation(storedAfterMove.latitude),
+      longitude: roundCookieExpectation(storedAfterMove.longitude),
+      zoom: roundCookieExpectation(storedAfterMove.zoom),
+    });
 
     await page.reload({ waitUntil: "domcontentloaded" });
 
@@ -92,4 +194,222 @@ test("map mounts when IP location is unavailable and restores the last view", as
   } finally {
     await page.unrouteAll({ behavior: "ignoreErrors" });
   }
+});
+
+test("map restores a localStorage-only view after hydration", async ({
+  page,
+}) => {
+  const hydrationErrors: string[] = [];
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      message.text().includes("Hydration failed")
+    ) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  await page.route(/api\.maptiler\.com\/geolocation/i, (route) =>
+    route.abort("failed")
+  );
+  await seedStoredMapViewLocalStorageOnly(page, {
+    ...INNER_WEST_MAP_VIEW,
+    zoom: 9,
+  });
+
+  try {
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+
+    const mapView = page.getByTestId("map-view");
+    await expect(mapView.locator(".maplibregl-canvas")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectMapPinDetailScale(page, 1);
+    expect(hydrationErrors).toEqual([]);
+  } finally {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  }
+});
+
+test("map pins minify at country zoom, then grow and animate selection", async ({
+  page,
+}) => {
+  const hydrationErrors: string[] = [];
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      message.text().includes("Hydration failed")
+    ) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  await seedStoredMapView(page, INNER_WEST_MAP_VIEW);
+
+  await page.goto("/map", { waitUntil: "domcontentloaded" });
+
+  const mapView = page.getByTestId("map-view");
+  await expect(mapView.locator(".maplibregl-canvas")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const firstPin = page.getByTestId("map-pin").first();
+  await expect(firstPin).toBeVisible({ timeout: 10_000 });
+  await expectMapPinDetailScale(page, 0);
+  await expectMapPinVisualWidth(
+    firstPin.locator('[data-testid="map-pin-compact-dot"]'),
+    10
+  );
+  await expect(
+    firstPin.locator('[data-testid="map-pin-compact-icon"]')
+  ).toHaveCSS("opacity", "0");
+  expect(hydrationErrors).toEqual([]);
+
+  const minifiedTargetMarker = page
+    .getByRole("button", { name: "Map marker" })
+    .last();
+  const minifiedTargetPin = minifiedTargetMarker.getByTestId("map-pin");
+  const minifiedTargetPinHandle = await minifiedTargetPin.elementHandle();
+  expect(minifiedTargetPinHandle).not.toBeNull();
+
+  await minifiedTargetPin.click();
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("open");
+
+  await mapView.click({ position: { x: 20, y: 450 } });
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("compact");
+
+  await minifiedTargetMarker.focus();
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("open");
+
+  await mapView.click({ position: { x: 20, y: 450 } });
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("compact");
+
+  await minifiedTargetMarker.focus();
+  await page.keyboard.press("Space");
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("open");
+
+  await mapView.click({ position: { x: 20, y: 450 } });
+  await expect
+    .poll(
+      async () =>
+        minifiedTargetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("compact");
+
+  await zoomInUntilMapPinsAreDetailed(page);
+
+  await expectMapPinDetailScale(page, 1);
+  await expectMapPinVisualWidth(
+    firstPin.locator('[data-testid="map-pin-compact-dot"]'),
+    24
+  );
+  await expect(
+    firstPin.locator('[data-testid="map-pin-compact-icon"]')
+  ).toHaveCSS("opacity", "1");
+
+  const targetMarker = page.getByRole("button", { name: "Map marker" }).last();
+  const targetPin = targetMarker.getByTestId("map-pin");
+  const targetPinHandle = await targetPin.elementHandle();
+  expect(targetPinHandle).not.toBeNull();
+
+  await targetPin.click();
+  await expect
+    .poll(
+      async () =>
+        targetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("open");
+  await expect
+    .poll(
+      async () =>
+        targetPinHandle!.evaluate((element) => {
+          const openLayer = element.querySelector(
+            '[data-testid="map-pin-open-layer"]'
+          );
+          if (!openLayer) return null;
+
+          return getComputedStyle(openLayer).visibility;
+        }),
+      { timeout: 5000 }
+    )
+    .toBe("visible");
+
+  const rootWasPreserved = await targetPinHandle!.evaluate(
+    (element) =>
+      element.isConnected &&
+      element.getAttribute("data-map-pin-state") === "open"
+  );
+  expect(rootWasPreserved).toBe(true);
+
+  await mapView.click({ position: { x: 20, y: 450 } });
+  await expect
+    .poll(
+      async () =>
+        targetPinHandle!.evaluate((element) =>
+          element.getAttribute("data-map-pin-state")
+        ),
+      { timeout: 5000 }
+    )
+    .toBe("compact");
+  await expect
+    .poll(
+      async () =>
+        targetPinHandle!.evaluate((element) => {
+          const compactIcon = element.querySelector(
+            '[data-testid="map-pin-compact-icon"]'
+          );
+          if (!compactIcon) return null;
+
+          return getComputedStyle(compactIcon).opacity;
+        }),
+      { timeout: 5000 }
+    )
+    .toBe("1");
 });

--- a/src/app/(core)/(interact)/(stretched)/map/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/map/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { cookies } from "next/headers";
 import type { Metadata } from "next/types";
 
 import { createClient } from "@/utils/supabase/server";
@@ -6,6 +7,8 @@ import { siteConfig } from "@/config/site";
 import { generateListingMetadata } from "@/utils/listingUtils";
 import MapPageClient from "@/features/map";
 import type { Listing } from "@/types/listing";
+import { parseStoredInitialMapCoordinates } from "@/features/map/lib/mapInitialView";
+import { STORED_MAP_VIEW_KEY } from "@/features/map/lib/mapStorageConstants";
 
 type MapPageSearchParams = {
   listing?: string;
@@ -36,6 +39,16 @@ const getInitialData = cache(async (listingSlug: string | undefined) => {
   };
 });
 
+function parseInitialMapCoordinatesCookie(value: string | undefined) {
+  if (!value) return null;
+
+  try {
+    return parseStoredInitialMapCoordinates(decodeURIComponent(value));
+  } catch {
+    return parseStoredInitialMapCoordinates(value);
+  }
+}
+
 export async function generateMetadata({
   searchParams,
 }: MapPageProps): Promise<Metadata> {
@@ -59,12 +72,16 @@ export default async function Page({ searchParams }: MapPageProps) {
   const listingSlug = (await searchParams)?.listing;
   const { user, listing } = await getInitialData(listingSlug);
   const referenceNow = new Date().toISOString();
+  const storedMapViewCookie = (await cookies()).get(STORED_MAP_VIEW_KEY)?.value;
+  const initialMapCoordinates =
+    parseInitialMapCoordinatesCookie(storedMapViewCookie);
 
   return (
     <MapPageClient
       user={user}
       initialListingSlug={listingSlug ?? null}
       initialListing={listing}
+      initialMapCoordinates={initialMapCoordinates}
       referenceNow={referenceNow}
     />
   );

--- a/src/components/MapPin/MapPin.tsx
+++ b/src/components/MapPin/MapPin.tsx
@@ -7,12 +7,23 @@ import { theme } from "@/styles/theme.yak";
 import type { ListingType } from "@/types/listing";
 
 type MapPinProps = {
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
   selected?: boolean;
+  markerId?: number | string;
   // Accept any string so callers that hold generic listing types (e.g.
   // LocationSelect) can still pass them in; unknown values just render the
   // default pin without a specialised icon.
   type?: string;
 };
+
+const PIN_ANIMATION_CURVE = "cubic-bezier(0.175, 0.885, 0.28, 1.12)";
+const PIN_MORPH_COLLAPSE_MS = 110;
+const PIN_MORPH_DOT_HOLD_MS = PIN_MORPH_COLLAPSE_MS;
+const PIN_MORPH_POP_MS = 135;
+const PIN_MORPH_REVEAL_DELAY_MS = PIN_MORPH_DOT_HOLD_MS + 35;
+const PIN_MORPH_REVEAL_MS = 50;
+const PIN_MORPH_COLLAPSED_SCALE = 0.16;
+const PIN_OPEN_ENTER_SCALE = 0.88;
 
 const residentialPinStyles = css`
   background:
@@ -79,18 +90,70 @@ const businessSelectedIconStyles = css`
   fill: ${theme.colors.marker.background.business};
 `;
 
-const UnselectedPin = styled.div`
+const PinRoot = styled.div<{ $selected?: boolean }>`
   cursor: pointer;
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
+  position: relative;
+  isolation: isolate;
+  pointer-events: none;
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      transition-duration: 1ms !important;
+      animation-duration: 1ms !important;
+    }
+  }
+`;
+
+const PinLayer = styled.div`
+  position: absolute;
+  top: -18px;
+  left: -18px;
+  width: 80px;
+  height: 80px;
   display: flex;
   justify-content: center;
   align-items: center;
+  pointer-events: none;
+  transform-origin: center;
 `;
 
-const UnselectedPinInner = styled.div<{ $type?: string }>`
-  box-shadow: 0 0 0 2.5px ${theme.colors.marker.border};
+const CompactPinLayer = styled(PinLayer)<{ $selected?: boolean }>`
+  visibility: ${({ $selected }) => ($selected ? "hidden" : "visible")};
+  transform: translateY(${({ $selected }) => ($selected ? "0.125rem" : "0")})
+    scale(${({ $selected }) => ($selected ? PIN_MORPH_COLLAPSED_SCALE : 1)});
+  transition:
+    visibility 0ms
+      ${({ $selected }) => ($selected ? "0ms" : `${PIN_MORPH_COLLAPSE_MS}ms`)},
+    transform
+      ${({ $selected }) =>
+        $selected
+          ? `${PIN_MORPH_COLLAPSE_MS}ms ease-in`
+          : `${PIN_MORPH_POP_MS}ms ${PIN_ANIMATION_CURVE} ${PIN_MORPH_DOT_HOLD_MS}ms`};
+  z-index: 2;
+`;
+
+const CompactPinHitTarget = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  cursor: pointer;
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+`;
+
+const CompactPinInner = styled.div<{ $type?: string }>`
+  box-shadow:
+    0 0 0 2.5px ${theme.colors.marker.border},
+    0 3px 14px rgba(0, 0, 0, 0.22),
+    0 0 4px rgba(0, 0, 0, 0.22);
   width: 24px;
   height: 24px;
   border-radius: 50%;
@@ -98,21 +161,55 @@ const UnselectedPinInner = styled.div<{ $type?: string }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  filter: drop-shadow(0px 3px 18px rgba(0, 0, 0, 0.1))
-    drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.15));
+  pointer-events: none;
+  transform: scale(var(--map-pin-compact-scale, 1));
+  transform-origin: center;
 
   ${({ $type }) => $type === "residential" && residentialPinStyles}
   ${({ $type }) => $type === "community" && communityPinStyles}
   ${({ $type }) => $type === "business" && businessPinStyles}
 `;
 
+const CompactPinIcon = styled.div`
+  display: flex;
+  opacity: var(--map-pin-icon-opacity, 1);
+  transform: scale(var(--map-pin-icon-scale, 1));
+`;
+
+const SelectedPinRingLayer = styled(PinLayer)<{ $selected?: boolean }>`
+  visibility: ${({ $selected }) => ($selected ? "visible" : "hidden")};
+  opacity: ${({ $selected }) => ($selected ? 1 : 0)};
+  transform: scale(
+    ${({ $selected }) => ($selected ? 1 : PIN_OPEN_ENTER_SCALE)}
+  );
+  transition:
+    visibility 0ms
+      ${({ $selected }) => ($selected ? "0ms" : `${PIN_MORPH_COLLAPSE_MS}ms`)},
+    opacity
+      ${({ $selected }) =>
+        $selected
+          ? `${PIN_MORPH_REVEAL_MS}ms ease-out ${PIN_MORPH_REVEAL_DELAY_MS}ms`
+          : `1ms linear ${PIN_MORPH_COLLAPSE_MS}ms`},
+    transform
+      ${({ $selected }) =>
+        $selected
+          ? `${PIN_MORPH_POP_MS}ms ${PIN_ANIMATION_CURVE} ${PIN_MORPH_DOT_HOLD_MS}ms`
+          : `${PIN_MORPH_COLLAPSE_MS}ms ease-in`};
+  will-change: ${({ $selected }) => ($selected ? "transform" : "auto")};
+  z-index: 1;
+`;
+
 const SelectedPinRing = styled.div<{ $type?: string }>`
   width: 80px;
   height: 80px;
+  position: absolute;
   border-radius: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
+  pointer-events: none;
+  z-index: 0;
+  transform: scale(var(--map-pin-halo-scale, 1));
 
   ${({ $type }) => {
     if ($type === "community") return communitySelectedRingStyles;
@@ -124,26 +221,60 @@ const SelectedPinRing = styled.div<{ $type?: string }>`
 const SelectedPinDot = styled.div`
   width: 0.5rem;
   height: 0.5rem;
+  position: relative;
+  z-index: 1;
   border-radius: 50%;
   background-color: ${theme.colors.marker.dot};
   box-shadow: 0 0 1px 1px ${theme.colors.border.elevated};
+  transition: transform 120ms ease-out;
 `;
 
-const SelectedPin = styled.div`
-  display: flex;
+const OpenPinLayer = styled(PinLayer)<{ $selected?: boolean }>`
+  visibility: ${({ $selected }) => ($selected ? "visible" : "hidden")};
+  opacity: ${({ $selected }) => ($selected ? 1 : 0)};
+  pointer-events: ${({ $selected }) => ($selected ? "auto" : "none")};
   cursor: pointer;
+  transform: translateY(
+      ${({ $selected }) => ($selected ? "-0.375rem" : "0.125rem")}
+    )
+    scale(${({ $selected }) => ($selected ? 1 : PIN_OPEN_ENTER_SCALE)});
+  transition:
+    visibility 0ms
+      ${({ $selected }) => ($selected ? "0ms" : `${PIN_MORPH_COLLAPSE_MS}ms`)},
+    opacity
+      ${({ $selected }) =>
+        $selected
+          ? `${PIN_MORPH_REVEAL_MS}ms ease-out ${PIN_MORPH_REVEAL_DELAY_MS}ms`
+          : `1ms linear ${PIN_MORPH_COLLAPSE_MS}ms`},
+    transform
+      ${({ $selected }) =>
+        $selected
+          ? `${PIN_MORPH_POP_MS}ms ${PIN_ANIMATION_CURVE} ${PIN_MORPH_DOT_HOLD_MS}ms`
+          : `${PIN_MORPH_COLLAPSE_MS}ms ease-in`};
+  will-change: ${({ $selected }) => ($selected ? "transform" : "auto")};
+  z-index: 3;
 
-  ${SelectedPinDot},
-  ${SelectedPinRing} {
-    transition: transform 75ms ease-in-out;
+  @media (hover: hover) {
+    ${PinRoot}:hover & {
+      transform: translateY(
+          ${({ $selected }) => ($selected ? "-0.5rem" : "0.125rem")}
+        )
+        scale(${({ $selected }) => ($selected ? 1.025 : PIN_OPEN_ENTER_SCALE)});
+    }
   }
+`;
 
-  &:hover ${SelectedPinDot} {
-    transform: scale(1.05);
-  }
+const SelectedPinHalo = styled.div`
+  display: contents;
 
-  &:hover ${SelectedPinRing} {
-    transform: scale(1.25);
+  @media (hover: hover) {
+    ${PinRoot}:hover & ${SelectedPinRing} {
+      transform: scale(calc(var(--map-pin-halo-scale, 1) * 1.035));
+    }
+
+    ${PinRoot}:hover & ${SelectedPinDot} {
+      transform: scale(1.08);
+    }
   }
 `;
 
@@ -157,8 +288,8 @@ const SelectedPinIcon = styled.svg<{ $type?: string }>`
   top: -0.2rem;
   left: 0;
   transform: translate(calc(40px - 1.625rem), -50%);
-  filter: drop-shadow(0px 3px 18px rgba(0, 0, 0, 0.12))
-    drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.15));
+  filter: drop-shadow(0px 4px 10px rgba(0, 0, 0, 0.14))
+    drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.2));
   transition: transform 110ms ease-in-out;
   transform-origin: center;
 
@@ -187,30 +318,43 @@ function isListingPinType(value: string | undefined): value is ListingType {
   );
 }
 
-function MapPin({ selected = false, type }: MapPinProps) {
+function MapPin({ onClick, selected = false, markerId, type }: MapPinProps) {
   const IconComponent = isListingPinType(type) ? iconMap[type] : null;
 
-  if (selected) {
-    return (
-      <SelectedPin>
-        <SelectedPinRing $type={type}>
+  return (
+    <PinRoot
+      $selected={selected}
+      data-map-pin-id={markerId}
+      data-map-pin-state={selected ? "open" : "compact"}
+      data-testid="map-pin"
+    >
+      <SelectedPinRingLayer $selected={selected} data-testid="map-pin-halo">
+        <SelectedPinHalo>
+          <SelectedPinRing $type={type} />
           <SelectedPinDot />
-        </SelectedPinRing>
+        </SelectedPinHalo>
+      </SelectedPinRingLayer>
 
+      <CompactPinLayer $selected={selected} data-testid="map-pin-compact-layer">
+        <CompactPinHitTarget onClick={onClick} />
+        <CompactPinInner $type={type ?? ""} data-testid="map-pin-compact-dot">
+          <CompactPinIcon data-testid="map-pin-compact-icon">
+            {IconComponent && <IconComponent size="normal" />}
+          </CompactPinIcon>
+        </CompactPinInner>
+      </CompactPinLayer>
+
+      <OpenPinLayer
+        $selected={selected}
+        data-testid="map-pin-open-layer"
+        onClick={onClick}
+      >
         <SelectedPinIcon viewBox="0 0 20 24" $type={type}>
           <path d={ICON} />
         </SelectedPinIcon>
         {IconComponent && <IconComponent size="large" />}
-      </SelectedPin>
-    );
-  }
-
-  return (
-    <UnselectedPin>
-      <UnselectedPinInner $type={type ?? ""}>
-        {IconComponent && <IconComponent size="normal" />}
-      </UnselectedPinInner>
-    </UnselectedPin>
+      </OpenPinLayer>
+    </PinRoot>
   );
 }
 

--- a/src/components/MapThumbnail/MapThumbnail.tsx
+++ b/src/components/MapThumbnail/MapThumbnail.tsx
@@ -13,6 +13,7 @@ import { useLocale } from "next-intl";
 
 import { styled } from "next-yak";
 import type { ComponentProps, ReactNode } from "react";
+import { handleMapError } from "@/features/map/lib/mapErrors";
 import { createProtomapsStyle } from "@/features/map/lib/protomapsStyle";
 import { usePreferredMapFlavor } from "@/features/map/hooks/usePreferredMapFlavor";
 
@@ -43,6 +44,7 @@ export default function MapThumbnail({
       <Map
         attributionControl={false} // Customised below
         mapStyle={mapStyle}
+        onError={handleMapError}
         renderWorldCopies={true}
         style={{
           width: "100%",

--- a/src/features/map/components/MapPageClient.tsx
+++ b/src/features/map/components/MapPageClient.tsx
@@ -14,6 +14,7 @@ import MapListingDrawerPanel from "./MapListingDrawerPanel";
 import MapSidebar from "./MapSidebar";
 import { useMapListingUrl } from "../hooks/useMapListingUrl";
 import { useIpInitialLocation } from "../hooks/useIpInitialLocation";
+import type { InitialMapCoordinates } from "../lib/mapInitialView";
 import {
   MAP_DRAWER_SNAP_POINTS,
   useMapDrawerState,
@@ -23,6 +24,7 @@ type MapPageClientProps = {
   user: User | null;
   initialListingSlug?: string | null;
   initialListing?: Listing | null;
+  initialMapCoordinates?: InitialMapCoordinates | null;
   referenceNow: string;
 };
 
@@ -51,6 +53,7 @@ export default function MapPageClient({
   user,
   initialListingSlug,
   initialListing,
+  initialMapCoordinates,
   referenceNow,
 }: MapPageClientProps) {
   const { isDesktop, hasTouch } = useDeviceContext();
@@ -66,6 +69,7 @@ export default function MapPageClient({
   } = useMapListingUrl({ user, initialListingSlug, initialListing });
 
   const { initialCoordinates, countryCode } = useIpInitialLocation({
+    initialCoordinates: initialMapCoordinates,
     skip: Boolean(initialListingSlug),
   });
 
@@ -135,7 +139,6 @@ export default function MapPageClient({
             initialCoordinates={initialCoordinates}
             onMapClick={handleMapClick}
             onMarkerClick={handleMarkerClick}
-            DrawerTrigger={Drawer.Trigger}
             isDesktop={isDesktop}
             countryCode={countryCode}
           />

--- a/src/features/map/components/MapPinLayer.tsx
+++ b/src/features/map/components/MapPinLayer.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import type { ComponentType } from "react";
-import { Marker } from "react-map-gl/maplibre";
+import { useEffect, useRef } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import {
+  Marker,
+  type MarkerEvent,
+  type MarkerInstance,
+} from "react-map-gl/maplibre";
 
 import MapPin from "@/components/MapPin";
 import type { ListingCoordinates, ListingMarker } from "@/types/listing";
@@ -11,14 +16,137 @@ import { hasValidCoordinates } from "../lib/mapUtils";
 type MapPinLayerProps = {
   listings: ListingMarker[];
   selectedListingId: number | null;
-  DrawerTrigger: ComponentType<{ children?: React.ReactNode }>;
   onMarkerClick: (listing: ListingMarker) => void;
 };
+
+type ListingMapPinMarkerProps = {
+  listing: ListingMarker;
+  coords: ListingCoordinates;
+  isSelected: boolean;
+  onMarkerClick: MapPinLayerProps["onMarkerClick"];
+};
+
+const KEYBOARD_ACTIVATION_KEYS = new Set(["Enter", " "]);
+// React handles pointer clicks on the inner 44px hit target, while MapLibre
+// also reports marker clicks from its own element. Suppress only same-tick
+// duplicate events without blocking deliberate follow-up activations.
+const DUPLICATE_MARKER_CLICK_SUPPRESSION_MS = 100;
+
+function ListingMapPinMarker({
+  listing,
+  coords,
+  isSelected,
+  onMarkerClick,
+}: ListingMapPinMarkerProps) {
+  const markerRef = useRef<MarkerInstance | null>(null);
+  const lastPinPointerClickRef = useRef<{
+    listingId: ListingMarker["id"];
+    timeStamp: number;
+  } | null>(null);
+  const lastKeyboardActivationRef = useRef<number | null>(null);
+  const isSpaceActivationPendingRef = useRef(false);
+
+  useEffect(() => {
+    const markerElement = markerRef.current?.getElement();
+    if (!markerElement) return;
+
+    markerElement.tabIndex = 0;
+
+    const activateFromKeyboard = (event: KeyboardEvent) => {
+      lastKeyboardActivationRef.current = event.timeStamp;
+      onMarkerClick(listing);
+    };
+
+    const handleMarkerKeyDown = (event: KeyboardEvent) => {
+      if (!KEYBOARD_ACTIVATION_KEYS.has(event.key)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.repeat) return;
+
+      if (event.key === " ") {
+        isSpaceActivationPendingRef.current = true;
+        return;
+      }
+
+      activateFromKeyboard(event);
+    };
+
+    const handleMarkerKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== " " || !isSpaceActivationPendingRef.current) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      isSpaceActivationPendingRef.current = false;
+      activateFromKeyboard(event);
+    };
+
+    markerElement.addEventListener("keydown", handleMarkerKeyDown);
+    markerElement.addEventListener("keyup", handleMarkerKeyUp);
+
+    return () => {
+      isSpaceActivationPendingRef.current = false;
+      markerElement.removeEventListener("keydown", handleMarkerKeyDown);
+      markerElement.removeEventListener("keyup", handleMarkerKeyUp);
+    };
+  }, [listing, onMarkerClick]);
+
+  const handlePinClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopPropagation();
+    lastPinPointerClickRef.current = {
+      listingId: listing.id,
+      timeStamp: event.timeStamp,
+    };
+    onMarkerClick(listing);
+  };
+
+  const handleMarkerClick = (event: MarkerEvent<globalThis.MouseEvent>) => {
+    event.originalEvent.stopPropagation();
+    const lastPinPointerClick = lastPinPointerClickRef.current;
+    if (
+      lastPinPointerClick?.listingId === listing.id &&
+      Math.abs(lastPinPointerClick.timeStamp - event.originalEvent.timeStamp) <
+        DUPLICATE_MARKER_CLICK_SUPPRESSION_MS
+    ) {
+      return;
+    }
+
+    const lastKeyboardActivation = lastKeyboardActivationRef.current;
+    if (
+      lastKeyboardActivation !== null &&
+      Math.abs(lastKeyboardActivation - event.originalEvent.timeStamp) <
+        DUPLICATE_MARKER_CLICK_SUPPRESSION_MS
+    ) {
+      return;
+    }
+
+    onMarkerClick(listing);
+  };
+
+  return (
+    <Marker
+      ref={markerRef}
+      longitude={coords.longitude}
+      latitude={coords.latitude}
+      anchor="center"
+      onClick={handleMarkerClick}
+      style={{ zIndex: isSelected ? 1 : 0 }}
+    >
+      <MapPin
+        markerId={listing.id}
+        onClick={handlePinClick}
+        selected={isSelected}
+        type={listing.type ?? undefined}
+      />
+    </Marker>
+  );
+}
 
 export default function MapPinLayer({
   listings,
   selectedListingId,
-  DrawerTrigger,
   onMarkerClick,
 }: MapPinLayerProps) {
   return (
@@ -30,23 +158,13 @@ export default function MapPinLayer({
           const isSelected = selectedListingId === listing.id;
 
           return (
-            <DrawerTrigger key={listing.id}>
-              <Marker
-                longitude={coords.longitude}
-                latitude={coords.latitude}
-                anchor="center"
-                onClick={(event) => {
-                  event.originalEvent.stopPropagation();
-                  onMarkerClick(listing);
-                }}
-                style={{ zIndex: isSelected ? 1 : 0 }}
-              >
-                <MapPin
-                  selected={isSelected}
-                  type={listing.type ?? undefined}
-                />
-              </Marker>
-            </DrawerTrigger>
+            <ListingMapPinMarker
+              key={listing.id}
+              listing={listing}
+              coords={coords}
+              isSelected={isSelected}
+              onMarkerClick={onMarkerClick}
+            />
           );
         })}
     </>

--- a/src/features/map/components/MapView.tsx
+++ b/src/features/map/components/MapView.tsx
@@ -2,7 +2,7 @@
 import { theme } from "@/styles/theme.yak";
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import type { ComponentType, CSSProperties } from "react";
+import type { CSSProperties } from "react";
 
 import Map, {
   NavigationControl,
@@ -33,6 +33,7 @@ import {
 import { useListingsInView } from "../hooks/useListingsInView";
 import { useMapCenter } from "../hooks/useMapCenter";
 import { usePreferredMapFlavor } from "../hooks/usePreferredMapFlavor";
+import { handleMapError } from "../lib/mapErrors";
 import { createProtomapsStyle } from "../lib/protomapsStyle";
 import {
   NEUTRAL_INITIAL_COORDINATES,
@@ -52,7 +53,6 @@ type MapViewProps = {
   initialCoordinates: InitialMapCoordinates | null;
   onMapClick: () => void;
   onMarkerClick: (listing: ListingMarker) => void;
-  DrawerTrigger: ComponentType<{ children?: React.ReactNode }>;
   isDesktop: boolean;
   countryCode: string | null;
 };
@@ -95,7 +95,7 @@ const LoadingChip = styled.div`
 `;
 
 const attributionControlMobileStyle: CSSProperties = {
-  marginRight: `calc(clamp(var(--spacing-tabBar-marginX), calc(((100vw - var(--spacing-tabBar-maxWidth)) / 2)), 100vw) + 4px)`,
+  marginRight: "0.75rem",
   marginBottom: "5.25rem",
   opacity: 0.875,
 };
@@ -116,6 +116,56 @@ const searchStyle: CSSProperties = {
 const STORE_MAP_VIEW_DELAY_MS = 300;
 const STORE_MAP_VIEW_DELTA = 0.000001;
 const STORE_MAP_ZOOM_DELTA = 0.01;
+const PIN_DETAIL_MIN_ZOOM = 7.25;
+const PIN_DETAIL_MAX_ZOOM = 8.25;
+const PIN_ICON_MIN_ZOOM = 7.75;
+const PIN_HALO_MIN_ZOOM = 8;
+const PIN_HALO_MIN_SCALE = 0.18;
+const PIN_HALO_FULL_ZOOM = MAP_MAX_ZOOM;
+const PIN_HALO_GROWTH_EXPONENT = 2.2;
+
+type MapPinZoomStyle = CSSProperties & {
+  "--map-pin-compact-scale": string;
+  "--map-pin-detail-scale": string;
+  "--map-pin-icon-opacity": string;
+  "--map-pin-icon-scale": string;
+  "--map-pin-halo-scale": string;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getZoomProgress(zoom: number, minZoom: number, maxZoom: number) {
+  return clamp((zoom - minZoom) / (maxZoom - minZoom), 0, 1);
+}
+
+function resolveMapPinZoomVariables(zoom: number): MapPinZoomStyle {
+  const detailScale = getZoomProgress(
+    zoom,
+    PIN_DETAIL_MIN_ZOOM,
+    PIN_DETAIL_MAX_ZOOM
+  );
+  const haloProgress = getZoomProgress(
+    zoom,
+    PIN_HALO_MIN_ZOOM,
+    PIN_HALO_FULL_ZOOM
+  );
+  const easedHaloProgress = Math.pow(haloProgress, PIN_HALO_GROWTH_EXPONENT);
+  const haloScale =
+    PIN_HALO_MIN_SCALE + (1 - PIN_HALO_MIN_SCALE) * easedHaloProgress;
+  const iconOpacity = zoom >= PIN_ICON_MIN_ZOOM ? 1 : 0;
+  const iconScale = zoom >= PIN_ICON_MIN_ZOOM ? 0.5 + detailScale * 0.5 : 0;
+  const compactScale = (10 + 14 * detailScale) / 24;
+
+  return {
+    "--map-pin-compact-scale": compactScale.toFixed(3),
+    "--map-pin-detail-scale": detailScale.toFixed(3),
+    "--map-pin-icon-opacity": iconOpacity.toFixed(3),
+    "--map-pin-icon-scale": iconScale.toFixed(3),
+    "--map-pin-halo-scale": haloScale.toFixed(3),
+  };
+}
 
 function resolveInitialViewState(
   selectedListing: SelectedListing | null,
@@ -148,7 +198,6 @@ export default function MapView({
   initialCoordinates,
   onMapClick,
   onMarkerClick,
-  DrawerTrigger,
   isDesktop,
   countryCode,
 }: MapViewProps) {
@@ -156,6 +205,11 @@ export default function MapView({
   const locale = useLocale();
   const mapFlavor = usePreferredMapFlavor();
   const mapRef = useRef<MapRef | null>(null);
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapPinZoomStyleRef = useRef<MapPinZoomStyle | null>(null);
+  const initialMapPinZoomStyleRef = useRef<MapPinZoomStyle | null>(null);
+  const pendingPinZoomRef = useRef<number | null>(null);
+  const pinZoomAnimationFrameRef = useRef<number | null>(null);
   const saveMapViewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
@@ -170,6 +224,12 @@ export default function MapView({
     () => resolveInitialViewState(selectedListing, initialCoordinates),
     [initialCoordinates, selectedListing]
   );
+
+  if (initialMapPinZoomStyleRef.current === null) {
+    initialMapPinZoomStyleRef.current = resolveMapPinZoomVariables(
+      initialViewState.zoom
+    );
+  }
 
   const { listings, isFetching, requestBounds } = useListingsInView();
 
@@ -191,13 +251,75 @@ export default function MapView({
     [requestBounds]
   );
 
+  const applyMapPinZoomVariables = useCallback((zoom: number) => {
+    const container = mapContainerRef.current;
+    if (!container) return;
+
+    const variables = resolveMapPinZoomVariables(zoom);
+    const previousVariables = mapPinZoomStyleRef.current;
+    if (
+      previousVariables &&
+      previousVariables["--map-pin-compact-scale"] ===
+        variables["--map-pin-compact-scale"] &&
+      previousVariables["--map-pin-detail-scale"] ===
+        variables["--map-pin-detail-scale"] &&
+      previousVariables["--map-pin-icon-opacity"] ===
+        variables["--map-pin-icon-opacity"] &&
+      previousVariables["--map-pin-icon-scale"] ===
+        variables["--map-pin-icon-scale"] &&
+      previousVariables["--map-pin-halo-scale"] ===
+        variables["--map-pin-halo-scale"]
+    ) {
+      return;
+    }
+
+    mapPinZoomStyleRef.current = variables;
+    container.style.setProperty(
+      "--map-pin-compact-scale",
+      variables["--map-pin-compact-scale"]
+    );
+    container.style.setProperty(
+      "--map-pin-detail-scale",
+      variables["--map-pin-detail-scale"]
+    );
+    container.style.setProperty(
+      "--map-pin-icon-opacity",
+      variables["--map-pin-icon-opacity"]
+    );
+    container.style.setProperty(
+      "--map-pin-icon-scale",
+      variables["--map-pin-icon-scale"]
+    );
+    container.style.setProperty(
+      "--map-pin-halo-scale",
+      variables["--map-pin-halo-scale"]
+    );
+  }, []);
+
+  const scheduleMapPinZoomUpdate = useCallback(
+    (zoom: number) => {
+      pendingPinZoomRef.current = zoom;
+
+      if (pinZoomAnimationFrameRef.current !== null) return;
+
+      pinZoomAnimationFrameRef.current = window.requestAnimationFrame(() => {
+        pinZoomAnimationFrameRef.current = null;
+
+        if (pendingPinZoomRef.current === null) return;
+        applyMapPinZoomVariables(pendingPinZoomRef.current);
+      });
+    },
+    [applyMapPinZoomVariables]
+  );
+
   const handleLoad = useCallback(() => {
     handleMapLoad();
     const map = mapRef.current?.getMap();
     if (map) {
+      applyMapPinZoomVariables(map.getZoom());
       emitBoundsChange(map.getBounds());
     }
-  }, [emitBoundsChange, handleMapLoad]);
+  }, [applyMapPinZoomVariables, emitBoundsChange, handleMapLoad]);
 
   useEffect(() => {
     if (initialCoordinates) {
@@ -243,8 +365,19 @@ export default function MapView({
       if (saveMapViewTimeoutRef.current !== null) {
         clearTimeout(saveMapViewTimeoutRef.current);
       }
+
+      if (pinZoomAnimationFrameRef.current !== null) {
+        window.cancelAnimationFrame(pinZoomAnimationFrameRef.current);
+      }
     };
   }, []);
+
+  const handleMove = useCallback(
+    (event: ViewStateChangeEvent) => {
+      scheduleMapPinZoomUpdate(event.viewState.zoom);
+    },
+    [scheduleMapPinZoomUpdate]
+  );
 
   const handleMoveEnd = useCallback(
     (_event: ViewStateChangeEvent) => {
@@ -289,7 +422,11 @@ export default function MapView({
     hasValidCoordinates(selectedListing) || initialCoordinates !== null;
 
   return (
-    <MapContainer data-testid="map-view">
+    <MapContainer
+      ref={mapContainerRef}
+      data-testid="map-view"
+      style={initialMapPinZoomStyleRef.current}
+    >
       {hasInitialPosition ? (
         <>
           <Map
@@ -299,8 +436,11 @@ export default function MapView({
             maxZoom={MAP_MAX_ZOOM}
             renderWorldCopies={true}
             initialViewState={initialViewState}
+            onMove={handleMove}
+            onZoom={handleMove}
             onMoveEnd={handleMoveEnd}
             onLoad={handleLoad}
+            onError={handleMapError}
             onClick={handleMapClickInternal}
           >
             <GeolocateControl showUserLocation={true} />
@@ -318,7 +458,6 @@ export default function MapView({
             <MapPinLayer
               listings={listings}
               selectedListingId={selectedListingId}
-              DrawerTrigger={DrawerTrigger}
               onMarkerClick={onMarkerClick}
             />
           </Map>

--- a/src/features/map/hooks/useIpInitialLocation.ts
+++ b/src/features/map/hooks/useIpInitialLocation.ts
@@ -7,10 +7,12 @@ import { ZOOM_LEVEL_DEFAULT } from "../lib/mapUtils";
 import {
   NEUTRAL_INITIAL_COORDINATES,
   readStoredInitialMapCoordinates,
+  saveStoredInitialMapCoordinates,
   type InitialMapCoordinates,
 } from "../lib/mapInitialView";
 
 type UseIpInitialLocationArgs = {
+  initialCoordinates?: InitialMapCoordinates | null;
   // Skip when the page already has a listing slug (deep-linked selections
   // centre on the listing instead of the user's IP location).
   skip?: boolean;
@@ -44,20 +46,26 @@ const INITIAL_LOCATION_TIMEOUT_MS = 1500;
 // One-time initial centre. Prefer the user's last viewed map area, otherwise
 // wait briefly for IP location before falling back to a neutral world view.
 export function useIpInitialLocation({
+  initialCoordinates: initialCoordinatesFromServer = null,
   skip = false,
 }: UseIpInitialLocationArgs = {}): UseIpInitialLocationResult {
-  const shouldApplyIpCoordinatesRef = useRef(false);
+  const shouldApplyIpCoordinatesRef = useRef(
+    !skip && initialCoordinatesFromServer === null
+  );
   const [initialCoordinates, setInitialCoordinates] =
     useState<InitialMapCoordinates | null>(() => {
       if (skip) return NEUTRAL_INITIAL_COORDINATES;
-      const storedCoordinates = readStoredInitialMapCoordinates();
-      shouldApplyIpCoordinatesRef.current = storedCoordinates === null;
-      return storedCoordinates;
+      // Keep the first render tied to the server-readable cookie snapshot.
+      // Reading localStorage here would help old cookie-less sessions mount a
+      // beat earlier, but it would also let the client hydrate different map
+      // markup from the server whenever cookies are missing or blocked.
+      return initialCoordinatesFromServer;
     });
   const [countryCode, setCountryCode] = useState<string | null>(null);
 
   useEffect(() => {
     if (skip) {
+      shouldApplyIpCoordinatesRef.current = false;
       // Deep-linked selections centre on the listing when possible. Otherwise
       // the neutral fallback keeps the map mountable.
       setInitialCoordinates(
@@ -69,19 +77,24 @@ export function useIpInitialLocation({
     ensureMapTilerConfig();
 
     let cancelled = false;
-
-    if (!shouldApplyIpCoordinatesRef.current) {
-      async function initializeCountryCode() {
-        try {
-          const response = (await geolocation.info()) as MapTilerIpLocation;
-          if (!cancelled) {
-            setCountryCode(response.country_code ?? null);
-          }
-        } catch {
-          // The stored map view is enough to render; country-code narrowing is
-          // a best-effort enhancement for search.
+    async function initializeCountryCode() {
+      try {
+        const response = (await geolocation.info()) as MapTilerIpLocation;
+        if (!cancelled) {
+          setCountryCode(response.country_code ?? null);
         }
+      } catch {
+        // The stored/server map view is enough to render; country-code
+        // narrowing is a best-effort enhancement for search.
       }
+    }
+
+    const storedCoordinates = readStoredInitialMapCoordinates();
+
+    if (storedCoordinates) {
+      shouldApplyIpCoordinatesRef.current = false;
+      setInitialCoordinates(storedCoordinates);
+      saveStoredInitialMapCoordinates(storedCoordinates);
 
       initializeCountryCode();
 
@@ -89,6 +102,20 @@ export function useIpInitialLocation({
         cancelled = true;
       };
     }
+
+    if (initialCoordinatesFromServer) {
+      shouldApplyIpCoordinatesRef.current = false;
+      setInitialCoordinates(initialCoordinatesFromServer);
+      saveStoredInitialMapCoordinates(initialCoordinatesFromServer);
+
+      initializeCountryCode();
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    shouldApplyIpCoordinatesRef.current = true;
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -167,7 +194,7 @@ export function useIpInitialLocation({
         timeoutId = null;
       }
     };
-  }, [skip]);
+  }, [initialCoordinatesFromServer, skip]);
 
   return { initialCoordinates, countryCode };
 }

--- a/src/features/map/lib/mapErrors.ts
+++ b/src/features/map/lib/mapErrors.ts
@@ -1,0 +1,36 @@
+import type { ErrorEvent } from "react-map-gl/maplibre";
+
+function isBenignMapResourceError(error: Error) {
+  const message = error.message.toLowerCase();
+  const isProtomapsTileError = message.includes("api.protomaps.com/tiles/");
+
+  // MapLibre reports routine resource churn through `onError`: aborted tile
+  // requests during pan/zoom and occasional Protomaps tile fetch blips. Those
+  // can make the Next dev overlay look catastrophic even though the map
+  // recovers on the next tile request.
+  //
+  // Keep this allow-list narrow so style/layer/rendering mistakes still reach
+  // the console via `handleMapError`. In particular, do not suppress Safari's
+  // generic "Load failed" message unless MapLibre includes the tile URL.
+  if (error.name === "AbortError" || message === "aborterror") {
+    return true;
+  }
+
+  if (
+    error.name === "AJAXError" &&
+    isProtomapsTileError &&
+    (message.includes("failed to fetch") || message.includes("load failed"))
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function handleMapError(event: ErrorEvent) {
+  if (isBenignMapResourceError(event.error)) {
+    return;
+  }
+
+  console.error("Map rendering error:", event.error);
+}

--- a/src/features/map/lib/mapInitialView.ts
+++ b/src/features/map/lib/mapInitialView.ts
@@ -1,7 +1,10 @@
 import type { ListingCoordinates } from "@/types/listing";
 
 import { MAP_MAX_ZOOM, wrapLongitude } from "./mapUtils";
-import { STORED_MAP_VIEW_KEY } from "./mapStorageConstants";
+import {
+  STORED_MAP_VIEW_COOKIE_MAX_AGE,
+  STORED_MAP_VIEW_KEY,
+} from "./mapStorageConstants";
 
 export type InitialMapCoordinates = ListingCoordinates & { zoom: number };
 
@@ -10,6 +13,15 @@ export const NEUTRAL_INITIAL_COORDINATES: InitialMapCoordinates = {
   longitude: 0,
   zoom: 1.5,
 };
+
+const COOKIE_COORDINATE_PRECISION = 2;
+const COOKIE_ZOOM_PRECISION = 2;
+
+function roundToPrecision(value: number, precision: number) {
+  const factor = 10 ** precision;
+  const roundedValue = Math.round(value * factor) / factor;
+  return Object.is(roundedValue, -0) ? 0 : roundedValue;
+}
 
 function isValidInitialMapCoordinates(
   value: Partial<InitialMapCoordinates> | null
@@ -40,15 +52,33 @@ function normaliseInitialMapCoordinates(
   };
 }
 
+function coarsenInitialMapCoordinatesForCookie(
+  value: InitialMapCoordinates
+): InitialMapCoordinates {
+  return {
+    latitude: roundToPrecision(value.latitude, COOKIE_COORDINATE_PRECISION),
+    longitude: roundToPrecision(value.longitude, COOKIE_COORDINATE_PRECISION),
+    zoom: roundToPrecision(value.zoom, COOKIE_ZOOM_PRECISION),
+  };
+}
+
+export function parseStoredInitialMapCoordinates(value: string | null) {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as Partial<InitialMapCoordinates> | null;
+    return normaliseInitialMapCoordinates(parsed);
+  } catch {
+    return null;
+  }
+}
+
 export function readStoredInitialMapCoordinates() {
   if (typeof window === "undefined") return null;
 
   try {
     const value = window.localStorage.getItem(STORED_MAP_VIEW_KEY);
-    if (!value) return null;
-
-    const parsed = JSON.parse(value) as Partial<InitialMapCoordinates> | null;
-    return normaliseInitialMapCoordinates(parsed);
+    return parseStoredInitialMapCoordinates(value);
   } catch {
     return null;
   }
@@ -60,13 +90,26 @@ export function saveStoredInitialMapCoordinates(
   if (typeof window === "undefined") return;
   const normalisedCoordinates = normaliseInitialMapCoordinates(coordinates);
   if (!normalisedCoordinates) return;
+  const serialisedCoordinates = JSON.stringify(normalisedCoordinates);
+  // The cookie is only a hydration snapshot, so keep it coarse. localStorage
+  // retains the precise client-side view without sending it back to the server.
+  const serialisedCookieCoordinates = JSON.stringify(
+    coarsenInitialMapCoordinatesForCookie(normalisedCoordinates)
+  );
 
   try {
-    window.localStorage.setItem(
-      STORED_MAP_VIEW_KEY,
-      JSON.stringify(normalisedCoordinates)
-    );
+    window.localStorage.setItem(STORED_MAP_VIEW_KEY, serialisedCoordinates);
   } catch {
     // Ignore storage failures, such as private browsing restrictions.
+  }
+
+  try {
+    const secureAttribute =
+      window.location.protocol === "https:" ? "; Secure" : "";
+    window.document.cookie = `${STORED_MAP_VIEW_KEY}=${encodeURIComponent(
+      serialisedCookieCoordinates
+    )}; Path=/map; Max-Age=${STORED_MAP_VIEW_COOKIE_MAX_AGE}; SameSite=Lax${secureAttribute}`;
+  } catch {
+    // Ignore cookie write failures, such as restrictive browser settings.
   }
 }

--- a/src/features/map/lib/mapStorageConstants.ts
+++ b/src/features/map/lib/mapStorageConstants.ts
@@ -1,1 +1,2 @@
 export const STORED_MAP_VIEW_KEY = "peels.map.lastView.v1";
+export const STORED_MAP_VIEW_COOKIE_MAX_AGE = 60 * 60 * 24 * 180;


### PR DESCRIPTION
## Summary
- adds zoom-aware compact map pin density with minified dots at wider zooms
- refactors map pins to animate between compact and open states without replacing the root test hook
- preserves stored map view hydration by mirroring local storage into a scoped cookie
- quiets benign MapLibre resource errors and improves tap targets/shadows for live map pins

## Validation
- npm run typecheck
- npm run check
- npm run test:e2e:prod -- e2e/map.spec.ts
