### PR TITLE
fix visibility metadata

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -33,6 +33,7 @@ test("chat loads the seeded thread and composer for a signed-in donor", async ({
   });
 
   await expect(page).toHaveURL(new RegExp(`/chats/${SEEDED_THREAD_ID}$`));
+  await expect(page).toHaveTitle("Avery · Chats · Peels");
   await expect(page.getByTestId("chat-window")).toBeVisible();
   await expect(page.getByTestId("chat-message-list")).toContainText(
     "Hey Avery, do you take coffee grounds from a small home espresso machine?"
@@ -50,6 +51,7 @@ test("chat loads the seeded thread and composer for a signed-in donor", async ({
   await expect(page).toHaveURL(
     new RegExp(`/chats/${SECOND_SEEDED_THREAD_ID}$`)
   );
+  await expect(page).toHaveTitle("Morgan · Chats · Peels");
   await expect(page.getByTestId("thread-list")).toHaveAttribute(
     "data-persist-check",
     "true"
@@ -63,6 +65,7 @@ test("chat loads the seeded thread and composer for a signed-in donor", async ({
 
   await page.getByTestId(`thread-preview-${SEEDED_THREAD_ID}`).click();
   await expect(page).toHaveURL(new RegExp(`/chats/${SEEDED_THREAD_ID}$`));
+  await expect(page).toHaveTitle("Avery · Chats · Peels");
   await expect(page.getByTestId("chat-message-list")).toContainText(
     "Yes, absolutely. Small sealed containers are perfect."
   );

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "@playwright/test";
+import { DONOR_EMAIL, SEEDED_THREAD_ID, signIn } from "./helpers";
 
 const LISTING_PATH = "/listings/demo-marrickville-compost";
 const MAP_LISTING_PATH = "/map?listing=demo-marrickville-compost";
 const RESIDENTIAL_LISTING_PATH = "/listings/demo-newtown-worm-farm";
+const SITE_URL = "https://www.peels.app";
+const DEFAULT_OG_IMAGE_PATTERN =
+  /^https:\/\/www\.peels\.app\/opengraph-image\.jpg/;
 
 async function getMetaDescription(page: import("@playwright/test").Page) {
   return page.locator('head meta[name="description"]').getAttribute("content");
@@ -10,6 +14,35 @@ async function getMetaDescription(page: import("@playwright/test").Page) {
 
 async function getListingJsonLdScripts(page: import("@playwright/test").Page) {
   return page.locator('script[type="application/ld+json"]').allTextContents();
+}
+
+async function expectSharedSocialMetadata(
+  page: import("@playwright/test").Page,
+  canonicalPath: string
+) {
+  const canonicalUrl =
+    canonicalPath === "/" ? SITE_URL : `${SITE_URL}${canonicalPath}`;
+
+  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    canonicalUrl
+  );
+  await expect(page.locator('head meta[property="og:url"]')).toHaveAttribute(
+    "content",
+    canonicalUrl
+  );
+  await expect(page.locator('head meta[property="og:image"]')).toHaveAttribute(
+    "content",
+    DEFAULT_OG_IMAGE_PATTERN
+  );
+  await expect(page.locator('head meta[name="twitter:card"]')).toHaveAttribute(
+    "content",
+    "summary_large_image"
+  );
+  await expect(page.locator('head meta[name="twitter:image"]')).toHaveAttribute(
+    "content",
+    DEFAULT_OG_IMAGE_PATTERN
+  );
 }
 
 type ListingJsonLd = {
@@ -57,25 +90,73 @@ test("homepage emits object-shaped site JSON-LD", async ({ page }) => {
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
   const jsonLdScripts = await getListingJsonLdScripts(page);
-  const siteJsonLd = parseJsonLdScripts(jsonLdScripts).find((data) =>
-    Array.isArray(data["@graph"])
+  const siteJsonLd = parseJsonLdScripts(jsonLdScripts);
+  const organizationJsonLd = siteJsonLd.find(
+    (data) => data["@type"] === "Organization"
   );
+  const websiteJsonLd = siteJsonLd.find((data) => data["@type"] === "WebSite");
 
-  expect(siteJsonLd).toEqual(
+  expect(organizationJsonLd).toEqual(
     expect.objectContaining({
       "@context": "https://schema.org",
-      "@graph": expect.arrayContaining([
-        expect.objectContaining({
-          "@type": "Organization",
-          name: "Peels",
-        }),
-        expect.objectContaining({
-          "@type": "WebSite",
-          name: "Peels",
-        }),
-      ]),
+      "@type": "Organization",
+      name: "Peels",
     })
   );
+  expect(websiteJsonLd).toEqual(
+    expect.objectContaining({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "Peels",
+    })
+  );
+});
+
+test("homepage exposes canonical social metadata and one primary H1", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page).toHaveTitle(
+    "Peels: Find a home for your food scraps, wherever you are"
+  );
+  await expectSharedSocialMetadata(page, "/");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText([
+    "Find a home for your food scraps, wherever you are",
+  ]);
+
+  const emptyLinks = await page.locator("a").evaluateAll((links) =>
+    links
+      .filter((link) => {
+        const text = link.textContent?.trim();
+        const ariaLabel = link.getAttribute("aria-label")?.trim();
+        const imageAlts = Array.from(link.querySelectorAll("img"))
+          .map((image) => image.getAttribute("alt")?.trim())
+          .filter(Boolean);
+
+        return !text && !ariaLabel && imageAlts.length === 0;
+      })
+      .map((link) => link.outerHTML)
+  );
+
+  expect(emptyLinks).toEqual([]);
+});
+
+test("public static pages expose canonical social metadata", async ({
+  page,
+}) => {
+  for (const { path, title } of [
+    { path: "/map", title: "Map · Peels" },
+    { path: "/newsletter", title: "Newsletter · Peels" },
+    { path: "/help", title: "Help · Peels" },
+    { path: "/partners", title: "Partners · Peels" },
+    { path: "/share", title: "Share · Peels" },
+  ]) {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveTitle(title);
+    await expectSharedSocialMetadata(page, path);
+  }
 });
 
 test("homepage emits summary FAQPage JSON-LD", async ({ page }) => {
@@ -104,11 +185,8 @@ test("public listing pages expose crawlable listing metadata", async ({
 }) => {
   await page.goto(LISTING_PATH, { waitUntil: "domcontentloaded" });
 
-  await expect(page).toHaveTitle("Marrickville Neighbourhood Compost");
-  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
-    "href",
-    /\/listings\/demo-marrickville-compost$/
-  );
+  await expect(page).toHaveTitle("Marrickville Neighbourhood Compost · Peels");
+  await expectSharedSocialMetadata(page, LISTING_PATH);
 
   const description = await getMetaDescription(page);
   expect(description).toContain(
@@ -148,11 +226,8 @@ test("anonymous residential listing pages expose an indexable private-host tease
 }) => {
   await page.goto(RESIDENTIAL_LISTING_PATH, { waitUntil: "domcontentloaded" });
 
-  await expect(page).toHaveTitle("Private Host");
-  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
-    "href",
-    /\/listings\/demo-newtown-worm-farm$/
-  );
+  await expect(page).toHaveTitle("Private Host · Peels");
+  await expectSharedSocialMetadata(page, RESIDENTIAL_LISTING_PATH);
   await expect(page.locator('head meta[name="robots"]')).toHaveCount(0);
 
   const description = await getMetaDescription(page);
@@ -213,7 +288,9 @@ test("public listing pages localise Spanish SEO metadata", async ({
     await page.goto(LISTING_PATH, { waitUntil: "domcontentloaded" });
 
     await expect(page.locator("html")).toHaveAttribute("lang", "es");
-    await expect(page).toHaveTitle("Marrickville Neighbourhood Compost");
+    await expect(page).toHaveTitle(
+      "Marrickville Neighbourhood Compost · Peels"
+    );
     await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
       "href",
       /\/listings\/demo-marrickville-compost$/
@@ -269,7 +346,7 @@ test("anonymous residential listing pages localise the private-host teaser", asy
     });
 
     await expect(page.locator("html")).toHaveAttribute("lang", "es");
-    await expect(page).toHaveTitle("Anfitrión privado");
+    await expect(page).toHaveTitle("Anfitrión privado · Peels");
     await expect(
       page.getByRole("heading", { name: "Anfitrión privado" })
     ).toBeVisible();
@@ -313,10 +390,7 @@ test("map listing URLs canonicalise to the static listing sibling", async ({
 }) => {
   await page.goto(MAP_LISTING_PATH, { waitUntil: "domcontentloaded" });
 
-  await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
-    "href",
-    /\/listings\/demo-marrickville-compost$/
-  );
+  await expectSharedSocialMetadata(page, LISTING_PATH);
 });
 
 test("map listing URLs localise metadata without changing canonical", async ({
@@ -331,10 +405,7 @@ test("map listing URLs localise metadata without changing canonical", async ({
   try {
     await page.goto(MAP_LISTING_PATH, { waitUntil: "domcontentloaded" });
 
-    await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute(
-      "href",
-      /\/listings\/demo-marrickville-compost$/
-    );
+    await expectSharedSocialMetadata(page, LISTING_PATH);
 
     const description = await getMetaDescription(page);
     expect(description).toContain(
@@ -380,10 +451,12 @@ test("auth utility pages are noindex and omitted from the sitemap", async ({
 }) => {
   await page.goto("/sign-in", { waitUntil: "domcontentloaded" });
 
+  await expect(page).toHaveTitle("Sign in · Peels");
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
     "content",
     /noindex,\s*follow/
   );
+  await expectSharedSocialMetadata(page, "/sign-in");
 
   const sitemap = await request.get("/sitemap.xml");
   expect(sitemap.ok()).toBeTruthy();
@@ -392,6 +465,37 @@ test("auth utility pages are noindex and omitted from the sitemap", async ({
   expect(sitemapXml).not.toContain("/sign-in");
   expect(sitemapXml).not.toContain("/sign-up");
   expect(sitemapXml).toContain("/listings/demo-marrickville-compost");
+});
+
+test("signed-in private pages keep noindex metadata and route-specific titles", async ({
+  page,
+}) => {
+  await signIn(page, { email: DONOR_EMAIL, redirectTo: "/profile" });
+
+  await expect(page).toHaveTitle("Profile · Peels");
+  await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
+    "content",
+    /noindex,\s*follow/
+  );
+  await expectSharedSocialMetadata(page, "/profile");
+
+  await page.goto("/chats", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveTitle("Chats · Peels");
+  await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
+    "content",
+    /noindex,\s*follow/
+  );
+  await expectSharedSocialMetadata(page, "/chats");
+
+  await page.goto(`/chats/${SEEDED_THREAD_ID}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page).toHaveTitle("Avery · Chats · Peels");
+  await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
+    "content",
+    /noindex,\s*follow/
+  );
+  await expectSharedSocialMetadata(page, `/chats/${SEEDED_THREAD_ID}`);
 });
 
 test("help page emits FAQPage JSON-LD for visible help questions", async ({

--- a/src/app/(core)/(interact)/(centered)/profile/page.tsx
+++ b/src/app/(core)/(interact)/(centered)/profile/page.tsx
@@ -20,6 +20,7 @@ import { getTranslations } from "next-intl/server";
 import { siteConfig } from "@/config/site";
 import { defaultLocale, normaliseLocale } from "@/i18n/config";
 import { redirect } from "next/navigation";
+import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
 import type { ListingType } from "@/types/listing";
 import {
   sharedSectionHeadingStyles,
@@ -27,14 +28,20 @@ import {
 } from "@/styles/commonStyles";
 
 export async function generateMetadata() {
-  const t = await getTranslations("Profile.sections");
+  const t = await getTranslations("App");
+  const title = t("profile");
 
-  return {
-    title: t("account"),
+  return createPeelsMetadata({
+    ...noindexFollowMetadata,
+    canonicalPath: "/profile",
+    title,
     openGraph: {
-      title: `${t("account")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+    },
+  });
 }
 
 // Keep URL-based feedback in a client leaf so server rendering is driven by auth/data only.

--- a/src/app/(core)/(interact)/(stretched)/chats/[threadId]/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[threadId]/page.tsx
@@ -2,7 +2,10 @@ import { createClient } from "@/utils/supabase/server";
 import { ChatConversationClient } from "@/components/ChatPageClient";
 import { getSelectedChatThread, isUuid } from "@/features/chat/chatData";
 import { redirect } from "next/navigation";
+import { cache } from "react";
 import type { Metadata } from "next";
+import { siteConfig } from "@/config/site";
+import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
 
 type ChatThreadPageProps = {
   params: Promise<{
@@ -10,9 +13,82 @@ type ChatThreadPageProps = {
   }>;
 };
 
-export const metadata: Metadata = {
-  title: "Chats",
-};
+const getChatThreadPageData = cache(async (threadId: string) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {
+      user: null,
+      selectedThread: null,
+    };
+  }
+
+  const selectedThread = await getSelectedChatThread(
+    supabase,
+    user.id,
+    threadId
+  );
+
+  return {
+    user,
+    selectedThread,
+  };
+});
+
+function getChatThreadTitle(
+  selectedThread: Awaited<ReturnType<typeof getSelectedChatThread>>,
+  userId: string
+) {
+  if (!selectedThread) return "Chats";
+
+  const otherPersonName =
+    selectedThread.initiator_id === userId
+      ? selectedThread.owner_first_name
+      : selectedThread.initiator_first_name;
+
+  return otherPersonName ? `${otherPersonName} · Chats` : "Chats";
+}
+
+export async function generateMetadata({
+  params,
+}: ChatThreadPageProps): Promise<Metadata> {
+  const { threadId } = await params;
+
+  if (!isUuid(threadId)) {
+    return createPeelsMetadata({
+      ...noindexFollowMetadata,
+      canonicalPath: "/chats",
+      title: "Chats",
+    });
+  }
+
+  const { user, selectedThread } = await getChatThreadPageData(threadId);
+
+  if (!user) {
+    return createPeelsMetadata({
+      ...noindexFollowMetadata,
+      canonicalPath: `/chats/${threadId}`,
+      title: "Chats",
+    });
+  }
+
+  const title = getChatThreadTitle(selectedThread, user.id);
+
+  return createPeelsMetadata({
+    ...noindexFollowMetadata,
+    canonicalPath: `/chats/${threadId}`,
+    title,
+    openGraph: {
+      title: `${title} · ${siteConfig.name}`,
+    },
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+    },
+  });
+}
 
 export default async function ChatThreadPage({ params }: ChatThreadPageProps) {
   const { threadId } = await params;
@@ -22,20 +98,11 @@ export default async function ChatThreadPage({ params }: ChatThreadPageProps) {
     redirect("/chats");
   }
 
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { user, selectedThread } = await getChatThreadPageData(threadId);
 
   if (!user) {
     redirect(`/sign-in?redirect_to=/chats/${threadId}`);
   }
-
-  const selectedThread = await getSelectedChatThread(
-    supabase,
-    user.id,
-    threadId
-  );
 
   if (!selectedThread) {
     redirect("/chats");

--- a/src/app/(core)/(interact)/(stretched)/chats/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPeelsMetadata({
+  ...noindexFollowMetadata,
+  canonicalPath: "/chats",
   title: "Chats",
-};
+});
 
 export default function ChatsIndexPage() {
   return null;

--- a/src/app/(core)/(interact)/(stretched)/map/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/map/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/utils/supabase/server";
 import { siteConfig } from "@/config/site";
 import { generateListingMetadata } from "@/utils/listingUtils";
 import { getListingSeoOptions } from "@/utils/listingSeo";
+import { createPeelsMetadata } from "@/utils/seo";
 import MapPageClient from "@/features/map";
 import type { Listing } from "@/types/listing";
 import { parseStoredInitialMapCoordinates } from "@/features/map/lib/mapInitialView";
@@ -50,35 +51,32 @@ function parseInitialMapCoordinatesCookie(value: string | undefined) {
   }
 }
 
+function getMapMetadata() {
+  return createPeelsMetadata({
+    title: "Map",
+    canonicalPath: "/map",
+    openGraph: {
+      title: `Map · ${siteConfig.name}`,
+    },
+    twitter: {
+      title: `Map · ${siteConfig.name}`,
+    },
+  });
+}
+
 export async function generateMetadata({
   searchParams,
 }: MapPageProps): Promise<Metadata> {
   const listingSlug = (await searchParams)?.listing;
 
   if (!listingSlug) {
-    return {
-      title: "Map",
-      alternates: {
-        canonical: "/map",
-      },
-      openGraph: {
-        title: `Map · ${siteConfig.name}`,
-      },
-    };
+    return getMapMetadata();
   }
 
   const { user, listing } = await getInitialData(listingSlug);
 
   if (!listing) {
-    return {
-      title: "Map",
-      alternates: {
-        canonical: "/map",
-      },
-      openGraph: {
-        title: `Map · ${siteConfig.name}`,
-      },
-    };
+    return getMapMetadata();
   }
 
   const listingSeoOptions = await getListingSeoOptions();

--- a/src/app/(core)/(static)/(index)/page.tsx
+++ b/src/app/(core)/(static)/(index)/page.tsx
@@ -15,6 +15,7 @@ import HeaderBlock from "@/components/HeaderBlock";
 import FooterBlock from "@/components/FooterBlock";
 import { PeelsFaqJsonLd } from "@/components/FaqJsonLd/FaqJsonLd";
 import { homepageCouncilMentions } from "@/content/partnerMentions";
+import { createPeelsMetadata } from "@/utils/seo";
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 import { sharedCenteredPageStackStyles } from "@/styles/commonStyles";
@@ -27,21 +28,24 @@ export async function generateMetadata() {
     .map((keyword) => keyword.trim())
     .filter(Boolean);
 
-  return {
+  const title = `${siteConfig.name}: ${t("title")}`;
+
+  return createPeelsMetadata({
+    canonicalPath: "/",
     title: {
-      absolute: `${siteConfig.name}: ${t("title")}`,
+      absolute: title,
     },
     description,
     keywords,
     openGraph: {
-      title: `${siteConfig.name}: ${t("title")}`,
+      title,
       description,
     },
     twitter: {
-      title: `${siteConfig.name}: ${t("title")}`,
+      title,
       description,
     },
-  };
+  });
 }
 
 export default function Index() {

--- a/src/app/(core)/(static)/(legal)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/(legal)/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   getLegalPageMetadata,
   getLegalPageModule,
 } from "@/lib/content/handlers/legal";
+import { createPeelsMetadata } from "@/utils/seo";
 import { getLocale, getTranslations } from "next-intl/server";
 
 type LegalPageProps = {
@@ -23,13 +24,20 @@ export async function generateMetadata({
   const { metadata } = await getLegalPageMetadata(slug, locale);
 
   if (metadata) {
-    return {
+    return createPeelsMetadata({
       ...metadata,
+      canonicalPath: `/${slug}`,
       openGraph: {
         ...metadata.openGraph,
+        title: metadata.title,
+        description: metadata.description,
         type: "article",
       },
-    };
+      twitter: {
+        title: metadata.title,
+        description: metadata.description,
+      },
+    });
   } else {
     throw new Error(`No metadata found for text page: ${slug}`);
   }

--- a/src/app/(core)/(static)/help/page.tsx
+++ b/src/app/(core)/(static)/help/page.tsx
@@ -10,19 +10,27 @@ import PeelsFaq from "@/components/PeelsFaq";
 import HeaderBlock from "@/components/HeaderBlock";
 import EmailSelector from "@/components/EmailSelector/EmailSelector";
 import { HelpFaqJsonLd } from "@/components/FaqJsonLd/FaqJsonLd";
+import { createPeelsMetadata } from "@/utils/seo";
 
 export async function generateMetadata() {
   const t = await getTranslations("Support");
   const description = t("metaDescription");
 
-  return {
-    title: t("title"),
+  const title = t("title");
+
+  return createPeelsMetadata({
+    canonicalPath: "/help",
+    title,
     description,
     openGraph: {
-      title: `${t("title")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
       description,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+      description,
+    },
+  });
 }
 
 export default function Help() {

--- a/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
+++ b/src/app/(core)/(static)/newsletter/(issues)/[slug]/page.tsx
@@ -14,6 +14,7 @@ import StaticPageSection from "@/components/StaticPageSection";
 import HeaderBlock from "@/components/HeaderBlock";
 import FooterBlock from "@/components/FooterBlock";
 import { getNewsletterIssueImageUrl } from "@/utils/storage";
+import { createPeelsMetadata } from "@/utils/seo";
 import TranslationNotice from "@/components/TranslationNotice";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getLocaleFromSearchParams } from "@/utils/authRedirects";
@@ -44,22 +45,28 @@ export async function generateMetadata({
   );
 
   if (metadata) {
-    return {
+    const image = {
+      url: getNewsletterIssueImageUrl(
+        customMetadata.issueNumber,
+        customMetadata.ogImage
+      ),
+    };
+
+    return createPeelsMetadata({
       ...metadata,
+      canonicalPath: `/newsletter/${slug}`,
       openGraph: {
         ...metadata.openGraph,
-        images: [
-          {
-            url: getNewsletterIssueImageUrl(
-              customMetadata.issueNumber,
-              customMetadata.ogImage
-            ),
-          },
-        ],
+        images: [image],
         type: "article",
         authors: metadata.authors,
       },
-    };
+      twitter: {
+        title: metadata.title,
+        description: metadata.description,
+        images: [image],
+      },
+    });
   } else {
     throw new Error(`No metadata found for newsletter issue: ${slug}`);
   }

--- a/src/app/(core)/(static)/newsletter/page.tsx
+++ b/src/app/(core)/(static)/newsletter/page.tsx
@@ -10,6 +10,7 @@ import StaticPageMain from "@/components/StaticPageMain";
 import { styled } from "next-yak";
 import { getLocale, getTranslations } from "next-intl/server";
 import { defaultLocale } from "@/i18n/config";
+import { createPeelsMetadata } from "@/utils/seo";
 import { theme } from "@/styles/theme.yak";
 
 export async function generateMetadata() {
@@ -17,14 +18,21 @@ export async function generateMetadata() {
   const t = await getTranslations({ locale, namespace: "Newsletter" });
   const description = t("description");
 
-  return {
-    title: t("title"),
+  const title = t("title");
+
+  return createPeelsMetadata({
+    canonicalPath: "/newsletter",
+    title,
     description,
     openGraph: {
-      title: `${t("title")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
       description,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+      description,
+    },
+  });
 }
 
 export default async function NewsletterPage() {

--- a/src/app/(core)/(static)/partners/page.tsx
+++ b/src/app/(core)/(static)/partners/page.tsx
@@ -16,19 +16,27 @@ import {
 } from "@/content/partnerMentions";
 import { sharedAnchorTagStyles } from "@/styles/commonStyles";
 import { theme } from "@/styles/theme.yak";
+import { createPeelsMetadata } from "@/utils/seo";
 
 export async function generateMetadata() {
   const t = await getTranslations("Partners");
   const description = t("metaDescription");
 
-  return {
-    title: t("title"),
+  const title = t("title");
+
+  return createPeelsMetadata({
+    canonicalPath: "/partners",
+    title,
     description,
     openGraph: {
-      title: `${t("title")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
       description,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+      description,
+    },
+  });
 }
 
 export default async function PartnersPage() {

--- a/src/app/(core)/(static)/share/page.tsx
+++ b/src/app/(core)/(static)/share/page.tsx
@@ -10,6 +10,7 @@ import StaticPageMain from "@/components/StaticPageMain";
 import StaticPageSection from "@/components/StaticPageSection";
 import { siteConfig } from "@/config/site";
 import { theme } from "@/styles/theme.yak";
+import { createPeelsMetadata } from "@/utils/seo";
 import { getShareResourcesUrl } from "@/utils/storage";
 
 const resourceKeys = ["digital", "print", "workshop"] as const;
@@ -19,14 +20,21 @@ export async function generateMetadata() {
   const t = await getTranslations("Share");
   const description = t("metaDescription");
 
-  return {
-    title: t("title"),
+  const title = t("title");
+
+  return createPeelsMetadata({
+    canonicalPath: "/share",
+    title,
     description,
     openGraph: {
-      title: `${t("title")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
       description,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+      description,
+    },
+  });
 }
 
 export default async function SharePage() {

--- a/src/app/(forms)/sign-in/page.tsx
+++ b/src/app/(forms)/sign-in/page.tsx
@@ -4,17 +4,25 @@ import StrongLink from "@/components/StrongLink";
 import SignInForm from "@/components/SignInForm";
 import FormFooter from "@/components/FormFooter";
 import { getTranslations } from "next-intl/server";
+import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
 import type { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Auth.signIn");
+  const t = await getTranslations();
 
-  return {
-    title: t("title"),
+  const title = t("Actions.signIn");
+
+  return createPeelsMetadata({
+    ...noindexFollowMetadata,
+    canonicalPath: "/sign-in",
+    title,
     openGraph: {
-      title: `${t("title")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+    },
+  });
 }
 
 export default async function SignIn(props: {

--- a/src/app/(forms)/sign-up/page.tsx
+++ b/src/app/(forms)/sign-up/page.tsx
@@ -6,17 +6,25 @@ import FormFooter from "@/components/FormFooter";
 import StrongLink from "@/components/StrongLink";
 import EncodedEmailLink from "@/components/EncodedEmailLink";
 import SignUpForm from "@/components/SignUpForm";
+import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
 import type { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations();
 
-  return {
-    title: t("Actions.signUp"),
+  const title = t("Actions.signUp");
+
+  return createPeelsMetadata({
+    ...noindexFollowMetadata,
+    canonicalPath: "/sign-up",
+    title,
     openGraph: {
-      title: `${t("Actions.signUp")} · ${siteConfig.name}`,
+      title: `${title} · ${siteConfig.name}`,
     },
-  };
+    twitter: {
+      title: `${title} · ${siteConfig.name}`,
+    },
+  });
 }
 
 export default async function SignUp(props: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale } from "next-intl/server";
-import { Metadata } from "next";
 import { siteConfig } from "@/config/site";
+import { createPeelsMetadata } from "@/utils/seo";
 import { getStaticFontUrl } from "@/utils/storage";
 
 import Link from "next/link";
@@ -45,31 +45,28 @@ const hostedFontFaces = `
   }
 `;
 
-const siteJsonLd = {
+const organizationJsonLd = {
   "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "Organization",
-      "@id": `${siteConfig.url}/#organization`,
-      name: siteConfig.name,
-      url: siteConfig.url,
-      logo: `${siteConfig.url}/icon.png`,
-    },
-    {
-      "@type": "WebSite",
-      "@id": `${siteConfig.url}/#website`,
-      name: siteConfig.name,
-      alternateName: "Peels.app",
-      url: siteConfig.url,
-      publisher: {
-        "@id": `${siteConfig.url}/#organization`,
-      },
-    },
-  ],
+  "@type": "Organization",
+  "@id": `${siteConfig.url}/#organization`,
+  name: siteConfig.name,
+  url: siteConfig.url,
+  logo: `${siteConfig.url}/icon.png`,
 };
 
-export const metadata: Metadata = {
-  metadataBase: new URL(siteConfig.url),
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": `${siteConfig.url}/#website`,
+  name: siteConfig.name,
+  alternateName: "Peels.app",
+  url: siteConfig.url,
+  publisher: {
+    "@id": `${siteConfig.url}/#organization`,
+  },
+};
+
+export const metadata = createPeelsMetadata({
   title: {
     default: siteConfig.name,
     template: `%s · ${siteConfig.name}`,
@@ -78,9 +75,6 @@ export const metadata: Metadata = {
   keywords: [...siteConfig.meta.keywords],
   openGraph: {
     title: siteConfig.name,
-    type: "website",
-    description: siteConfig.description,
-    siteName: siteConfig.name,
   },
   alternates: {
     types: {
@@ -92,7 +86,7 @@ export const metadata: Metadata = {
       ],
     },
   },
-};
+});
 
 export default async function RootLayout({
   children,
@@ -105,7 +99,8 @@ export default async function RootLayout({
   return (
     <html lang={locale} data-scroll-behavior="smooth">
       <body>
-        <JsonLd data={siteJsonLd} />
+        <JsonLd data={organizationJsonLd} />
+        <JsonLd data={websiteJsonLd} />
         {inlineFontFaces ? <style>{inlineFontFaces}</style> : null}
         <AuthHashCompletion />
         <AttributionCapture />

--- a/src/components/ChatHeader/ChatHeader.tsx
+++ b/src/components/ChatHeader/ChatHeader.tsx
@@ -39,7 +39,7 @@ const TitleBlock = styled.div`
   flex-direction: column;
   align-items: stretch;
 
-  & h1 {
+  & :is(h1, h3) {
     font-size: 1rem;
     line-height: 120%;
     color: ${theme.colors.text.ui.primary};
@@ -52,12 +52,12 @@ const TitleBlock = styled.div`
   }
 
   @media (min-width: 768px) {
-    & h1,
+    & :is(h1, h3),
     & h2 {
       text-align: left;
     }
 
-    & h1 {
+    & :is(h1, h3) {
       font-size: 1.25rem;
     }
 
@@ -182,6 +182,7 @@ function ChatHeader({
       ? listing.owner_first_name || ""
       : thread?.initiator_first_name || "";
   const listingSummary = getListingSummary(listing, role, t);
+  const HeadingTag = isDemo ? "h3" : "h1";
 
   return (
     <StyledChatHeader>
@@ -228,7 +229,7 @@ function ChatHeader({
         </AvatarContainer>
 
         <TitleBlock>
-          <h1>{otherPersonName}</h1>
+          <HeadingTag>{otherPersonName}</HeadingTag>
           {listingSummary && <p>{listingSummary}</p>}
         </TitleBlock>
       </MainContents>

--- a/src/components/ListingHeader/ListingHeader.tsx
+++ b/src/components/ListingHeader/ListingHeader.tsx
@@ -49,7 +49,7 @@ const titleBlockStyles = {
   flexDirection: "column",
   gap: "0.25rem",
   alignItems: "flex-start",
-  "& h1, & p": {
+  "& :is(h1, h2, h3), & p": {
     textAlign: "left",
   },
 };
@@ -59,12 +59,12 @@ const fullTitleBlockStyles = css`
   align-items: center;
   gap: 0.5rem;
 
-  & h1,
+  & :is(h1, h2, h3),
   & p {
     text-align: center;
   }
 
-  & h1 {
+  & :is(h1, h2, h3) {
     font-size: 2rem;
   }
 
@@ -74,12 +74,12 @@ const fullTitleBlockStyles = css`
     gap: ${titleBlockStyles.gap};
     align-items: ${titleBlockStyles.alignItems};
 
-    & h1,
+    & :is(h1, h2, h3),
     & p {
       text-align: left;
     }
 
-    & h1 {
+    & :is(h1, h2, h3) {
       font-size: 1.5rem;
     }
   }
@@ -91,12 +91,12 @@ const TitleBlock = styled.div<{ $presentation?: ListingHeaderPresentation }>`
   gap: ${titleBlockStyles.gap};
   align-items: ${titleBlockStyles.alignItems};
 
-  & h1,
+  & :is(h1, h2, h3),
   & p {
     text-align: left;
   }
 
-  & h1 {
+  & :is(h1, h2, h3) {
     font-size: 1.35rem;
     line-height: 120%;
     overflow-wrap: break-word;
@@ -131,6 +131,7 @@ function ListingHeader({
 }) {
   const t = useTranslations();
   const privateHostName = t("Listings.seo.privateHostName");
+  const HeadingTag = presentation === "demo" ? "h3" : "h1";
   const avatarProps = getListingAvatar(listing, user, {
     privateHostName,
     fallbackListingName: t("Listings.seo.fallbackListingName"),
@@ -152,7 +153,7 @@ function ListingHeader({
       />
 
       <TitleBlock $presentation={presentation}>
-        <h1>{listingName}</h1>
+        <HeadingTag>{listingName}</HeadingTag>
 
         {/* Use getListingDisplayType() here? Or is it too limiting? */}
         {listing?.type === "residential" && (

--- a/src/components/PeelsTab/PeelsTab.tsx
+++ b/src/components/PeelsTab/PeelsTab.tsx
@@ -2,11 +2,19 @@ import TabBarTab from "@/components/TabBarTab";
 import PeelsLogo from "@/components/PeelsLogo";
 
 type PeelsTabProps = {
+  ariaLabel: string;
   size?: number;
 };
 
-function PeelsTab({ size }: PeelsTabProps) {
-  return <TabBarTab icon={<PeelsLogo size={size} />} href="/" tone="brand" />;
+function PeelsTab({ ariaLabel, size }: PeelsTabProps) {
+  return (
+    <TabBarTab
+      icon={<PeelsLogo size={size} aria-hidden="true" />}
+      href="/"
+      tone="brand"
+      ariaLabel={ariaLabel}
+    />
+  );
 }
 
 export default PeelsTab;

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -125,6 +125,7 @@ function TabBar({
   position?: Exclude<TabBarPosition, "inherit">;
 } & HTMLAttributes<HTMLDivElement>) {
   const t = useTranslations("App");
+  const actionsT = useTranslations("Actions");
   const pathname = usePathname();
   const { tabBarProps } = useTabBar();
   const { shouldShowUnreadIndicator } = useUnreadMessages();
@@ -150,7 +151,9 @@ function TabBar({
     >
       <StyledTabBarNav>
         {/* Show 'home' AKA 'about' as the first tab item on larger breakpoints */}
-        {breakpoint === "md" && <PeelsTab size={32} />}
+        {breakpoint === "md" && (
+          <PeelsTab ariaLabel={actionsT("home")} size={32} />
+        )}
         {NAVIGATION_ITEMS.map(({ title, Icon, href }) => (
           <TabBarTab
             key={href}

--- a/src/components/TabBarTab/TabBarTab.tsx
+++ b/src/components/TabBarTab/TabBarTab.tsx
@@ -45,6 +45,7 @@ export default function TabBarTab({
   active = false,
   unreadDot = false,
   tone = "default",
+  ariaLabel,
 }: {
   title?: ReactNode;
   href?: string;
@@ -52,9 +53,15 @@ export default function TabBarTab({
   active?: boolean;
   unreadDot?: boolean;
   tone?: "default" | "brand";
+  ariaLabel?: string;
 }) {
   return (
-    <StyledTabBarTab href={href} $active={active} $tone={tone}>
+    <StyledTabBarTab
+      href={href}
+      aria-label={ariaLabel}
+      $active={active}
+      $tone={tone}
+    >
       <StyledTabBarTabIcon>
         {icon}
         {unreadDot && <UnreadDot />}

--- a/src/utils/listingUtils.test.ts
+++ b/src/utils/listingUtils.test.ts
@@ -8,6 +8,7 @@ import {
   getAnonymousSensitiveListingTeaser,
   getListingAvatar,
 } from "./listingUtils.ts";
+import { createPeelsMetadata } from "./seo.ts";
 import type { Listing } from "../types/listing.ts";
 import type { ListingSeoCopy } from "./listingUtils.ts";
 
@@ -129,15 +130,39 @@ const localisedSeoCopies = {
   },
 } satisfies Record<string, ListingSeoCopy>;
 
-test("listing metadata uses the listing name as the absolute title", () => {
+test("listing metadata uses the listing name with the site title template", () => {
   const metadata = generateListingMetadata(communityListing, null, {
     includeFullMetadata: true,
   });
 
-  assert.deepEqual(metadata.title, {
-    absolute: "Neighbourhood compost drop-off",
-  });
+  assert.equal(metadata.title, "Neighbourhood compost drop-off");
   assert.equal(metadata.openGraph?.title, "Neighbourhood compost drop-off");
+  assert.match(
+    JSON.stringify(metadata.openGraph?.images),
+    /opengraph-image\.jpg/
+  );
+  assert.match(
+    JSON.stringify(metadata.twitter?.images),
+    /opengraph-image\.jpg/
+  );
+});
+
+test("root metadata canonical matches the sitemap homepage URL", () => {
+  const metadata = createPeelsMetadata({ canonicalPath: "/" });
+
+  assert.equal(metadata.alternates?.canonical, "https://www.peels.app");
+  assert.equal(metadata.openGraph?.url, "https://www.peels.app");
+});
+
+test("shared metadata uses the page title for social previews", () => {
+  const metadata = createPeelsMetadata({
+    canonicalPath: "/chats",
+    title: "Chats",
+  });
+
+  assert.equal(metadata.title, "Chats");
+  assert.equal(metadata.openGraph?.title, "Chats");
+  assert.equal(metadata.twitter?.title, "Chats");
 });
 
 test("listing descriptions lead with compost and food-scrap intent", () => {
@@ -168,7 +193,11 @@ test("listing metadata includes the canonical listing path", () => {
 
   assert.equal(
     metadata.alternates?.canonical,
-    "/listings/test-community-compost"
+    "https://www.peels.app/listings/test-community-compost"
+  );
+  assert.equal(
+    metadata.openGraph?.url,
+    "https://www.peels.app/listings/test-community-compost"
   );
 });
 
@@ -240,9 +269,7 @@ test("anonymous residential metadata emits an indexable teaser without private d
   });
   const description = String(metadata.description);
 
-  assert.deepEqual(metadata.title, {
-    absolute: "Private Host",
-  });
+  assert.equal(metadata.title, "Private Host");
   assert.equal(metadata.robots, undefined);
   assert.match(
     description,
@@ -268,9 +295,7 @@ test("anonymous residential metadata avoids leaking profile names with localised
   });
   const description = String(metadata.description);
 
-  assert.deepEqual(metadata.title, {
-    absolute: "Anfitrión privado",
-  });
+  assert.equal(metadata.title, "Anfitrión privado");
   assert.match(
     description,
     /^Anfitrión privado acepta restos de comida para compostar/
@@ -299,9 +324,7 @@ test("anonymous unknown-type metadata emits a private teaser", () => {
   const description = String(metadata.description);
   const teaser = getAnonymousSensitiveListingTeaser(unknownTypeListing, null);
 
-  assert.deepEqual(metadata.title, {
-    absolute: "Private Host",
-  });
+  assert.equal(metadata.title, "Private Host");
   assert.match(
     description,
     /^Private Host accepts food scraps for composting in Marrickville, Australia\./
@@ -327,9 +350,7 @@ test("authenticated residential metadata can use private display names", () => {
     id: "user-1",
   });
 
-  assert.deepEqual(metadata.title, {
-    absolute: "Sam",
-  });
+  assert.equal(metadata.title, "Sam");
   assert.match(
     String(metadata.description),
     /^Sam accepts food scraps for composting in Marrickville, Australia\./

--- a/src/utils/listingUtils.ts
+++ b/src/utils/listingUtils.ts
@@ -1,6 +1,7 @@
 import { siteConfig } from "../config/site.ts";
 import { countries } from "../data/countries.ts";
 import { getStoragePublicUrl } from "./storage.ts";
+import { createPeelsMetadata } from "./seo.ts";
 import type { Metadata } from "next";
 import type { ListingCoordinates, ListingType } from "../types/listing.ts";
 
@@ -443,23 +444,20 @@ export function generateListingMetadata(
   const listingDescription = generateListingDescription(listing, user, options);
   const listingCanonicalPath = getListingCanonicalPath(listing);
 
-  const metadata: Metadata = {
-    title: {
-      absolute: listingDisplayName,
-    },
+  const metadata: Metadata = createPeelsMetadata({
+    title: listingDisplayName,
     description: listingDescription,
+    canonicalPath: listingCanonicalPath || undefined,
     openGraph: {
       title: listingDisplayName,
       description: listingDescription,
       siteName: siteConfig.name,
     },
-  };
-
-  if (listingCanonicalPath) {
-    metadata.alternates = {
-      canonical: listingCanonicalPath,
-    };
-  }
+    twitter: {
+      title: listingDisplayName,
+      description: listingDescription,
+    },
+  });
 
   if (options.includeFullMetadata) {
     const locationKeywords = listingFullLocation

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,4 +1,95 @@
 import type { Metadata } from "next";
+import { siteConfig } from "../config/site.ts";
+
+const openGraphImage = {
+  url: "/opengraph-image.jpg",
+  width: 1200,
+  height: 630,
+  alt: siteConfig.description,
+};
+
+type CreatePeelsMetadataOptions = Omit<
+  Metadata,
+  "alternates" | "metadataBase" | "openGraph" | "twitter"
+> & {
+  canonicalPath?: string;
+  alternates?: Metadata["alternates"];
+  openGraph?: Metadata["openGraph"];
+  twitter?: Metadata["twitter"];
+};
+
+export function getCanonicalUrl(path: string) {
+  if (path === "/") {
+    return siteConfig.url;
+  }
+
+  return new URL(path, siteConfig.url).toString();
+}
+
+function getMetadataTitle(title: Metadata["title"]) {
+  if (typeof title === "string") {
+    return title;
+  }
+
+  if (!title || typeof title !== "object") {
+    return null;
+  }
+
+  if ("absolute" in title && typeof title.absolute === "string") {
+    return title.absolute;
+  }
+
+  if ("default" in title && typeof title.default === "string") {
+    return title.default;
+  }
+
+  return null;
+}
+
+export function createPeelsMetadata({
+  canonicalPath,
+  alternates,
+  openGraph,
+  twitter,
+  title,
+  description = siteConfig.description,
+  ...metadata
+}: CreatePeelsMetadataOptions = {}): Metadata {
+  const canonicalUrl = canonicalPath
+    ? getCanonicalUrl(canonicalPath)
+    : undefined;
+  const metadataDescription = description ?? siteConfig.description;
+  const socialTitle = getMetadataTitle(title) ?? siteConfig.name;
+  const openGraphMetadata = openGraph ?? {};
+  const twitterMetadata = twitter ?? {};
+
+  return {
+    metadataBase: new URL(siteConfig.url),
+    description: metadataDescription,
+    title,
+    ...metadata,
+    alternates: {
+      ...(canonicalUrl ? { canonical: canonicalUrl } : {}),
+      ...alternates,
+    },
+    openGraph: {
+      title: socialTitle,
+      type: "website",
+      description: metadataDescription,
+      siteName: siteConfig.name,
+      ...(canonicalUrl ? { url: canonicalUrl } : {}),
+      ...openGraphMetadata,
+      images: openGraphMetadata.images ?? [openGraphImage],
+    } as Metadata["openGraph"],
+    twitter: {
+      card: "summary_large_image",
+      title: socialTitle,
+      description: metadataDescription,
+      ...twitterMetadata,
+      images: twitterMetadata.images ?? [openGraphImage],
+    },
+  };
+}
 
 export const noindexFollowMetadata = {
   robots: {


### PR DESCRIPTION
## Summary

- add shared metadata defaults for canonical URLs, Open Graph URLs/images, and Twitter image cards
- restore listing, profile, and selected-chat titles
- make homepage structured data and demo headings clearer for crawlers
- expand SEO/chat regression coverage for social metadata and noindex routes

## Validation

- npm run i18n:check
- npm run typecheck
- npm run check
- npm run test:e2e:prod -- e2e/seo.spec.ts e2e/chat.spec.ts
