### PR TITLE
Improve unsaved draft handling

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -210,9 +210,9 @@ test("chat restores unsent drafts after leaving and returning in the same tab", 
   await expect(page.getByTestId("thread-list")).toBeVisible();
 
   await page.goto(`/chats/${SEEDED_THREAD_ID}`);
-  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
-    draftMessage
-  );
+  await expect(
+    page.getByRole("textbox", { name: "Send a message to Avery..." })
+  ).toHaveValue(draftMessage);
 });
 
 test("unsent chat drafts warn before closing or reloading the page", async ({

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -148,6 +148,47 @@ test("chat send failures preserve the draft and show inline feedback", async ({
   await expect(page.getByText("Synthetic chat failure")).toBeVisible();
 });
 
+test("unsent chat drafts warn before closing or reloading the page", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+
+  const composerInput = page.getByTestId("chat-composer-input");
+  await composerInput.click();
+  await composerInput.pressSequentially(`Unsent chat draft ${Date.now()}`);
+
+  const dialogPromise = page.waitForEvent("dialog");
+  const reloadPromise = page.reload({ waitUntil: "domcontentloaded" });
+  const dialog = await dialogPromise;
+  expect(dialog.type()).toBe("beforeunload");
+  await dialog.accept();
+  await reloadPromise;
+});
+
+test("empty chat composers reload without an unsaved draft warning", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+
+  const dialogMessages: string[] = [];
+  page.once("dialog", async (dialog) => {
+    dialogMessages.push(dialog.message());
+    await dialog.dismiss();
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+
+  expect(dialogMessages).toEqual([]);
+});
+
 test("invalid chat thread ids redirect back to the chat index", async ({
   page,
 }) => {

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -125,6 +125,17 @@ test("chat send disables the composer while pending and appends the new message"
   await expect(composerInput).toBeDisabled();
   await expect(messageVisible).toBeVisible();
   await expect(composerInput).toHaveValue("");
+  await expect
+    .poll(async () =>
+      page.evaluate((threadId) => {
+        const draftEntry = Object.entries(sessionStorage).find(([key]) =>
+          key.endsWith(`:${threadId}`)
+        );
+
+        return draftEntry?.[1] ?? null;
+      }, SEEDED_THREAD_ID)
+    )
+    .toBeNull();
 });
 
 test("chat send failures preserve the draft and show inline feedback", async ({
@@ -146,6 +157,62 @@ test("chat send failures preserve the draft and show inline feedback", async ({
 
   await expect(composerInput).toHaveValue(failedMessage);
   await expect(page.getByText("Synthetic chat failure")).toBeVisible();
+});
+
+test("chat preserves unsent drafts when switching threads", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+
+  const composerInput = page.getByTestId("chat-composer-input");
+  const draftMessage = `Thread switch draft ${Date.now()}`;
+
+  await composerInput.click();
+  await composerInput.pressSequentially(draftMessage);
+  await expect(composerInput).toHaveValue(draftMessage);
+
+  await page.getByTestId(`thread-preview-${SECOND_SEEDED_THREAD_ID}`).click();
+  await expect(page).toHaveURL(
+    new RegExp(`/chats/${SECOND_SEEDED_THREAD_ID}$`)
+  );
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+
+  await page.getByTestId(`thread-preview-${SEEDED_THREAD_ID}`).click();
+  await expect(page).toHaveURL(new RegExp(`/chats/${SEEDED_THREAD_ID}$`));
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
+    draftMessage
+  );
+});
+
+test("chat restores unsent drafts after leaving and returning in the same tab", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: `/chats/${SEEDED_THREAD_ID}`,
+  });
+
+  const draftMessage = `Route return draft ${Date.now()}`;
+
+  await page.getByTestId("chat-composer-input").pressSequentially(draftMessage);
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
+    draftMessage
+  );
+
+  page.once("dialog", async (dialog) => {
+    expect(dialog.type()).toBe("beforeunload");
+    await dialog.accept();
+  });
+  await page.goto("/chats");
+  await expect(page.getByTestId("thread-list")).toBeVisible();
+
+  await page.goto(`/chats/${SEEDED_THREAD_ID}`);
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
+    draftMessage
+  );
 });
 
 test("unsent chat drafts warn before closing or reloading the page", async ({

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -111,7 +111,7 @@ test("listing edit saves and restores seeded business fields", async ({
   await expect(listingWriteForm.locator("#description").first()).toHaveValue(
     updatedDescription
   );
-  await expect(listingWriteForm.locator("#visibility")).toHaveValue(
+  await expect(listingWriteForm.locator("#visibility").first()).toHaveValue(
     updatedVisibility
   );
 
@@ -132,7 +132,7 @@ test("listing edit saves and restores seeded business fields", async ({
   await expect(listingWriteForm.locator("#description").first()).toHaveValue(
     originalDescription
   );
-  await expect(listingWriteForm.locator("#visibility")).toHaveValue(
+  await expect(listingWriteForm.locator("#visibility").first()).toHaveValue(
     originalVisibility
   );
 });

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -15,6 +15,19 @@ const RESIDENTIAL_LISTING_EDIT_PATH =
 const ALTERNATE_BUSINESS_DESCRIPTION =
   "A demo business listing with a slightly different description for e2e coverage.";
 
+function requireHref(href: string | null) {
+  expect(
+    href,
+    "Expected listing photo thumbnail to have an href"
+  ).not.toBeNull();
+
+  if (!href) {
+    throw new Error("Expected listing photo thumbnail to have an href");
+  }
+
+  return href;
+}
+
 test("profile loads the seeded host account and listings", async ({ page }) => {
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
 
@@ -235,13 +248,13 @@ test("listing photos open in a dedicated photo tab", async ({ page }) => {
   await expect(firstThumbnail).toBeVisible();
   await expect(firstThumbnail).toHaveAttribute("target", "_blank");
 
-  const href = await firstThumbnail.getAttribute("href");
+  const href = requireHref(await firstThumbnail.getAttribute("href"));
   expect(href).toBe(
     "/listings/demo-marrickville-compost/photos/demo/garden.jpg"
   );
 
   const photoPage = await page.context().newPage();
-  await photoPage.goto(new URL(href ?? "", page.url()).toString());
+  await photoPage.goto(new URL(href, page.url()).toString());
   await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
   await expect(photoPage.getByRole("navigation")).toHaveCount(0);
   await expect(page).toHaveURL(PUBLIC_MULTI_PHOTO_LISTING_PATH);
@@ -268,13 +281,13 @@ test("map listing photos open in a dedicated photo tab without disturbing the dr
   await expect(firstThumbnail).toBeVisible();
   await expect(firstThumbnail).toHaveAttribute("target", "_blank");
 
-  const href = await firstThumbnail.getAttribute("href");
+  const href = requireHref(await firstThumbnail.getAttribute("href"));
   expect(href).toBe(
     "/listings/demo-marrickville-compost/photos/demo/garden.jpg"
   );
 
   const photoPage = await page.context().newPage();
-  await photoPage.goto(new URL(href ?? "", page.url()).toString());
+  await photoPage.goto(new URL(href, page.url()).toString());
   await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
   await expect(page).toHaveURL(MAP_MULTI_PHOTO_LISTING_PATH);
   await expect(firstThumbnail).toBeVisible();

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -83,7 +83,7 @@ test("listing edit saves and restores seeded business fields", async ({
   const listingWriteForm = page.getByTestId("listing-write-form");
   await expect(listingWriteForm).toBeVisible();
   const descriptionInput = listingWriteForm.locator("#description").first();
-  const visibilityInput = listingWriteForm.locator("#visibility");
+  const visibilityInput = listingWriteForm.locator("#visibility").first();
   const originalDescription = await descriptionInput.inputValue();
   const originalVisibility = await visibilityInput.inputValue();
   const updatedDescription =
@@ -149,27 +149,47 @@ test("dirty listing edit asks before viewing the saved listing", async ({
   await expect(listingWriteForm).toBeVisible();
   const descriptionInput = listingWriteForm.locator("#description").first();
   const draftDescription = `Unsaved listing preview draft ${Date.now()}`;
-  const viewListingLink = page.getByRole("link", { name: "View listing" });
+  const viewListingButton = page.getByRole("button", { name: "View listing" });
 
   await descriptionInput.fill(draftDescription);
 
-  const cancelDialogPromise = page.waitForEvent("dialog");
-  await viewListingLink.click();
-  const cancelDialog = await cancelDialogPromise;
-  expect(cancelDialog.type()).toBe("confirm");
-  expect(cancelDialog.message()).toContain("unsaved changes");
-  await cancelDialog.dismiss();
+  await viewListingButton.click();
+  await expect(
+    page.getByRole("heading", { name: "Discard changes" })
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "You have unsaved changes. Are you sure you want to discard them and leave?"
+    )
+  ).toBeVisible();
+  await page.getByRole("button", { name: "No, go back" }).click();
 
   await expect(page).toHaveURL(/\/profile\/listings\/demo-inner-west-cafe$/);
   await expect(descriptionInput).toHaveValue(draftDescription);
 
-  const confirmDialogPromise = page.waitForEvent("dialog");
-  await viewListingLink.click();
-  const confirmDialog = await confirmDialogPromise;
-  expect(confirmDialog.type()).toBe("confirm");
-  await confirmDialog.accept();
+  await viewListingButton.click();
+  await page.getByRole("button", { name: "Yes, discard" }).click();
 
   await expect(page).toHaveURL(/\/listings\/demo-inner-west-cafe$/);
+});
+
+test("dirty new listing forms warn before closing or reloading the page", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: HOST_EMAIL,
+    redirectTo: "/profile/listings/new/business",
+  });
+
+  await expect(page.getByTestId("listing-write-form")).toBeVisible();
+  await page.locator("#name").fill(`Unsaved new listing ${Date.now()}`);
+
+  const dialogPromise = page.waitForEvent("dialog");
+  const reloadPromise = page.reload({ waitUntil: "domcontentloaded" });
+  const dialog = await dialogPromise;
+  expect(dialog.type()).toBe("beforeunload");
+  await dialog.accept();
+  await reloadPromise;
 });
 
 test("clean listing edit views the saved listing without asking", async ({
@@ -221,7 +241,7 @@ test("listing photos open in a dedicated photo tab", async ({ page }) => {
   );
 
   const photoPage = await page.context().newPage();
-  await photoPage.goto(`http://127.0.0.1:3000${href}`);
+  await photoPage.goto(new URL(href ?? "", page.url()).toString());
   await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
   await expect(photoPage.getByRole("navigation")).toHaveCount(0);
   await expect(page).toHaveURL(PUBLIC_MULTI_PHOTO_LISTING_PATH);
@@ -254,7 +274,7 @@ test("map listing photos open in a dedicated photo tab without disturbing the dr
   );
 
   const photoPage = await page.context().newPage();
-  await photoPage.goto(`http://127.0.0.1:3000${href}`);
+  await photoPage.goto(new URL(href ?? "", page.url()).toString());
   await expect(photoPage.getByTestId("listing-photo-tab-viewer")).toBeVisible();
   await expect(page).toHaveURL(MAP_MULTI_PHOTO_LISTING_PATH);
   await expect(firstThumbnail).toBeVisible();

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -137,6 +137,62 @@ test("listing edit saves and restores seeded business fields", async ({
   );
 });
 
+test("dirty listing edit asks before viewing the saved listing", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: HOST_EMAIL,
+    redirectTo: BUSINESS_LISTING_EDIT_PATH,
+  });
+
+  const listingWriteForm = page.getByTestId("listing-write-form");
+  await expect(listingWriteForm).toBeVisible();
+  const descriptionInput = listingWriteForm.locator("#description").first();
+  const draftDescription = `Unsaved listing preview draft ${Date.now()}`;
+  const viewListingLink = page.getByRole("link", { name: "View listing" });
+
+  await descriptionInput.fill(draftDescription);
+
+  const cancelDialogPromise = page.waitForEvent("dialog");
+  await viewListingLink.click();
+  const cancelDialog = await cancelDialogPromise;
+  expect(cancelDialog.type()).toBe("confirm");
+  expect(cancelDialog.message()).toContain("unsaved changes");
+  await cancelDialog.dismiss();
+
+  await expect(page).toHaveURL(/\/profile\/listings\/demo-inner-west-cafe$/);
+  await expect(descriptionInput).toHaveValue(draftDescription);
+
+  const confirmDialogPromise = page.waitForEvent("dialog");
+  await viewListingLink.click();
+  const confirmDialog = await confirmDialogPromise;
+  expect(confirmDialog.type()).toBe("confirm");
+  await confirmDialog.accept();
+
+  await expect(page).toHaveURL(/\/listings\/demo-inner-west-cafe$/);
+});
+
+test("clean listing edit views the saved listing without asking", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: HOST_EMAIL,
+    redirectTo: BUSINESS_LISTING_EDIT_PATH,
+  });
+
+  await expect(page.getByTestId("listing-write-form")).toBeVisible();
+  const dialogMessages: string[] = [];
+  page.on("dialog", async (dialog) => {
+    dialogMessages.push(dialog.message());
+    await dialog.dismiss();
+  });
+
+  await page.getByRole("link", { name: "View listing" }).click();
+
+  await expect(page).toHaveURL(/\/listings\/demo-inner-west-cafe$/);
+  expect(dialogMessages).toEqual([]);
+});
+
 test("residential listing edit leaves avatar management on the profile page", async ({
   page,
 }) => {

--- a/messages/de.json
+++ b/messages/de.json
@@ -350,7 +350,8 @@
     },
     "edit": {
       "title": "Eintrag bearbeiten",
-      "notFound": "Eintrag nicht gefunden"
+      "notFound": "Eintrag nicht gefunden",
+      "unsavedViewListingConfirm": "Du hast ungespeicherte Änderungen. Trotzdem den gespeicherten Eintrag ansehen?"
     },
     "form": {
       "basics": "Grundlagen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -351,7 +351,10 @@
     "edit": {
       "title": "Eintrag bearbeiten",
       "notFound": "Eintrag nicht gefunden",
-      "unsavedViewListingConfirm": "Du hast ungespeicherte Änderungen. Trotzdem den gespeicherten Eintrag ansehen?"
+      "discardChangesTitle": "Änderungen verwerfen",
+      "discardChangesBody": "Du hast ungespeicherte Änderungen. Möchtest du sie wirklich verwerfen und die Seite verlassen?",
+      "discardChangesCancel": "Nein, zurück",
+      "discardChangesConfirm": "Ja, verwerfen"
     },
     "form": {
       "basics": "Grundlagen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -350,7 +350,8 @@
     },
     "edit": {
       "title": "Edit listing",
-      "notFound": "Listing not found"
+      "notFound": "Listing not found",
+      "unsavedViewListingConfirm": "You have unsaved changes. View the saved listing anyway?"
     },
     "form": {
       "basics": "Basics",

--- a/messages/en.json
+++ b/messages/en.json
@@ -351,7 +351,10 @@
     "edit": {
       "title": "Edit listing",
       "notFound": "Listing not found",
-      "unsavedViewListingConfirm": "You have unsaved changes. View the saved listing anyway?"
+      "discardChangesTitle": "Discard changes",
+      "discardChangesBody": "You have unsaved changes. Are you sure you want to discard them and leave?",
+      "discardChangesCancel": "No, go back",
+      "discardChangesConfirm": "Yes, discard"
     },
     "form": {
       "basics": "Basics",

--- a/messages/es.json
+++ b/messages/es.json
@@ -350,7 +350,8 @@
     },
     "edit": {
       "title": "Editar anuncio",
-      "notFound": "Anuncio no encontrado"
+      "notFound": "Anuncio no encontrado",
+      "unsavedViewListingConfirm": "Tienes cambios sin guardar. ¿Quieres ver el anuncio guardado de todos modos?"
     },
     "form": {
       "basics": "Datos básicos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -351,7 +351,10 @@
     "edit": {
       "title": "Editar anuncio",
       "notFound": "Anuncio no encontrado",
-      "unsavedViewListingConfirm": "Tienes cambios sin guardar. ¿Quieres ver el anuncio guardado de todos modos?"
+      "discardChangesTitle": "Descartar cambios",
+      "discardChangesBody": "Tienes cambios sin guardar. ¿Seguro que quieres descartarlos y salir?",
+      "discardChangesCancel": "No, volver",
+      "discardChangesConfirm": "Sí, descartar"
     },
     "form": {
       "basics": "Datos básicos",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -350,7 +350,8 @@
     },
     "edit": {
       "title": "Modifier l’annonce",
-      "notFound": "Annonce introuvable"
+      "notFound": "Annonce introuvable",
+      "unsavedViewListingConfirm": "Vous avez des modifications non enregistrées. Voir quand même l’annonce enregistrée ?"
     },
     "form": {
       "basics": "Informations de base",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -351,7 +351,10 @@
     "edit": {
       "title": "Modifier l’annonce",
       "notFound": "Annonce introuvable",
-      "unsavedViewListingConfirm": "Vous avez des modifications non enregistrées. Voir quand même l’annonce enregistrée ?"
+      "discardChangesTitle": "Ignorer les modifications",
+      "discardChangesBody": "Vous avez des modifications non enregistrées. Voulez-vous vraiment les ignorer et quitter la page ?",
+      "discardChangesCancel": "Non, revenir",
+      "discardChangesConfirm": "Oui, ignorer"
     },
     "form": {
       "basics": "Informations de base",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -351,7 +351,10 @@
     "edit": {
       "title": "Editar anúncio",
       "notFound": "Anúncio não encontrado",
-      "unsavedViewListingConfirm": "Você tem alterações não salvas. Ver o anúncio salvo mesmo assim?"
+      "discardChangesTitle": "Descartar alterações",
+      "discardChangesBody": "Você tem alterações não salvas. Tem certeza de que quer descartá-las e sair?",
+      "discardChangesCancel": "Não, voltar",
+      "discardChangesConfirm": "Sim, descartar"
     },
     "form": {
       "basics": "Informações básicas",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -350,7 +350,8 @@
     },
     "edit": {
       "title": "Editar anúncio",
-      "notFound": "Anúncio não encontrado"
+      "notFound": "Anúncio não encontrado",
+      "unsavedViewListingConfirm": "Você tem alterações não salvas. Ver o anúncio salvo mesmo assim?"
     },
     "form": {
       "basics": "Informações básicas",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,7 +79,7 @@ export default async function RootLayout({
   const inlineFontFaces = hostedFontFaces.trim();
 
   return (
-    <html lang={locale}>
+    <html lang={locale} data-scroll-behavior="smooth">
       <body>
         {inlineFontFaces ? <style>{inlineFontFaces}</style> : null}
         <AuthHashCompletion />

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 import { useTranslations } from "next-intl";
 import type { FormSubmitHandler } from "@/types/events";
+import type { ButtonVariant } from "@/components/Button";
 
 const DialogContent = styled(Dialog.Content)`
   background: ${theme.colors.background.top};
@@ -67,7 +68,8 @@ const DialogOverlay = styled(Dialog.Overlay)`
 `;
 
 type ButtonToDialogProps = {
-  variant?: "primary" | "secondary" | "danger";
+  variant?: ButtonVariant;
+  triggerVariant?: ButtonVariant;
   size?: "massive" | "large" | "normal" | "small";
   initialButtonText: ReactNode;
   dialogTitle: ReactNode;
@@ -83,6 +85,7 @@ type ButtonToDialogProps = {
 
 function ButtonToDialog({
   variant = "danger",
+  triggerVariant,
   size,
   initialButtonText,
   dialogTitle,
@@ -138,7 +141,7 @@ function ButtonToDialog({
       <Dialog.Trigger asChild>
         <Button
           width="contained"
-          variant={variant}
+          variant={triggerVariant ?? variant}
           size={size}
           disabled={disabled || isPending}
         >

--- a/src/components/ButtonToDialog/ButtonToDialog.tsx
+++ b/src/components/ButtonToDialog/ButtonToDialog.tsx
@@ -67,8 +67,10 @@ const DialogOverlay = styled(Dialog.Overlay)`
   z-index: 3;
 `;
 
+type DialogVariant = Extract<ButtonVariant, "primary" | "secondary" | "danger">;
+
 type ButtonToDialogProps = {
-  variant?: ButtonVariant;
+  variant?: DialogVariant;
   triggerVariant?: ButtonVariant;
   size?: "massive" | "large" | "normal" | "small";
   initialButtonText: ReactNode;

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -69,6 +69,7 @@ const defaultChatRenderOptions: ChatRenderOptions = {
   timeZone: CHAT_RENDER_TIME_ZONE,
   useRelativeDayLabels: false,
 };
+const CHAT_DRAFT_WRITE_DELAY_MS = 150;
 
 function getChatDraftStorageKey({
   threadId,
@@ -174,6 +175,13 @@ const ChatWindow = memo(function ChatWindow({
   const realListing = isDemo ? null : (listing as ChatListing);
   const sendMutation = useInlineMutation<ChatSendResult>();
   const lastReadSignatureRef = useRef<string | null>(null);
+  const draftWriteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const pendingDraftWriteRef = useRef<{
+    key: string;
+    message: string;
+  } | null>(null);
 
   const [message, setMessage] = useState("");
   const [threadId, setThreadId] = useState<string | null>(
@@ -239,11 +247,51 @@ const ChatWindow = memo(function ChatWindow({
     return errorMessage;
   }
 
+  function clearPendingDraftWrite() {
+    if (draftWriteTimeoutRef.current) {
+      clearTimeout(draftWriteTimeoutRef.current);
+      draftWriteTimeoutRef.current = null;
+    }
+  }
+
+  function flushPendingDraftWrite() {
+    clearPendingDraftWrite();
+
+    if (!pendingDraftWriteRef.current) {
+      return;
+    }
+
+    const { key, message } = pendingDraftWriteRef.current;
+    pendingDraftWriteRef.current = null;
+    sessionStorage.setItem(key, message);
+  }
+
+  function scheduleDraftWrite(key: string, nextMessage: string) {
+    clearPendingDraftWrite();
+    pendingDraftWriteRef.current = {
+      key,
+      message: nextMessage,
+    };
+    draftWriteTimeoutRef.current = setTimeout(() => {
+      flushPendingDraftWrite();
+    }, CHAT_DRAFT_WRITE_DELAY_MS);
+  }
+
+  function removeDraftWrite(key: string) {
+    if (pendingDraftWriteRef.current?.key === key) {
+      clearPendingDraftWrite();
+      pendingDraftWriteRef.current = null;
+    }
+
+    sessionStorage.removeItem(key);
+  }
+
   useEffect(() => {
     setClientTimeZone(getClientTimeZone());
   }, []);
 
   useEffect(() => {
+    flushPendingDraftWrite();
     setThreadId(existingThread?.id ?? null);
     setMessages(getThreadMessages(existingThread));
     setMessage(
@@ -251,6 +299,13 @@ const ChatWindow = memo(function ChatWindow({
     );
     lastReadSignatureRef.current = null;
   }, [draftStorageKey, existingThread]);
+
+  useEffect(
+    () => () => {
+      flushPendingDraftWrite();
+    },
+    []
+  );
 
   useEffect(() => {
     if (isDemo || !supabase || !threadId || !user?.id) {
@@ -386,7 +441,7 @@ const ChatWindow = memo(function ChatWindow({
       setThreadId(sentThreadId);
       setMessages((previousMessages) => [...previousMessages, sentMessage]);
       if (draftStorageKey) {
-        sessionStorage.removeItem(draftStorageKey);
+        removeDraftWrite(draftStorageKey);
       }
       setMessage("");
     }
@@ -408,9 +463,9 @@ const ChatWindow = memo(function ChatWindow({
     }
 
     if (nextMessage.trim().length > 0) {
-      sessionStorage.setItem(draftStorageKey, nextMessage);
+      scheduleDraftWrite(draftStorageKey, nextMessage);
     } else {
-      sessionStorage.removeItem(draftStorageKey);
+      removeDraftWrite(draftStorageKey);
     }
   };
 

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -261,6 +261,7 @@ const ChatWindow = memo(function ChatWindow({
         userId: user?.id,
       });
   const hasUnsentMessage = !isDemo && message.trim().length > 0;
+  const hasLocalThread = !existingThread && Boolean(threadId);
 
   useBeforeUnloadWarning(hasUnsentMessage && !sendMutation.isPending);
 
@@ -357,9 +358,18 @@ const ChatWindow = memo(function ChatWindow({
     flushPendingDraftWrite();
     setThreadId(existingThread?.id ?? null);
     setMessages(getThreadMessages(existingThread));
-    setMessage(draftStorageKey ? readChatDraft(draftStorageKey) : "");
     lastReadSignatureRef.current = null;
-  }, [draftStorageKey, existingThread, flushPendingDraftWrite]);
+  }, [existingThread, flushPendingDraftWrite]);
+
+  useEffect(() => {
+    flushPendingDraftWrite();
+
+    if (hasLocalThread) {
+      return;
+    }
+
+    setMessage(draftStorageKey ? readChatDraft(draftStorageKey) : "");
+  }, [draftStorageKey, flushPendingDraftWrite, hasLocalThread]);
 
   useEffect(
     () => () => {
@@ -499,10 +509,15 @@ const ChatWindow = memo(function ChatWindow({
 
     if (result?.success && result.data) {
       const { message: sentMessage, threadId: sentThreadId } = result.data;
+      const sentDraftStorageKey = getChatDraftStorageKey({
+        threadId: sentThreadId,
+        userId: user?.id,
+      });
+
       setThreadId(sentThreadId);
       setMessages((previousMessages) => [...previousMessages, sentMessage]);
-      if (draftStorageKey) {
-        removeDraftWrite(draftStorageKey);
+      if (sentDraftStorageKey) {
+        removeDraftWrite(sentDraftStorageKey);
       }
       setMessage("");
     }

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { theme } from "@/styles/theme.yak";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 
 import { createClient } from "@/utils/supabase/client";
@@ -83,6 +83,42 @@ function getChatDraftStorageKey({
   }
 
   return `peels:chat-draft:${userId}:${threadId}`;
+}
+
+function readChatDraft(key: string) {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  try {
+    return window.sessionStorage.getItem(key) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeChatDraft(key: string, message: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(key, message);
+  } catch {
+    // Ignore storage failures, such as private browsing restrictions.
+  }
+}
+
+function removeChatDraft(key: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore storage failures, such as private browsing restrictions.
+  }
 }
 
 function getClientTimeZone() {
@@ -247,14 +283,14 @@ const ChatWindow = memo(function ChatWindow({
     return errorMessage;
   }
 
-  function clearPendingDraftWrite() {
+  const clearPendingDraftWrite = useCallback(() => {
     if (draftWriteTimeoutRef.current) {
       clearTimeout(draftWriteTimeoutRef.current);
       draftWriteTimeoutRef.current = null;
     }
-  }
+  }, []);
 
-  function flushPendingDraftWrite() {
+  const flushPendingDraftWrite = useCallback(() => {
     clearPendingDraftWrite();
 
     if (!pendingDraftWriteRef.current) {
@@ -263,28 +299,55 @@ const ChatWindow = memo(function ChatWindow({
 
     const { key, message } = pendingDraftWriteRef.current;
     pendingDraftWriteRef.current = null;
-    sessionStorage.setItem(key, message);
-  }
+    writeChatDraft(key, message);
+  }, [clearPendingDraftWrite]);
 
-  function scheduleDraftWrite(key: string, nextMessage: string) {
-    clearPendingDraftWrite();
-    pendingDraftWriteRef.current = {
-      key,
-      message: nextMessage,
-    };
-    draftWriteTimeoutRef.current = setTimeout(() => {
-      flushPendingDraftWrite();
-    }, CHAT_DRAFT_WRITE_DELAY_MS);
-  }
-
-  function removeDraftWrite(key: string) {
-    if (pendingDraftWriteRef.current?.key === key) {
+  const scheduleDraftWrite = useCallback(
+    (key: string, nextMessage: string) => {
       clearPendingDraftWrite();
-      pendingDraftWriteRef.current = null;
-    }
+      pendingDraftWriteRef.current = {
+        key,
+        message: nextMessage,
+      };
+      draftWriteTimeoutRef.current = setTimeout(() => {
+        flushPendingDraftWrite();
+      }, CHAT_DRAFT_WRITE_DELAY_MS);
+    },
+    [clearPendingDraftWrite, flushPendingDraftWrite]
+  );
 
-    sessionStorage.removeItem(key);
-  }
+  const removeDraftWrite = useCallback(
+    (key: string) => {
+      if (pendingDraftWriteRef.current?.key === key) {
+        clearPendingDraftWrite();
+        pendingDraftWriteRef.current = null;
+      }
+
+      removeChatDraft(key);
+    },
+    [clearPendingDraftWrite]
+  );
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      flushPendingDraftWrite();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushPendingDraftWrite();
+      }
+    };
+
+    window.addEventListener("beforeunload", handlePageHide);
+    window.addEventListener("pagehide", handlePageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("beforeunload", handlePageHide);
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [flushPendingDraftWrite]);
 
   useEffect(() => {
     setClientTimeZone(getClientTimeZone());
@@ -294,17 +357,15 @@ const ChatWindow = memo(function ChatWindow({
     flushPendingDraftWrite();
     setThreadId(existingThread?.id ?? null);
     setMessages(getThreadMessages(existingThread));
-    setMessage(
-      draftStorageKey ? sessionStorage.getItem(draftStorageKey) || "" : ""
-    );
+    setMessage(draftStorageKey ? readChatDraft(draftStorageKey) : "");
     lastReadSignatureRef.current = null;
-  }, [draftStorageKey, existingThread]);
+  }, [draftStorageKey, existingThread, flushPendingDraftWrite]);
 
   useEffect(
     () => () => {
       flushPendingDraftWrite();
     },
-    []
+    [flushPendingDraftWrite]
   );
 
   useEffect(() => {

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -70,6 +70,20 @@ const defaultChatRenderOptions: ChatRenderOptions = {
   useRelativeDayLabels: false,
 };
 
+function getChatDraftStorageKey({
+  threadId,
+  userId,
+}: {
+  threadId: string | null | undefined;
+  userId: string | null | undefined;
+}) {
+  if (!threadId || !userId) {
+    return null;
+  }
+
+  return `peels:chat-draft:${userId}:${threadId}`;
+}
+
 function getClientTimeZone() {
   return (
     Intl.DateTimeFormat().resolvedOptions().timeZone ?? CHAT_RENDER_TIME_ZONE
@@ -196,6 +210,12 @@ const ChatWindow = memo(function ChatWindow({
       ),
     [messages, chatRenderOptions.timeZone]
   );
+  const draftStorageKey = isDemo
+    ? null
+    : getChatDraftStorageKey({
+        threadId: existingThread?.id ?? threadId,
+        userId: user?.id,
+      });
   const hasUnsentMessage = !isDemo && message.trim().length > 0;
 
   useBeforeUnloadWarning(hasUnsentMessage && !sendMutation.isPending);
@@ -226,8 +246,11 @@ const ChatWindow = memo(function ChatWindow({
   useEffect(() => {
     setThreadId(existingThread?.id ?? null);
     setMessages(getThreadMessages(existingThread));
+    setMessage(
+      draftStorageKey ? sessionStorage.getItem(draftStorageKey) || "" : ""
+    );
     lastReadSignatureRef.current = null;
-  }, [existingThread]);
+  }, [draftStorageKey, existingThread]);
 
   useEffect(() => {
     if (isDemo || !supabase || !threadId || !user?.id) {
@@ -362,6 +385,9 @@ const ChatWindow = memo(function ChatWindow({
       const { message: sentMessage, threadId: sentThreadId } = result.data;
       setThreadId(sentThreadId);
       setMessages((previousMessages) => [...previousMessages, sentMessage]);
+      if (draftStorageKey) {
+        sessionStorage.removeItem(draftStorageKey);
+      }
       setMessage("");
     }
   }
@@ -373,7 +399,19 @@ const ChatWindow = memo(function ChatWindow({
       sendMutation.reset();
     }
 
-    setMessage(event.target.value);
+    const nextMessage = event.target.value;
+
+    setMessage(nextMessage);
+
+    if (!draftStorageKey) {
+      return;
+    }
+
+    if (nextMessage.trim().length > 0) {
+      sessionStorage.setItem(draftStorageKey, nextMessage);
+    } else {
+      sessionStorage.removeItem(draftStorageKey);
+    }
   };
 
   const role = isDemo

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -495,6 +495,15 @@ const ChatWindow = memo(function ChatWindow({
           setMessages(threadResult.data.messages);
         }
 
+        const nextDraftStorageKey = getChatDraftStorageKey({
+          threadId: nextThreadId,
+          userId: user.id,
+        });
+
+        if (nextDraftStorageKey) {
+          writeChatDraft(nextDraftStorageKey, messageToSend);
+        }
+
         return sendChatMessage({
           content: messageToSend,
           supabase,

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -23,6 +23,7 @@ import {
 
 import { styled } from "next-yak";
 import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
+import { useBeforeUnloadWarning } from "@/hooks/useBeforeUnloadWarning";
 import { useInlineMutation } from "@/hooks/useInlineMutation";
 import { useLocale, useTranslations } from "next-intl";
 import type {
@@ -195,6 +196,9 @@ const ChatWindow = memo(function ChatWindow({
       ),
     [messages, chatRenderOptions.timeZone]
   );
+  const hasUnsentMessage = !isDemo && message.trim().length > 0;
+
+  useBeforeUnloadWarning(hasUnsentMessage && !sendMutation.isPending);
 
   function resolveChatErrorMessage(errorMessage: string | null) {
     if (!errorMessage) {

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -300,9 +300,18 @@ export default function ListingWrite({
       visibility,
     ]
   );
-  const hasUnsavedChanges =
-    JSON.stringify(initialListingValues) !==
-    JSON.stringify(currentListingValues);
+  const initialListingValuesJson = useMemo(
+    () => JSON.stringify(initialListingValues),
+    [initialListingValues]
+  );
+  const currentListingValuesJson = useMemo(
+    () => JSON.stringify(currentListingValues),
+    [currentListingValues]
+  );
+  const hasUnsavedChanges = useMemo(
+    () => initialListingValuesJson !== currentListingValuesJson,
+    [currentListingValuesJson, initialListingValuesJson]
+  );
   const errorCount = Object.keys(errors).length;
   const feedbackError =
     deleteMutation.result.error || submitMutation.result.error;

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -577,6 +577,7 @@ export default function ListingWrite({
               setCountryCode={setCountryCode}
               areaName={areaName}
               setAreaName={setAreaName}
+              autoDetectCountry={!initialListing}
               error={errors.location}
             />
 

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -8,7 +8,6 @@ import {
   type ChangeEvent,
   type ComponentType,
   type InputHTMLAttributes,
-  type MouseEvent,
 } from "react";
 import { useRouter } from "next/navigation";
 import { FIELD_CONFIGS } from "@/lib/formValidation";
@@ -127,7 +126,6 @@ function getListingWriteSavedValues({
   coordinates,
   countryCode,
   description,
-  initialListing,
   isStub,
   links,
   listingType,
@@ -143,7 +141,6 @@ function getListingWriteSavedValues({
   coordinates: ListingCoordinates | null;
   countryCode: string | null | undefined;
   description: string | null | undefined;
-  initialListing?: Listing | null;
   isStub: boolean | null | undefined;
   links: string[] | null | undefined;
   listingType: ListingType;
@@ -164,7 +161,7 @@ function getListingWriteSavedValues({
     links: listingType === "residential" ? [] : normalizeTextList(links),
     name:
       listingType === "residential" ? profile?.first_name || "" : name || "",
-    photos: initialListing ? (photos ?? []) : [],
+    photos: photos ?? [],
     rejectedItems: normalizeTextList(rejectedItems),
     visibility: visibility ?? true,
   };
@@ -226,9 +223,10 @@ export default function ListingWrite({
     initialListing?.is_stub ?? false
   );
   const [pendingPhotos, setPendingPhotos] = useState<string[]>([]);
+  const [hasInteractedWithForm, setHasInteractedWithForm] = useState(false);
 
   const isMutating = submitMutation.isPending || deleteMutation.isPending;
-  const savedListingValues = useMemo(
+  const initialListingValues = useMemo(
     () =>
       initialListing
         ? getListingWriteSavedValues({
@@ -238,7 +236,6 @@ export default function ListingWrite({
             coordinates: initialListing.coordinates,
             countryCode: initialListing.country_code,
             description: initialListing.description,
-            initialListing,
             isStub: initialListing.is_stub,
             links: initialListing.links,
             listingType,
@@ -248,30 +245,42 @@ export default function ListingWrite({
             rejectedItems: initialListing.rejected_items,
             visibility: initialListing.visibility,
           })
-        : null,
+        : getListingWriteSavedValues({
+            acceptedItems: [""],
+            areaName: "",
+            avatar: "",
+            coordinates: null,
+            countryCode: "",
+            description: "",
+            isStub: false,
+            links: [],
+            listingType,
+            name: listingType === "residential" ? profile?.first_name : "",
+            photos: [],
+            profile,
+            rejectedItems: [],
+            visibility: true,
+          }),
     [initialListing, listingType, profile]
   );
   const currentListingValues = useMemo(
     () =>
-      initialListing
-        ? getListingWriteSavedValues({
-            acceptedItems,
-            areaName,
-            avatar,
-            coordinates,
-            countryCode,
-            description,
-            initialListing,
-            isStub,
-            links,
-            listingType,
-            name,
-            photos,
-            profile,
-            rejectedItems,
-            visibility,
-          })
-        : null,
+      getListingWriteSavedValues({
+        acceptedItems,
+        areaName,
+        avatar,
+        coordinates,
+        countryCode,
+        description,
+        isStub,
+        links,
+        listingType,
+        name,
+        photos: initialListing ? photos : pendingPhotos,
+        profile,
+        rejectedItems,
+        visibility,
+      }),
     [
       acceptedItems,
       areaName,
@@ -284,6 +293,7 @@ export default function ListingWrite({
       links,
       listingType,
       name,
+      pendingPhotos,
       photos,
       profile,
       rejectedItems,
@@ -291,8 +301,8 @@ export default function ListingWrite({
     ]
   );
   const hasUnsavedChanges =
-    Boolean(savedListingValues && currentListingValues) &&
-    JSON.stringify(savedListingValues) !== JSON.stringify(currentListingValues);
+    JSON.stringify(initialListingValues) !==
+    JSON.stringify(currentListingValues);
   const errorCount = Object.keys(errors).length;
   const feedbackError =
     deleteMutation.result.error || submitMutation.result.error;
@@ -304,18 +314,20 @@ export default function ListingWrite({
         })
       : null);
 
-  useBeforeUnloadWarning(
-    Boolean(initialListing && hasUnsavedChanges && !isMutating)
-  );
+  const shouldWarnBeforeUnload = initialListing
+    ? hasUnsavedChanges
+    : hasInteractedWithForm && hasUnsavedChanges;
 
-  function handleViewListingClick(event: MouseEvent<HTMLElement>) {
-    if (!hasUnsavedChanges) {
+  useBeforeUnloadWarning(Boolean(shouldWarnBeforeUnload && !isMutating));
+
+  async function handleDiscardChanges(event: FormSubmitEvent) {
+    event.preventDefault();
+
+    if (!initialListing || isMutating) {
       return;
     }
 
-    if (!window.confirm(t("Listings.edit.unsavedViewListingConfirm"))) {
-      event.preventDefault();
-    }
+    router.push(`/listings/${initialListing.slug}`);
   }
 
   async function handleDeleteListing(event: FormSubmitEvent) {
@@ -475,6 +487,8 @@ export default function ListingWrite({
 
       <Form
         onSubmit={handleSubmit}
+        onChange={() => setHasInteractedWithForm(true)}
+        onInput={() => setHasInteractedWithForm(true)}
         data-testid="listing-write-form"
         data-hydrated={isHydrated ? "true" : "false"}
       >
@@ -784,15 +798,29 @@ export default function ListingWrite({
 
       {initialListing && (
         <AdditionalSettings>
-          <Button
-            variant="secondary"
-            width="contained"
-            href={`/listings/${initialListing.slug}`}
-            disabled={isMutating}
-            onClick={handleViewListingClick}
-          >
-            {t("Actions.viewListing")}
-          </Button>
+          {hasUnsavedChanges ? (
+            <ButtonToDialog
+              variant="danger"
+              triggerVariant="secondary"
+              initialButtonText={t("Actions.viewListing")}
+              dialogTitle={t("Listings.edit.discardChangesTitle")}
+              confirmButtonText={t("Listings.edit.discardChangesConfirm")}
+              cancelButtonText={t("Listings.edit.discardChangesCancel")}
+              disabled={isMutating}
+              onSubmit={handleDiscardChanges}
+            >
+              {t("Listings.edit.discardChangesBody")}
+            </ButtonToDialog>
+          ) : (
+            <Button
+              variant="secondary"
+              width="contained"
+              href={`/listings/${initialListing.slug}`}
+              disabled={isMutating}
+            >
+              {t("Actions.viewListing")}
+            </Button>
+          )}
 
           <ButtonToDialog
             variant="danger"

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -3,10 +3,12 @@
 import { theme } from "@/styles/theme.yak";
 import {
   useEffect,
+  useMemo,
   useState,
   type ChangeEvent,
   type ComponentType,
   type InputHTMLAttributes,
+  type MouseEvent,
 } from "react";
 import { useRouter } from "next/navigation";
 import { FIELD_CONFIGS } from "@/lib/formValidation";
@@ -31,6 +33,7 @@ import Fieldset from "@/components/Fieldset";
 import Lozenge from "@/components/Lozenge";
 import FormMessage from "@/components/FormMessage";
 import SubmitButton from "@/components/SubmitButton";
+import { useBeforeUnloadWarning } from "@/hooks/useBeforeUnloadWarning";
 import { styled } from "next-yak";
 import { useTranslations } from "next-intl";
 import type { User } from "@supabase/supabase-js";
@@ -46,6 +49,7 @@ import {
 import type {
   DeleteListingResult,
   Listing,
+  ListingCoordinates,
   ListingSubmitFailureData,
   ListingSubmitResult,
   ListingType,
@@ -96,6 +100,75 @@ type ListingWriteProps = {
   user: User | null;
   profile: ListingWriteProfile | null;
 };
+
+type ListingWriteSavedValues = {
+  acceptedItems: string[];
+  areaName: string;
+  avatar: string;
+  coordinates: ListingCoordinates | null;
+  countryCode: string;
+  description: string;
+  isStub: boolean;
+  links: string[];
+  name: string;
+  photos: string[];
+  rejectedItems: string[];
+  visibility: boolean;
+};
+
+function normalizeTextList(items: string[] | null | undefined) {
+  return (items ?? []).filter((item) => item.trim() !== "");
+}
+
+function getListingWriteSavedValues({
+  acceptedItems,
+  areaName,
+  avatar,
+  coordinates,
+  countryCode,
+  description,
+  initialListing,
+  isStub,
+  links,
+  listingType,
+  name,
+  photos,
+  profile,
+  rejectedItems,
+  visibility,
+}: {
+  acceptedItems: string[] | null | undefined;
+  areaName: string | null | undefined;
+  avatar: string | null | undefined;
+  coordinates: ListingCoordinates | null;
+  countryCode: string | null | undefined;
+  description: string | null | undefined;
+  initialListing?: Listing | null;
+  isStub: boolean | null | undefined;
+  links: string[] | null | undefined;
+  listingType: ListingType;
+  name: string | null | undefined;
+  photos: string[] | null | undefined;
+  profile: ListingWriteProfile | null;
+  rejectedItems: string[] | null | undefined;
+  visibility: boolean | null | undefined;
+}): ListingWriteSavedValues {
+  return {
+    acceptedItems: normalizeTextList(acceptedItems),
+    areaName: areaName || "",
+    avatar: listingType === "residential" ? "" : avatar || "",
+    coordinates,
+    countryCode: countryCode || "",
+    description: description || "",
+    isStub: Boolean(isStub),
+    links: listingType === "residential" ? [] : normalizeTextList(links),
+    name:
+      listingType === "residential" ? profile?.first_name || "" : name || "",
+    photos: initialListing ? (photos ?? []) : [],
+    rejectedItems: normalizeTextList(rejectedItems),
+    visibility: visibility ?? true,
+  };
+}
 
 export default function ListingWrite({
   initialListing,
@@ -155,6 +228,71 @@ export default function ListingWrite({
   const [pendingPhotos, setPendingPhotos] = useState<string[]>([]);
 
   const isMutating = submitMutation.isPending || deleteMutation.isPending;
+  const savedListingValues = useMemo(
+    () =>
+      initialListing
+        ? getListingWriteSavedValues({
+            acceptedItems: initialListing.accepted_items,
+            areaName: initialListing.area_name,
+            avatar: initialListing.avatar,
+            coordinates: initialListing.coordinates,
+            countryCode: initialListing.country_code,
+            description: initialListing.description,
+            initialListing,
+            isStub: initialListing.is_stub,
+            links: initialListing.links,
+            listingType,
+            name: initialListing.name,
+            photos: initialListing.photos,
+            profile,
+            rejectedItems: initialListing.rejected_items,
+            visibility: initialListing.visibility,
+          })
+        : null,
+    [initialListing, listingType, profile]
+  );
+  const currentListingValues = useMemo(
+    () =>
+      initialListing
+        ? getListingWriteSavedValues({
+            acceptedItems,
+            areaName,
+            avatar,
+            coordinates,
+            countryCode,
+            description,
+            initialListing,
+            isStub,
+            links,
+            listingType,
+            name,
+            photos,
+            profile,
+            rejectedItems,
+            visibility,
+          })
+        : null,
+    [
+      acceptedItems,
+      areaName,
+      avatar,
+      coordinates,
+      countryCode,
+      description,
+      initialListing,
+      isStub,
+      links,
+      listingType,
+      name,
+      photos,
+      profile,
+      rejectedItems,
+      visibility,
+    ]
+  );
+  const hasUnsavedChanges =
+    Boolean(savedListingValues && currentListingValues) &&
+    JSON.stringify(savedListingValues) !== JSON.stringify(currentListingValues);
   const errorCount = Object.keys(errors).length;
   const feedbackError =
     deleteMutation.result.error || submitMutation.result.error;
@@ -165,6 +303,20 @@ export default function ListingWrite({
           count: errorCount,
         })
       : null);
+
+  useBeforeUnloadWarning(
+    Boolean(initialListing && hasUnsavedChanges && !isMutating)
+  );
+
+  function handleViewListingClick(event: MouseEvent<HTMLElement>) {
+    if (!hasUnsavedChanges) {
+      return;
+    }
+
+    if (!window.confirm(t("Listings.edit.unsavedViewListingConfirm"))) {
+      event.preventDefault();
+    }
+  }
 
   async function handleDeleteListing(event: FormSubmitEvent) {
     event.preventDefault();
@@ -637,6 +789,7 @@ export default function ListingWrite({
             width="contained"
             href={`/listings/${initialListing.slug}`}
             disabled={isMutating}
+            onClick={handleViewListingClick}
           >
             {t("Actions.viewListing")}
           </Button>

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -2,6 +2,7 @@
 
 import { theme } from "@/styles/theme.yak";
 import {
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -224,6 +225,9 @@ export default function ListingWrite({
   );
   const [pendingPhotos, setPendingPhotos] = useState<string[]>([]);
   const [hasInteractedWithForm, setHasInteractedWithForm] = useState(false);
+  const markFormInteracted = useCallback(() => {
+    setHasInteractedWithForm(true);
+  }, []);
 
   const isMutating = submitMutation.isPending || deleteMutation.isPending;
   const initialListingValues = useMemo(
@@ -490,14 +494,28 @@ export default function ListingWrite({
     });
   };
 
+  const handlePhotosChange = useCallback(
+    (nextPhotos: string[]) => {
+      markFormInteracted();
+
+      if (initialListing) {
+        setPhotos(nextPhotos);
+        return;
+      }
+
+      setPendingPhotos(nextPhotos);
+    },
+    [initialListing, markFormInteracted]
+  );
+
   return (
     <>
       {initialListing?.is_stub && <Lozenge>{t("Common.stub")}</Lozenge>}
 
       <Form
         onSubmit={handleSubmit}
-        onChange={() => setHasInteractedWithForm(true)}
-        onInput={() => setHasInteractedWithForm(true)}
+        onChange={markFormInteracted}
+        onInput={markFormInteracted}
         data-testid="listing-write-form"
         data-hydrated={isHydrated ? "true" : "false"}
       >
@@ -578,6 +596,7 @@ export default function ListingWrite({
               areaName={areaName}
               setAreaName={setAreaName}
               autoDetectCountry={!initialListing}
+              onLocationInteract={markFormInteracted}
               error={errors.location}
             />
 
@@ -698,7 +717,7 @@ export default function ListingWrite({
               <ListingPhotosManager
                 initialPhotos={initialListing ? photos : pendingPhotos}
                 listingSlug={initialListing?.slug}
-                onPhotosChange={initialListing ? setPhotos : setPendingPhotos}
+                onPhotosChange={handlePhotosChange}
                 isNewListing={!initialListing}
               />
             </FieldsetWithGap>

--- a/src/components/ListingWrite/listingWriteController.ts
+++ b/src/components/ListingWrite/listingWriteController.ts
@@ -53,6 +53,7 @@ export type LocationSelectProps = {
   setAreaName: Dispatch<SetStateAction<string>>;
   initialPlaceholderText?: string;
   autoDetectCountry?: boolean;
+  onLocationInteract?: () => void;
   error?: string;
 };
 

--- a/src/components/ListingWrite/listingWriteController.ts
+++ b/src/components/ListingWrite/listingWriteController.ts
@@ -52,6 +52,7 @@ export type LocationSelectProps = {
   areaName: string;
   setAreaName: Dispatch<SetStateAction<string>>;
   initialPlaceholderText?: string;
+  autoDetectCountry?: boolean;
   error?: string;
 };
 

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -57,6 +57,7 @@ type LocationSelectProps = {
   areaName: string;
   setAreaName: Dispatch<SetStateAction<string>>;
   initialPlaceholderText?: string;
+  autoDetectCountry?: boolean;
   error?: string;
 };
 
@@ -148,6 +149,7 @@ export default function LocationSelect({
   areaName,
   setAreaName,
   initialPlaceholderText,
+  autoDetectCountry = true,
   error,
 }: LocationSelectProps) {
   const t = useTranslations();
@@ -160,7 +162,7 @@ export default function LocationSelect({
   );
 
   useEffect(() => {
-    if (!countryCode) {
+    if (autoDetectCountry && !countryCode) {
       let isMounted = true; // Track if component is mounted
 
       const initializeLocation = async () => {
@@ -185,7 +187,7 @@ export default function LocationSelect({
         isMounted = false;
       };
     }
-  }, [countryCode, setCountryCode]);
+  }, [autoDetectCountry, countryCode, setCountryCode]);
 
   const handleCountryChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -58,6 +58,7 @@ type LocationSelectProps = {
   setAreaName: Dispatch<SetStateAction<string>>;
   initialPlaceholderText?: string;
   autoDetectCountry?: boolean;
+  onLocationInteract?: () => void;
   error?: string;
 };
 
@@ -150,6 +151,7 @@ export default function LocationSelect({
   setAreaName,
   initialPlaceholderText,
   autoDetectCountry = true,
+  onLocationInteract,
   error,
 }: LocationSelectProps) {
   const t = useTranslations();
@@ -191,12 +193,13 @@ export default function LocationSelect({
 
   const handleCountryChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
+      onLocationInteract?.();
       setCountryCode(e.target.value);
       console.log("Country changed, focusing input...");
       setMapShown(false);
       inputRef.current?.focus();
     },
-    [setCountryCode]
+    [onLocationInteract, setCountryCode]
   );
 
   const handleDragStart = useCallback(() => {
@@ -209,6 +212,7 @@ export default function LocationSelect({
   const handleDragEnd = useCallback(
     async (event: any) => {
       console.log("Drag end. Location:", event.lngLat);
+      onLocationInteract?.();
 
       const nextCoordinates = {
         latitude: event.lngLat.lat,
@@ -224,7 +228,7 @@ export default function LocationSelect({
       setAreaName(nextAreaName);
       setPlaceholderText(nextAreaName);
     },
-    [setCoordinates, setAreaName]
+    [onLocationInteract, setCoordinates, setAreaName]
   );
 
   const handlePick = useCallback(
@@ -235,6 +239,7 @@ export default function LocationSelect({
 
       // Otherwise continue as normal
       console.log("Picked:", event, event.feature?.center);
+      onLocationInteract?.();
 
       const nextCoordinates = {
         latitude: event.feature?.center[1],
@@ -269,7 +274,7 @@ export default function LocationSelect({
         setCoordinates(nextCoordinates);
       }
     },
-    [mapShown, coordinates, setCoordinates, setAreaName]
+    [mapShown, coordinates, onLocationInteract, setCoordinates, setAreaName]
   );
 
   return (

--- a/src/hooks/useBeforeUnloadWarning.ts
+++ b/src/hooks/useBeforeUnloadWarning.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useBeforeUnloadWarning(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION
## Summary
- replace the listing edit native confirm with the existing destructive dialog pattern
- warn on dirty listing forms for browser close/reload, including new listings
- preserve chat composer drafts per signed-in user and thread in tab-scoped session storage
- add the root smooth-scroll opt-in expected by Next.js to avoid the route transition warning
- keep demo chat excluded and avoid a global route blocker

## Validation
- npm run i18n:check
- npm run typecheck
- npm run check
- PLAYWRIGHT_PORT=3108 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331 NEXT_PUBLIC_SUPABASE_ANON_KEY=*** npm run test:e2e -- e2e/listings.spec.ts e2e/chat.spec.ts
