### PR TITLE
avoid account button auth flash

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -142,7 +142,6 @@ test("homepage account button stays hidden while signed-in profile state loads",
   await profileRequestStarted;
 
   try {
-    await expect(page.getByTestId("account-button-loading")).toHaveCount(0);
     await expect(page.getByTestId("account-button-profile")).toHaveCount(0);
     await expect(page.getByTestId("account-button-sign-in")).toHaveCount(0);
   } finally {

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -110,7 +110,7 @@ test("homepage drop-off only shows curated featured hosts", async ({
   ).toHaveCount(0);
 });
 
-test("homepage account button shows a skeleton while signed-in profile state loads", async ({
+test("homepage account button stays hidden while signed-in profile state loads", async ({
   page,
 }) => {
   await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
@@ -141,34 +141,18 @@ test("homepage account button shows a skeleton while signed-in profile state loa
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await profileRequestStarted;
 
-  const loadingAccountButton = page.getByTestId("account-button-loading");
-
   try {
-    await expect(loadingAccountButton).toHaveCount(1);
-    expect(
-      await loadingAccountButton.evaluate((element) => {
-        const { display, opacity, visibility } =
-          window.getComputedStyle(element);
-        const rect = element.getBoundingClientRect();
-
-        return (
-          display !== "none" &&
-          visibility !== "hidden" &&
-          Number(opacity) > 0 &&
-          rect.width > 0 &&
-          rect.height > 0
-        );
-      })
-    ).toBe(true);
+    await expect(page.getByTestId("account-button-loading")).toHaveCount(0);
+    await expect(page.getByTestId("account-button-profile")).toHaveCount(0);
     await expect(page.getByTestId("account-button-sign-in")).toHaveCount(0);
   } finally {
     continueProfileRequest();
   }
 
-  await expect(page.getByTestId("account-button-profile")).toHaveAttribute(
-    "href",
-    "/profile"
-  );
+  const profileAccountButton = page.getByTestId("account-button-profile");
+
+  await expect(profileAccountButton).toHaveAttribute("href", "/profile");
+  await expect(profileAccountButton).toHaveCSS("opacity", "1");
 });
 
 test("homepage account button links guests to sign in", async ({ page }) => {

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { HOST_EMAIL, signIn } from "./helpers";
 
 test("homepage hydrates without chat date mismatches", async ({
   browser,
@@ -107,4 +108,75 @@ test("homepage drop-off only shows curated featured hosts", async ({
   await expect(
     page.getByTestId("homepage-featured-host-demo-newtown-worm-farm")
   ).toHaveCount(0);
+});
+
+test("homepage account button shows a skeleton while signed-in profile state loads", async ({
+  page,
+}) => {
+  await signIn(page, { email: HOST_EMAIL, redirectTo: "/profile" });
+
+  let resolveProfileRequest = () => {};
+  const profileRequestStarted = new Promise<void>((resolve) => {
+    resolveProfileRequest = resolve;
+  });
+  let continueProfileRequest = () => {};
+  const profileRequestCanContinue = new Promise<void>((resolve) => {
+    continueProfileRequest = resolve;
+  });
+
+  await page.route(/\/rest\/v1\/profiles(?:\?|$)/, async (route) => {
+    const request = route.request();
+
+    if (
+      request.method() === "GET" &&
+      request.url().includes("select=first_name")
+    ) {
+      resolveProfileRequest();
+      await profileRequestCanContinue;
+    }
+
+    await route.continue();
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await profileRequestStarted;
+
+  const loadingAccountButton = page.getByTestId("account-button-loading");
+
+  try {
+    await expect(loadingAccountButton).toHaveCount(1);
+    expect(
+      await loadingAccountButton.evaluate((element) => {
+        const { display, opacity, visibility } =
+          window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+
+        return (
+          display !== "none" &&
+          visibility !== "hidden" &&
+          Number(opacity) > 0 &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      })
+    ).toBe(true);
+    await expect(page.getByTestId("account-button-sign-in")).toHaveCount(0);
+  } finally {
+    continueProfileRequest();
+  }
+
+  await expect(page.getByTestId("account-button-profile")).toHaveAttribute(
+    "href",
+    "/profile"
+  );
+});
+
+test("homepage account button links guests to sign in", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByTestId("account-button-sign-in")).toHaveAttribute(
+    "href",
+    "/sign-in"
+  );
+  await expect(page.getByTestId("account-button-profile")).toHaveCount(0);
 });

--- a/src/components/AccountButton/AccountButton.tsx
+++ b/src/components/AccountButton/AccountButton.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { styled } from "next-yak";
 import Button from "@/components/Button";
 import { useAuthUser } from "@/hooks/useAuthUser";
 import type { LinkButtonProps } from "@/components/Button";
+import { theme } from "@/styles/theme.yak";
 
 type AccountButtonProps = Omit<
   LinkButtonProps,
@@ -13,16 +15,66 @@ type AccountButtonProps = Omit<
 export default function AccountButton({ ...props }: AccountButtonProps) {
   const t = useTranslations("Actions");
   const tCommon = useTranslations("Common");
-  const { user, profileFirstName } = useAuthUser({ includeProfile: true });
+  const { user, profileFirstName, isLoading } = useAuthUser({
+    includeProfile: true,
+  });
   const label = profileFirstName?.trim() || tCommon("account");
 
+  if (isLoading) {
+    return (
+      <AccountButtonSkeleton
+        aria-hidden="true"
+        className={props.className}
+        data-testid="account-button-loading"
+      >
+        <SkeletonLabel />
+      </AccountButtonSkeleton>
+    );
+  }
+
   return user ? (
-    <Button href="/profile" variant="secondary" {...props}>
+    <Button
+      href="/profile"
+      variant="secondary"
+      {...props}
+      data-testid="account-button-profile"
+    >
       {label}
     </Button>
   ) : (
-    <Button href="/sign-in" variant="secondary" {...props}>
+    <Button
+      href="/sign-in"
+      variant="secondary"
+      {...props}
+      data-testid="account-button-sign-in"
+    >
       {t("signIn")}
     </Button>
   );
 }
+
+const AccountButtonSkeleton = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: flex-start;
+  min-width: 6.5rem;
+  height: 3rem;
+  padding: 0 calc(${theme.spacing.unit} * 2);
+  border-radius: ${theme.corners.base};
+  background: ${theme.colors.button.secondary.background};
+  box-shadow: 0px 0px 0px 2px ${theme.colors.border.base};
+  opacity: 0.72;
+
+  @media (prefers-reduced-motion: reduce) {
+    opacity: 0.8;
+  }
+`;
+
+const SkeletonLabel = styled.span`
+  width: 3.75rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: ${theme.colors.border.base};
+`;

--- a/src/components/AccountButton/AccountButton.tsx
+++ b/src/components/AccountButton/AccountButton.tsx
@@ -78,8 +78,6 @@ const FadingAccountButton = styled(Button)<{ $visible: boolean }>`
   transition: opacity 160ms ease-out;
 
   @media (prefers-reduced-motion: reduce) {
-    opacity: 1;
-    pointer-events: auto;
     transition: none;
   }
 `;

--- a/src/components/AccountButton/AccountButton.tsx
+++ b/src/components/AccountButton/AccountButton.tsx
@@ -40,11 +40,19 @@ export default function AccountButton({ ...props }: AccountButtonProps) {
     return null;
   }
 
+  const hiddenButtonProps = !isReadyToShow
+    ? ({
+        "aria-hidden": true,
+        tabIndex: -1,
+      } satisfies Pick<LinkButtonProps, "aria-hidden" | "tabIndex">)
+    : {};
+
   return user ? (
     <FadingAccountButton
       href="/profile"
       variant="secondary"
       {...props}
+      {...hiddenButtonProps}
       $visible={isReadyToShow}
       data-testid="account-button-profile"
     >
@@ -55,6 +63,7 @@ export default function AccountButton({ ...props }: AccountButtonProps) {
       href="/sign-in"
       variant="secondary"
       {...props}
+      {...hiddenButtonProps}
       $visible={isReadyToShow}
       data-testid="account-button-sign-in"
     >

--- a/src/components/AccountButton/AccountButton.tsx
+++ b/src/components/AccountButton/AccountButton.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { styled } from "next-yak";
 import Button from "@/components/Button";
 import { useAuthUser } from "@/hooks/useAuthUser";
 import type { LinkButtonProps } from "@/components/Button";
-import { theme } from "@/styles/theme.yak";
 
 type AccountButtonProps = Omit<
   LinkButtonProps,
@@ -18,63 +18,59 @@ export default function AccountButton({ ...props }: AccountButtonProps) {
   const { user, profileFirstName, isLoading } = useAuthUser({
     includeProfile: true,
   });
+  const [isReadyToShow, setIsReadyToShow] = useState(false);
   const label = profileFirstName?.trim() || tCommon("account");
 
+  useEffect(() => {
+    if (isLoading) {
+      setIsReadyToShow(false);
+      return;
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      setIsReadyToShow(true);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+    };
+  }, [isLoading]);
+
   if (isLoading) {
-    return (
-      <AccountButtonSkeleton
-        aria-hidden="true"
-        className={props.className}
-        data-testid="account-button-loading"
-      >
-        <SkeletonLabel />
-      </AccountButtonSkeleton>
-    );
+    return null;
   }
 
   return user ? (
-    <Button
+    <FadingAccountButton
       href="/profile"
       variant="secondary"
       {...props}
+      $visible={isReadyToShow}
       data-testid="account-button-profile"
     >
       {label}
-    </Button>
+    </FadingAccountButton>
   ) : (
-    <Button
+    <FadingAccountButton
       href="/sign-in"
       variant="secondary"
       {...props}
+      $visible={isReadyToShow}
       data-testid="account-button-sign-in"
     >
       {t("signIn")}
-    </Button>
+    </FadingAccountButton>
   );
 }
 
-const AccountButtonSkeleton = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  align-self: flex-start;
-  min-width: 6.5rem;
-  height: 3rem;
-  padding: 0 calc(${theme.spacing.unit} * 2);
-  border-radius: ${theme.corners.base};
-  background: ${theme.colors.button.secondary.background};
-  box-shadow: 0px 0px 0px 2px ${theme.colors.border.base};
-  opacity: 0.72;
+const FadingAccountButton = styled(Button)<{ $visible: boolean }>`
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  pointer-events: ${({ $visible }) => ($visible ? "auto" : "none")};
+  transition: opacity 160ms ease-out;
 
   @media (prefers-reduced-motion: reduce) {
-    opacity: 0.8;
+    opacity: 1;
+    pointer-events: auto;
+    transition: none;
   }
-`;
-
-const SkeletonLabel = styled.span`
-  width: 3.75rem;
-  height: 0.85rem;
-  border-radius: 999px;
-  background: ${theme.colors.border.base};
 `;


### PR DESCRIPTION
## Summary

This keeps the top-right account button from briefly showing “Sign in” for signed-in users while the client auth/profile state is still loading.

## Changes

- Render no top-right account control until `useAuthUser` has resolved.
- Fade in the final signed-in or signed-out account button once the state is known.
- Keep the final signed-in and signed-out destinations unchanged.
- Add homepage e2e coverage for signed-in loading, signed-in profile, and guest sign-in states.

## Checks

- `npm run test:e2e:prod -- e2e/home.spec.ts`
- `npm run check`