### PR TITLE
improve public page crawl signals

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -46,8 +46,10 @@ test("guest chats redirect preserves the requested chat path", async ({
 }) => {
   await page.goto(`/chats/${SEEDED_THREAD_ID}`);
 
-  await expect(page).toHaveURL(
-    new RegExp(`/sign-in\\?redirect_to=/?chats/${SEEDED_THREAD_ID}$`)
+  await expect(page).toHaveURL(/\/sign-in\?/);
+  const redirectedUrl = new URL(page.url());
+  expect(redirectedUrl.searchParams.get("redirect_to")).toBe(
+    `/chats/${SEEDED_THREAD_ID}`
   );
   await expect(page.getByTestId("sign-in-form")).toBeVisible();
 });

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -134,11 +134,12 @@ test("listing edit saves and restores seeded business fields", async ({
     .fill(originalDescription);
   await listingWriteForm
     .locator("#visibility")
+    .first()
     .selectOption(originalVisibility);
 
   await Promise.all([
     page.waitForURL(/\/listings\/demo-inner-west-cafe\?status=updated$/),
-    page.getByTestId("listing-write-submit").click(),
+    listingWriteForm.getByTestId("listing-write-submit").first().click(),
   ]);
 
   await page.goto(BUSINESS_LISTING_EDIT_PATH);

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -13,6 +13,7 @@ const INNER_WEST_MAP_VIEW: StoredMapView = {
   longitude: 151.16,
   zoom: 7,
 };
+const MAP_MARKER_RENDER_TIMEOUT_MS = 20_000;
 
 async function seedStoredMapView(page: Page, view: StoredMapView) {
   await page.context().addCookies([
@@ -254,7 +255,9 @@ test("map pins minify at country zoom, then grow and animate selection", async (
   });
 
   const firstPin = page.getByTestId("map-pin").first();
-  await expect(firstPin).toBeVisible({ timeout: 10_000 });
+  await expect(firstPin).toBeVisible({
+    timeout: MAP_MARKER_RENDER_TIMEOUT_MS,
+  });
   await expectMapPinDetailScale(page, 0);
   await expectMapPinVisualWidth(
     firstPin.locator('[data-testid="map-pin-compact-dot"]'),

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+const LISTING_PATH = "/listings/demo-marrickville-compost";
+const MAP_LISTING_PATH = "/map?listing=demo-marrickville-compost";
+
+test("public listing pages expose crawlable listing metadata", async ({
+  page,
+}) => {
+  await page.goto(LISTING_PATH, { waitUntil: "domcontentloaded" });
+
+  await expect(page).toHaveTitle("Marrickville Neighbourhood Compost");
+  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    /\/listings\/demo-marrickville-compost$/
+  );
+
+  const description = await page
+    .locator('head meta[name="description"]')
+    .getAttribute("content");
+  expect(description).toContain(
+    "Marrickville Neighbourhood Compost helps people compost food scraps"
+  );
+
+  const jsonLdScripts = await page
+    .locator('script[type="application/ld+json"]')
+    .allTextContents();
+  expect(
+    jsonLdScripts.some(
+      (script) =>
+        script.includes('"@type":"WebPage"') &&
+        script.includes("Marrickville Neighbourhood Compost")
+    )
+  ).toBeTruthy();
+});
+
+test("map listing URLs canonicalise to the static listing sibling", async ({
+  page,
+}) => {
+  await page.goto(MAP_LISTING_PATH, { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    /\/listings\/demo-marrickville-compost$/
+  );
+});
+
+test("auth utility pages are noindex and omitted from the sitemap", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/sign-in", { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
+    "content",
+    /noindex,\s*follow/
+  );
+
+  const sitemap = await request.get("/sitemap.xml");
+  expect(sitemap.ok()).toBeTruthy();
+
+  const sitemapXml = await sitemap.text();
+  expect(sitemapXml).not.toContain("/sign-in");
+  expect(sitemapXml).not.toContain("/sign-up");
+  expect(sitemapXml).toContain("/listings/demo-marrickville-compost");
+});
+
+test("robots.txt allows crawling and advertises the sitemap", async ({
+  request,
+}) => {
+  const response = await request.get("/robots.txt");
+  expect(response.ok()).toBeTruthy();
+
+  const robots = await response.text();
+  expect(robots).toContain("Allow: /");
+  expect(robots).toContain("Sitemap: https://www.peels.app/sitemap.xml");
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "i18n:check": "node scripts/check-i18n-messages.mjs",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "check": "npm run i18n:check && npm run format:check && npm run test:unit",
-    "test:unit": "node --test --experimental-strip-types src/utils/dateUtils.test.ts",
+    "test:unit": "node scripts/run-unit-tests.mjs",
     "test:e2e": "playwright test",
     "pretest:e2e:prod": "npm run build",
     "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -1,0 +1,45 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function collectTestFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectTestFiles(entryPath);
+      }
+
+      return entry.isFile() && entry.name.endsWith(".test.ts")
+        ? [entryPath]
+        : [];
+    })
+    .sort();
+}
+
+const testFiles = collectTestFiles("src");
+
+if (testFiles.length === 0) {
+  console.error("No unit test files found.");
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  ["--test", "--experimental-strip-types", ...testFiles],
+  {
+    stdio: "inherit",
+  }
+);
+
+if (result.error) {
+  throw result.error;
+}
+
+if (result.signal) {
+  console.error(`Unit test process exited with signal ${result.signal}.`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/src/app/(core)/(interact)/(centered)/listings/[slug]/page.tsx
+++ b/src/app/(core)/(interact)/(centered)/listings/[slug]/page.tsx
@@ -1,7 +1,11 @@
 import { createClient } from "@/utils/supabase/server";
 import { notFound } from "next/navigation";
-import { generateListingMetadata } from "@/utils/listingUtils";
+import {
+  generateListingJsonLd,
+  generateListingMetadata,
+} from "@/utils/listingUtils";
 import ListingRead from "@/components/ListingRead";
+import JsonLd from "@/components/JsonLd";
 import { styled } from "next-yak";
 import { cache } from "react";
 import { theme } from "@/styles/theme.yak";
@@ -67,10 +71,13 @@ export default async function ListingPage({
     notFound();
   }
 
+  const listingJsonLd = generateListingJsonLd(listing, user);
+
   // TODO: Return 'Success' toast for folks who have just created a new listing and have been redirected to it, here
 
   return (
     <StyledMain>
+      {listingJsonLd ? <JsonLd data={listingJsonLd} /> : null}
       <ListingRead user={user} listing={listing} referenceNow={referenceNow} />
     </StyledMain>
   );

--- a/src/app/(core)/(interact)/(centered)/profile/layout.tsx
+++ b/src/app/(core)/(interact)/(centered)/profile/layout.tsx
@@ -1,6 +1,10 @@
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
+import { noindexFollowMetadata } from "@/utils/seo";
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = noindexFollowMetadata;
 
 const ProfilePageLayout = styled.main`
   flex: 1;

--- a/src/app/(core)/(interact)/(stretched)/chats/layout.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/layout.tsx
@@ -5,7 +5,11 @@ import { currentPathHeaderName } from "@/utils/supabase/authState";
 import { normaliseNextPath } from "@/utils/authRedirects";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { noindexFollowMetadata } from "@/utils/seo";
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = noindexFollowMetadata;
 
 export default async function ChatsLayout({
   children,

--- a/src/app/(core)/(interact)/(stretched)/map/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/map/page.tsx
@@ -57,6 +57,9 @@ export async function generateMetadata({
   if (!listingSlug) {
     return {
       title: "Map",
+      alternates: {
+        canonical: "/map",
+      },
       openGraph: {
         title: `Map · ${siteConfig.name}`,
       },
@@ -64,6 +67,18 @@ export async function generateMetadata({
   }
 
   const { user, listing } = await getInitialData(listingSlug);
+
+  if (!listing) {
+    return {
+      title: "Map",
+      alternates: {
+        canonical: "/map",
+      },
+      openGraph: {
+        title: `Map · ${siteConfig.name}`,
+      },
+    };
+  }
 
   return generateListingMetadata(listing, user);
 }

--- a/src/app/(forms)/layout.tsx
+++ b/src/app/(forms)/layout.tsx
@@ -1,6 +1,10 @@
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
+import { noindexFollowMetadata } from "@/utils/seo";
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = noindexFollowMetadata;
 
 const AuthPage = styled.main`
   margin: 0.5rem auto;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import "./theme.css";
 import { UnreadMessagesProvider } from "@/contexts/UnreadMessagesContext";
 import AttributionCapture from "@/components/AttributionCapture";
 import AuthHashCompletion from "@/components/AuthHashCompletion";
+import JsonLd from "@/components/JsonLd";
 
 const regularFontUrl = getStaticFontUrl("national-2-regular-subset.woff2");
 const mediumFontUrl = getStaticFontUrl("national-2-medium-subset.woff2");
@@ -43,6 +44,28 @@ const hostedFontFaces = `
     font-display: swap;
   }
 `;
+
+const siteJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": `${siteConfig.url}/#organization`,
+    name: siteConfig.name,
+    url: siteConfig.url,
+    logo: `${siteConfig.url}/icon.png`,
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${siteConfig.url}/#website`,
+    name: siteConfig.name,
+    alternateName: "Peels.app",
+    url: siteConfig.url,
+    publisher: {
+      "@id": `${siteConfig.url}/#organization`,
+    },
+  },
+];
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.url),
@@ -81,6 +104,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} data-scroll-behavior="smooth">
       <body>
+        <JsonLd data={siteJsonLd} />
         {inlineFontFaces ? <style>{inlineFontFaces}</style> : null}
         <AuthHashCompletion />
         <AttributionCapture />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -73,18 +73,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "yearly",
       priority: 0.5,
     },
-    {
-      url: `${siteConfig.url}/sign-in`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.5,
-    },
-    {
-      url: `${siteConfig.url}/sign-up`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.5,
-    },
   ];
 
   return [...staticRoutes, ...listingRoutes];

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,14 @@
+type JsonLdProps = {
+  data: unknown;
+};
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/src/features/map/lib/mapUtils.test.ts
+++ b/src/features/map/lib/mapUtils.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { LngLatBounds } from "maplibre-gl";
+
+import { padBounds } from "./mapUtils.ts";
+
+function bounds(
+  south: number,
+  west: number,
+  north: number,
+  east: number
+): LngLatBounds {
+  return {
+    getSouthWest: () => ({ lat: south, lng: west }),
+    getNorthEast: () => ({ lat: north, lng: east }),
+  } as LngLatBounds;
+}
+
+test("padBounds splits full-world viewports into geography-safe boxes", () => {
+  const boxes = padBounds(bounds(-90, -180, 90, 180), 0);
+
+  assert.deepEqual(boxes, [
+    { south: -89.999999, north: 89.999999, west: -180, east: -60 },
+    { south: -89.999999, north: 89.999999, west: -60, east: 60 },
+    { south: -89.999999, north: 89.999999, west: 60, east: 180 },
+  ]);
+});
+
+test("padBounds still splits antimeridian crossings", () => {
+  const boxes = padBounds(bounds(-10, 170, 10, 190), 0.3);
+
+  assert.deepEqual(boxes, [
+    { south: -16, north: 16, west: 164, east: 180 },
+    { south: -16, north: 16, west: -180, east: -164 },
+  ]);
+});

--- a/src/features/map/lib/mapUtils.ts
+++ b/src/features/map/lib/mapUtils.ts
@@ -6,7 +6,7 @@ import {
   type ListingCoordinates,
   type ListingMarker,
   type SelectedListing,
-} from "@/types/listing";
+} from "../../../types/listing.ts";
 
 export type BoundingBox = {
   south: number;
@@ -14,6 +14,9 @@ export type BoundingBox = {
   north: number;
   east: number;
 };
+
+const GEOGRAPHY_BOUND_EPSILON = 0.000001;
+const GLOBAL_LONGITUDE_SLICES = [-180, -60, 60, 180] as const;
 
 export const ZOOM_LEVEL_DEFAULT = 11;
 export const ZOOM_LEVEL_SELECTED = 14;
@@ -99,13 +102,19 @@ export function padBounds(bounds: LngLatBounds, factor = 0.3): BoundingBox[] {
   const latPad = latSpan * factor;
   const lngPad = lngSpan * factor;
 
-  const south = Math.max(-90, sw.lat - latPad);
-  const north = Math.min(90, ne.lat + latPad);
+  const south = Math.max(-90 + GEOGRAPHY_BOUND_EPSILON, sw.lat - latPad);
+  const north = Math.min(90 - GEOGRAPHY_BOUND_EPSILON, ne.lat + latPad);
 
   // If the padded viewport already covers the whole globe, just request the
-  // whole world (avoids degenerate envelopes in PostGIS).
+  // world as multiple geography-safe slices. A single `-180..180` envelope can
+  // create antipodal edges when PostGIS casts it to geography.
   if (lngSpan + 2 * lngPad >= 360) {
-    return [{ south, north, west: -180, east: 180 }];
+    return GLOBAL_LONGITUDE_SLICES.slice(0, -1).map((west, index) => ({
+      south,
+      north,
+      west,
+      east: GLOBAL_LONGITUDE_SLICES[index + 1],
+    }));
   }
 
   const west = wrapLongitude(sw.lng - lngPad);

--- a/src/utils/listingUtils.test.ts
+++ b/src/utils/listingUtils.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  generateListingDescription,
+  generateListingJsonLd,
+  generateListingMetadata,
+} from "./listingUtils.ts";
+import type { Listing } from "../types/listing.ts";
+
+const communityListing = {
+  id: 1,
+  name: "Neighbourhood compost drop-off",
+  description:
+    "Households can subscribe to drop off their food scraps at a local community hub.",
+  accepted_items: ["Food scraps"],
+  rejected_items: [],
+  photos: ["demo/community-garden.jpg"],
+  links: [],
+  type: "community",
+  avatar: "demo/community-avatar.jpg",
+  slug: "test-community-compost",
+  coordinates: {
+    latitude: -33.911,
+    longitude: 151.1569,
+  },
+  country_code: "AU",
+  area_name: "Marrickville",
+  is_stub: false,
+  owner_has_multiple_non_residential_listings: false,
+} satisfies Listing;
+
+test("listing metadata uses the listing name as the absolute title", () => {
+  const metadata = generateListingMetadata(communityListing, null, {
+    includeFullMetadata: true,
+  });
+
+  assert.deepEqual(metadata.title, {
+    absolute: "Neighbourhood compost drop-off",
+  });
+  assert.equal(metadata.openGraph?.title, "Neighbourhood compost drop-off");
+});
+
+test("listing descriptions lead with compost and food-scrap intent", () => {
+  const description = generateListingDescription(communityListing, null);
+
+  assert.match(
+    description,
+    /^Neighbourhood compost drop-off helps people compost food scraps in Marrickville, Australia\./
+  );
+  assert.match(description, /local community hub/);
+});
+
+test("listing metadata includes the canonical listing path", () => {
+  const metadata = generateListingMetadata(communityListing, null, {
+    includeFullMetadata: true,
+  });
+
+  assert.equal(
+    metadata.alternates?.canonical,
+    "/listings/test-community-compost"
+  );
+});
+
+test("residential public metadata avoids leaking host names", () => {
+  const residentialListing = {
+    ...communityListing,
+    type: "residential",
+    name: null,
+    owner_first_name: "Sam",
+    slug: "private-host",
+  } satisfies Listing;
+
+  const metadata = generateListingMetadata(residentialListing, null, {
+    includeFullMetadata: true,
+  });
+  const description = String(metadata.description);
+
+  assert.deepEqual(metadata.title, {
+    absolute: "Private Host",
+  });
+  assert.match(description, /^Private Host accepts food scraps for composting/);
+  assert.doesNotMatch(description, /Sam/);
+});
+
+test("listing JSON-LD describes the public listing page and place conservatively", () => {
+  const jsonLd = generateListingJsonLd(communityListing, null);
+
+  assert.ok(jsonLd);
+  assert.equal(jsonLd["@type"], "WebPage");
+  assert.equal(jsonLd.name, "Neighbourhood compost drop-off");
+  assert.equal(
+    jsonLd.url,
+    "https://www.peels.app/listings/test-community-compost"
+  );
+  assert.equal(jsonLd.about["@type"], "Place");
+  assert.ok(jsonLd.about.address);
+  assert.equal(jsonLd.about.address.addressLocality, "Marrickville");
+  assert.equal(jsonLd.about.address.addressCountry, "Australia");
+});
+
+test("anonymous residential listing JSON-LD omits structured location details", () => {
+  const residentialListing = {
+    ...communityListing,
+    type: "residential",
+    name: null,
+    owner_first_name: "Sam",
+    slug: "private-host",
+  } satisfies Listing;
+
+  const jsonLd = generateListingJsonLd(residentialListing, null);
+
+  assert.ok(jsonLd);
+  assert.equal(jsonLd.name, "Private Host");
+  assert.equal(jsonLd.about.address, undefined);
+  assert.equal(jsonLd.about.geo, undefined);
+});

--- a/src/utils/listingUtils.ts
+++ b/src/utils/listingUtils.ts
@@ -1,7 +1,8 @@
-import { siteConfig } from "@/config/site";
-import { countries } from "@/data/countries";
+import { siteConfig } from "../config/site.ts";
+import { countries } from "../data/countries.ts";
+import { getStoragePublicUrl } from "./storage.ts";
 import type { Metadata } from "next";
-import type { ListingType } from "@/types/listing";
+import type { ListingCoordinates, ListingType } from "../types/listing.ts";
 
 type ListingLike = {
   type?: ListingType | string | null;
@@ -10,9 +11,12 @@ type ListingLike = {
   owner_avatar?: string | null;
   avatar?: string | null;
   is_demo?: boolean;
+  slug?: string | null;
   country_code?: string | null;
   area_name?: string | null;
   description?: string | null;
+  photos?: string[] | null;
+  coordinates?: ListingCoordinates | null;
 };
 
 type ListingUser =
@@ -52,6 +56,49 @@ function compactTextParts(parts: Array<string | null | undefined>) {
   return parts
     .map((part) => part?.trim())
     .filter((part): part is string => Boolean(part));
+}
+
+function getListingCountryName(listing: ListingLike | null | undefined) {
+  return countries.find((country) => country.code === listing?.country_code)
+    ?.name;
+}
+
+function getListingLocation(listing: ListingLike | null | undefined) {
+  const listingCountryName = getListingCountryName(listing);
+
+  return compactTextParts([listing?.area_name, listingCountryName]).join(", ");
+}
+
+function getListingCanonicalPath(listing: ListingLike) {
+  if (!listing.slug) return null;
+
+  return `/listings/${encodeURIComponent(listing.slug)}`;
+}
+
+function getListingStructuredDataImage(
+  listing: ListingLike,
+  user: ListingUser
+) {
+  if (normaliseListingType(listing.type) === "residential") {
+    return null;
+  }
+
+  const firstPhoto = listing.photos?.[0];
+  if (firstPhoto) {
+    return getStoragePublicUrl("listing_photos", firstPhoto);
+  }
+
+  const avatar = getListingAvatar(listing, user);
+
+  if (avatar?.path) {
+    return new URL(avatar.path, siteConfig.url).toString();
+  }
+
+  if (avatar?.bucket && avatar.filename) {
+    return getStoragePublicUrl(avatar.bucket, avatar.filename);
+  }
+
+  return null;
 }
 
 export function getListingDisplayName(
@@ -163,6 +210,39 @@ export function getListingDisplayType(listing: ListingLike | null | undefined) {
   return "Local listing";
 }
 
+export function generateListingDescription(
+  listing: ListingLike | null | undefined,
+  user: ListingUser
+) {
+  if (!listing) return "";
+
+  const listingDisplayName = getListingDisplayName(listing, user);
+  const listingType = normaliseListingType(listing.type);
+  const listingFullLocation = getListingLocation(listing);
+  const listingIntro =
+    listingType === "residential"
+      ? `${listingDisplayName} accepts food scraps for composting`
+      : `${listingDisplayName} helps people compost food scraps`;
+  const listingLocationSuffix = listingFullLocation
+    ? ` in ${listingFullLocation}.`
+    : ".";
+  const listingDescriptionParts = [
+    `${listingIntro}${listingLocationSuffix}`,
+    listingType === "residential"
+      ? null
+      : listing.description?.trim()
+        ? listing.description.trim()
+        : null,
+    `Connect with ${
+      listingType === "residential"
+        ? "them"
+        : listing.name || listingDisplayName
+    } on ${siteConfig.name}, ${siteConfig.meta.explainer}.`,
+  ];
+
+  return compactTextParts(listingDescriptionParts).join(" ");
+}
+
 export function generateListingMetadata(
   listing: ListingLike | null | undefined,
   user: ListingUser,
@@ -175,47 +255,27 @@ export function generateListingMetadata(
   }
 
   const listingDisplayName = getListingDisplayName(listing, user);
-  const listingType = normaliseListingType(listing.type);
-  const listingCountryName = countries.find(
-    (country) => country.code === listing.country_code
-  )?.name;
-  const listingLocationParts = compactTextParts([
-    listing.area_name,
-    listingCountryName,
-  ]);
-  const listingFullLocation = listingLocationParts.join(", ");
-  const listingBaseDescriptor =
-    listingType === "residential"
-      ? `${listingDisplayName} is a local resident`
-      : listingType
-        ? `${listingDisplayName} is a ${listingType}`
-        : `${listingDisplayName} is a local listing`;
-  const listingDescriptionParts = [
-    listingBaseDescriptor,
-    listingFullLocation ? `based in ${listingFullLocation}.` : null,
-    listingType === "residential"
-      ? null
-      : listing.description?.trim()
-        ? `${listing.description.trim()}`
-        : null,
-    `Connect with ${
-      listingType === "residential"
-        ? "them"
-        : listing.name || listingDisplayName
-    } on ${siteConfig.name}, ${siteConfig.meta.explainer}.`,
-  ];
-  const listingDescription = compactTextParts(listingDescriptionParts).join(
-    " "
-  );
+  const listingFullLocation = getListingLocation(listing);
+  const listingDescription = generateListingDescription(listing, user);
+  const listingCanonicalPath = getListingCanonicalPath(listing);
 
   const metadata: Metadata = {
-    title: listingDisplayName,
+    title: {
+      absolute: listingDisplayName,
+    },
+    description: listingDescription,
     openGraph: {
       title: listingDisplayName,
       description: listingDescription,
       siteName: siteConfig.name,
     },
   };
+
+  if (listingCanonicalPath) {
+    metadata.alternates = {
+      canonical: listingCanonicalPath,
+    };
+  }
 
   if (options.includeFullMetadata) {
     const locationKeywords = listingFullLocation
@@ -228,9 +288,62 @@ export function generateListingMetadata(
         ]
       : [];
 
-    metadata.description = listingDescription;
     metadata.keywords = [...locationKeywords, ...siteConfig.meta.keywords];
   }
 
   return metadata;
+}
+
+export function generateListingJsonLd(
+  listing: ListingLike | null | undefined,
+  user: ListingUser
+) {
+  if (!listing?.slug) return null;
+
+  const listingDisplayName = getListingDisplayName(listing, user);
+  const listingDescription = generateListingDescription(listing, user);
+  const listingType = normaliseListingType(listing.type);
+  const listingCountryName = getListingCountryName(listing);
+  const listingCanonicalUrl = new URL(
+    `/listings/${encodeURIComponent(listing.slug)}`,
+    siteConfig.url
+  ).toString();
+  const structuredDataImage = getListingStructuredDataImage(listing, user);
+  const canIncludeStructuredLocation = listingType !== "residential" || !!user;
+  const address = {
+    "@type": "PostalAddress",
+    ...(listing.area_name ? { addressLocality: listing.area_name } : {}),
+    ...(listingCountryName ? { addressCountry: listingCountryName } : {}),
+  };
+  const place = {
+    "@type": "Place",
+    name: listingDisplayName,
+    description: listingDescription,
+    ...(canIncludeStructuredLocation && Object.keys(address).length > 1
+      ? { address }
+      : {}),
+    ...(canIncludeStructuredLocation && listing.coordinates
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: listing.coordinates.latitude,
+            longitude: listing.coordinates.longitude,
+          },
+        }
+      : {}),
+    ...(structuredDataImage ? { image: structuredDataImage } : {}),
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${listingCanonicalUrl}#webpage`,
+    url: listingCanonicalUrl,
+    name: listingDisplayName,
+    description: listingDescription,
+    isPartOf: {
+      "@id": `${siteConfig.url}/#website`,
+    },
+    about: place,
+  };
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+
+export const noindexFollowMetadata = {
+  robots: {
+    index: false,
+    follow: true,
+  },
+} satisfies Metadata;


### PR DESCRIPTION
## Summary

- improve listing metadata with listing-only titles, canonical URLs, compost-forward descriptions, and JSON-LD
- add site-level WebSite/Organization JSON-LD and noindex utility surfaces
- harden the e2e-prod auth redirect assertion by checking the decoded `redirect_to` value
- avoid PostGIS antipodal geography envelopes in wide map bounds and add focused coverage

## Validation

- `npm run check`
- `npx playwright test --config=playwright.prod.config.ts e2e/map.spec.ts e2e/auth.spec.ts`
- `npm run test:e2e:prod` was also run during validation; after the map bounds fix, targeted map/auth coverage passes without the antipodal RPC warning.