### PR TITLE
improve first paint performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,17 @@ These instructions apply to the whole repository.
 - For React form submit handlers, use the shared `FormSubmitEvent` / `FormSubmitHandler` types from `src/types/events.ts`, which wrap React 19's `SubmitEvent`. Avoid deprecated `FormEvent`, `FormEventHandler`, and `React.FormEvent`; keep `ChangeEvent` for input/select/textarea change handlers.
 - In MDX prose, if an inline component inside a Markdown list item is formatted onto multiple lines and changes rendered spacing, use a targeted `{/* prettier-ignore */}` before that list rather than disabling formatting for the whole file.
 
+## Auth, Sessions, and Public-Page Performance
+
+- `src/proxy.ts` intentionally does not refresh Supabase auth on every request. Public pages should use `createSignedOutResponse()` so their initial response does not wait on `supabase.auth.getUser()`.
+- Only add paths to `authRequiredPathPrefixes` when the first server response must know auth state, such as protected routes, auth callbacks, and guest-only auth pages. Adding public routes there can regress TTFB, FCP, and LCP.
+- Server components that branch on auth should treat `authStateHeaderName` as a forwarded proxy hint, not proof that public routes have performed a fresh auth lookup. Public pages are deliberately signed-out on the initial server render until client auth resolves.
+- Keep auth-aware public UI in small client slots or enhancements, such as `AccountButton`, `FooterLocaleSlot`, and unread chat dots. It is acceptable for these to appear or update after first paint.
+- Keep `UnreadMessagesProvider` scoped to tab-bar and chat layouts rather than the root layout. It should not make public HTML wait on Supabase, and its initial auth/unread check should remain idle or otherwise deferred.
+- For signed-in preferred locale, public pages should use the locale cookie for the initial render. Profile-backed locale lookup belongs on authenticated/private flows.
+- Chat route data shared by layout, metadata, and page should go through cached helpers in `src/features/chat/chatPageData.ts` to avoid duplicate Supabase work.
+- For more detail, see `docs/auth-session-architecture.md`.
+
 ## Testing
 
 - Add or update Playwright e2e coverage when changing important user flows such as auth, listings, locale switching, chat, or other multi-step interactions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ These instructions apply to the whole repository.
 ## Auth, Sessions, and Public-Page Performance
 
 - `src/proxy.ts` intentionally does not refresh Supabase auth on every request. Public pages should use `createSignedOutResponse()` so their initial response does not wait on `supabase.auth.getUser()`.
-- Only add paths to `authRequiredPathPrefixes` when the first server response must know auth state, such as protected routes, auth callbacks, and guest-only auth pages. Adding public routes there can regress TTFB, FCP, and LCP.
+- Only add paths to `authRequiredPathPrefixes` when the first server response must know auth state, such as protected routes, auth callbacks, guest-only auth pages, or routes that server-render private/public data differently. `/map` and `/listings` belong there because they call server `auth.getUser()` before choosing listing data sources.
 - Server components that branch on auth should treat `authStateHeaderName` as a forwarded proxy hint, not proof that public routes have performed a fresh auth lookup. Public pages are deliberately signed-out on the initial server render until client auth resolves.
 - Keep auth-aware public UI in small client slots or enhancements, such as `AccountButton`, `FooterLocaleSlot`, and unread chat dots. It is acceptable for these to appear or update after first paint.
 - Keep `UnreadMessagesProvider` scoped to tab-bar and chat layouts rather than the root layout. It should not make public HTML wait on Supabase, and its initial auth/unread check should remain idle or otherwise deferred.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ peels/
 │   ├── app/               # Next.js app router pages
 │   ├── components/        # React components
 │   ├── lib/               # Utility functions and shared logic
-│   └── middleware.ts      # Next.js middleware for auth
+│   └── proxy.ts           # Next.js proxy for auth-aware routing
 ├── public/                # Static assets
 ├── supabase/              # Supabase configurations and migrations
 └── package.json           # Project dependencies and scripts
@@ -89,6 +89,8 @@ Peels intentionally uses the `54331`-`54334` local port range so it can run alon
 If you need to serve [Supabase edge functions](https://github.com/dnywh/peels/blob/main/supabase/functions) locally, copy `supabase/.env.example` to `supabase/.env` and add only the secrets you actually need. Production secrets should remain dashboard-managed for now.
 
 For the fuller operational walkthrough, including GitHub/Vercel dashboard setup and fresh-computer bootstrap, see [docs/supabase-local-first.md](./docs/supabase-local-first.md).
+
+For how auth/session forwarding, public-page performance, footer locale state, unread chat dots, and deferred homepage demos fit together, see [docs/auth-session-architecture.md](./docs/auth-session-architecture.md).
 
 ### Usage
 

--- a/docs/auth-session-architecture.md
+++ b/docs/auth-session-architecture.md
@@ -8,9 +8,9 @@ Peels keeps public pages fast by avoiding a server-side Supabase auth refresh un
 
 - Auth-required paths use `updateSession()`. This creates a Supabase server client, calls `supabase.auth.getUser()`, refreshes cookies when needed, forwards `x-peels-auth-state`, and applies auth redirects for protected or guest-only pages.
 - Public paths use `createSignedOutResponse()`. This forwards the current path and a signed-out auth hint without calling Supabase, so pages such as `/`, `/share`, and static content do not block first paint on auth.
-- `authRequiredPathPrefixes` should stay small. Add to it only when the first server response truly needs auth state.
+- `authRequiredPathPrefixes` should stay small. Add to it only when the first server response truly needs auth state. `/map` and `/listings` belong there because they server-render auth-aware listing data before client hydration.
 
-The forwarded auth state is a rendering hint. On public routes, it intentionally says signed-out on the initial server render even if the browser has a valid session cookie. Client-side auth slots can then resolve the real state after hydration.
+The forwarded auth state is a rendering hint. On public routes that do not need server auth, it intentionally says signed-out on the initial server render even if the browser has a valid session cookie. Client-side auth slots can then resolve the real state after hydration.
 
 ## Locale Behaviour
 
@@ -38,7 +38,7 @@ The unread check should stay deferred so it does not delay public HTML. If the u
 
 The homepage should server-render useful static content first, then hydrate dynamism later.
 
-- `IntroHeader` owns the static hero frame and primary calls to action.
+- `IntroHeader` reserves the hero visual space without server-rendering the decorative map/avatar/pin frame.
 - `DeferredIntroHeaderRotator` loads the animated hero rotator after the first paint/idle window.
 - `PeelsHowItWorks` keeps crawlable explanatory content in the initial HTML.
 - Deferred demo components load map, listing, chat, and photo demos after intersection or idle.

--- a/docs/auth-session-architecture.md
+++ b/docs/auth-session-architecture.md
@@ -1,0 +1,69 @@
+# Auth and Session Architecture
+
+Peels keeps public pages fast by avoiding a server-side Supabase auth refresh unless a route actually needs auth before it can render. Public pages can still become auth-aware after hydration, but their first HTML response should be cheap, useful, and crawlable.
+
+## Request Flow
+
+`src/proxy.ts` decides whether a request needs a fresh server auth check.
+
+- Auth-required paths use `updateSession()`. This creates a Supabase server client, calls `supabase.auth.getUser()`, refreshes cookies when needed, forwards `x-peels-auth-state`, and applies auth redirects for protected or guest-only pages.
+- Public paths use `createSignedOutResponse()`. This forwards the current path and a signed-out auth hint without calling Supabase, so pages such as `/`, `/share`, and static content do not block first paint on auth.
+- `authRequiredPathPrefixes` should stay small. Add to it only when the first server response truly needs auth state.
+
+The forwarded auth state is a rendering hint. On public routes, it intentionally says signed-out on the initial server render even if the browser has a valid session cookie. Client-side auth slots can then resolve the real state after hydration.
+
+## Locale Behaviour
+
+Public pages should use the locale cookie as the fast path. Signed-in profile-backed locale lookup belongs on authenticated/private flows where the server has already paid the auth cost.
+
+If a signed-in user sees the wrong language on a public page, first check whether their locale cookie is stale or missing. Do not fix that by making every public request call `supabase.auth.getUser()`.
+
+## Public Auth UI
+
+Auth-aware UI on public pages should be isolated to small client components:
+
+- `AccountButton` can resolve the current user after hydration.
+- `FooterLocaleSlot` decides whether to show the guest language picker after client auth resolves.
+- Unread chat dots can appear after the scoped unread check completes.
+
+This means the first paint can briefly look signed-out on public pages. That is expected. The page should converge to the right signed-in or signed-out UI after hydration.
+
+## Unread Chat State
+
+`UnreadMessagesProvider` belongs near the UI that displays or consumes unread state, such as tab-bar and chat layouts. It should not wrap the root layout.
+
+The unread check should stay deferred so it does not delay public HTML. If the unread dot disappears entirely, check the provider scope, the idle auth check, the `chat_threads` query, and the `unread_chat_thread_ids` RPC before moving the provider back to the root.
+
+## Homepage First Paint
+
+The homepage should server-render useful static content first, then hydrate dynamism later.
+
+- `IntroHeader` owns the static hero frame and primary calls to action.
+- `DeferredIntroHeaderRotator` loads the animated hero rotator after the first paint/idle window.
+- `PeelsHowItWorks` keeps crawlable explanatory content in the initial HTML.
+- Deferred demo components load map, listing, chat, and photo demos after intersection or idle.
+
+Avoid importing production-heavy interactive components such as listing reads, map demos, or chat windows directly into the initial homepage path unless the performance tradeoff is intentional.
+
+## Chat Route Data
+
+Selected chat routes need auth, thread lists, selected-thread data, and metadata. Shared server lookups should go through the cached helpers in `src/features/chat/chatPageData.ts` so the layout, page, and `generateMetadata()` do not repeat the same Supabase work in one request.
+
+## Debugging Checklist
+
+- If guests can reach a protected page, check `authRequiredPathPrefixes`, `updateSession()`, and the route-level redirect assumptions.
+- If a public page becomes slow, check that it was not added to `authRequiredPathPrefixes` and that no server component on that path now calls auth, `headers()`, or profile lookup unnecessarily.
+- If footer locale behaviour looks wrong, inspect `FooterLocaleSlot` and `useAuthUser()`. Remember that the guest picker appears only after client auth resolves.
+- If signed-in preferred locale is missing on a public first render, treat that as expected unless the locale cookie should have been updated.
+- If unread dots are missing, check provider scope and the deferred unread lookup before broadening the provider.
+- If selected chat pages duplicate Supabase calls, route shared work through `src/features/chat/chatPageData.ts`.
+
+## Useful Checks
+
+For auth/session, homepage, and chat changes, prefer production-style e2e checks:
+
+```bash
+npm run test:e2e:prod -- e2e/home.spec.ts e2e/chat.spec.ts e2e/i18n.spec.ts
+```
+
+Add `e2e/seo.spec.ts` when metadata, public routes, or crawlable content are affected.

--- a/docs/auth-session-architecture.md
+++ b/docs/auth-session-architecture.md
@@ -32,7 +32,7 @@ This means the first paint can briefly look signed-out on public pages. That is 
 
 `UnreadMessagesProvider` belongs near the UI that displays or consumes unread state, such as tab-bar and chat layouts. It should not wrap the root layout.
 
-The unread check should stay deferred so it does not delay public HTML. If the unread dot disappears entirely, check the provider scope, the idle auth check, the `chat_threads` query, and the `unread_chat_thread_ids` RPC before moving the provider back to the root.
+The unread check should stay deferred so it does not delay public HTML. If the unread dot disappears entirely, check the provider scope, the idle auth check, and the unread `chat_messages` count before moving the provider back to the root.
 
 ## Homepage First Paint
 

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
-import { HOST_EMAIL, signIn } from "./helpers";
+import { DONOR_EMAIL, HOST_EMAIL, signIn } from "./helpers";
 
-test("homepage hydrates without chat date mismatches", async ({
+test("homepage renders static content before deferred chat demo hydrates", async ({
   browser,
   page,
 }) => {
@@ -42,9 +42,6 @@ test("homepage hydrates without chat date mismatches", async ({
   const serverDayLabels = await serverPage
     .getByTestId("chat-day-label")
     .allTextContents();
-  const serverTimestamps = await serverPage
-    .getByTestId("chat-message-timestamp")
-    .allTextContents();
   await serverContext.close();
 
   await page.waitForLoadState("networkidle");
@@ -59,9 +56,9 @@ test("homepage hydrates without chat date mismatches", async ({
     .getByTestId("chat-message-timestamp")
     .allTextContents();
 
-  expect(serverDayLabels).toEqual(["Thu, May 1", "Fri, May 2"]);
+  expect(serverDayLabels).toEqual([]);
   expect(hydratedDayLabels).toEqual(["Yesterday", "Today"]);
-  expect(hydratedTimestamps).toEqual(serverTimestamps);
+  expect(hydratedTimestamps).toHaveLength(2);
   expect(
     pageErrors.some((message) => message.includes("Minified React error #418"))
   ).toBeFalsy();
@@ -152,6 +149,7 @@ test("homepage account button stays hidden while signed-in profile state loads",
 
   await expect(profileAccountButton).toHaveAttribute("href", "/profile");
   await expect(profileAccountButton).toHaveCSS("opacity", "1");
+  await expect(page.getByTestId("locale-picker-select")).toHaveCount(0);
 });
 
 test("homepage account button links guests to sign in", async ({ page }) => {
@@ -162,4 +160,40 @@ test("homepage account button links guests to sign in", async ({ page }) => {
     "/sign-in"
   );
   await expect(page.getByTestId("account-button-profile")).toHaveCount(0);
+  await expect(page.getByTestId("locale-picker-select")).toBeVisible();
+});
+
+test("homepage unread chat dot appears after scoped unread check", async ({
+  page,
+}) => {
+  await page.route(/\/rest\/v1\/chat_threads(?:\?|$)/, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ id: "33333333-3333-4333-8333-333333333333" }]),
+    });
+  });
+  await page.route(
+    /\/rest\/v1\/rpc\/unread_chat_thread_ids(?:\?|$)/,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { thread_id: "33333333-3333-4333-8333-333333333333" },
+        ]),
+      });
+    }
+  );
+
+  await signIn(page, { email: DONOR_EMAIL, redirectTo: "/" });
+
+  await expect(page.getByTestId("tab-unread-dot").first()).toBeVisible({
+    timeout: 15_000,
+  });
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -146,9 +146,14 @@ test("homepage account button stays hidden while signed-in profile state loads",
   }
 
   const profileAccountButton = page.getByTestId("account-button-profile");
+  const heroSecondaryAction = page.getByTestId("hero-secondary-action");
 
   await expect(profileAccountButton).toHaveAttribute("href", "/profile");
   await expect(profileAccountButton).toHaveCSS("opacity", "1");
+  await expect(heroSecondaryAction).toHaveAttribute(
+    "href",
+    "/profile/listings/new"
+  );
   await expect(page.getByTestId("locale-picker-select")).toHaveCount(0);
 });
 
@@ -160,14 +165,20 @@ test("homepage account button links guests to sign in", async ({ page }) => {
     "/sign-in"
   );
   await expect(page.getByTestId("account-button-profile")).toHaveCount(0);
+  await expect(page.getByTestId("hero-secondary-action")).toHaveAttribute(
+    "href",
+    "/sign-up"
+  );
   await expect(page.getByTestId("locale-picker-select")).toBeVisible();
 });
 
 test("homepage unread chat dot appears after scoped unread check", async ({
   page,
 }) => {
-  await page.route(/\/rest\/v1\/chat_threads(?:\?|$)/, async (route) => {
-    if (route.request().method() !== "GET") {
+  await page.route(/\/rest\/v1\/chat_messages(?:\?|$)/, async (route) => {
+    const method = route.request().method();
+
+    if (method !== "GET" && method !== "HEAD") {
       await route.continue();
       return;
     }
@@ -175,21 +186,13 @@ test("homepage unread chat dot appears after scoped unread check", async ({
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify([{ id: "33333333-3333-4333-8333-333333333333" }]),
+      headers: {
+        "content-range": "0-0/1",
+        "access-control-expose-headers": "content-range",
+      },
+      body: method === "HEAD" ? "" : JSON.stringify([]),
     });
   });
-  await page.route(
-    /\/rest\/v1\/rpc\/unread_chat_thread_ids(?:\?|$)/,
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([
-          { thread_id: "33333333-3333-4333-8333-333333333333" },
-        ]),
-      });
-    }
-  );
 
   await signIn(page, { email: DONOR_EMAIL, redirectTo: "/" });
 

--- a/src/app/(core)/(interact)/(centered)/layout.tsx
+++ b/src/app/(core)/(interact)/(centered)/layout.tsx
@@ -1,5 +1,6 @@
 import TabBar from "@/components/TabBar";
 import { TabBarProvider } from "@/contexts/TabBarContext";
+import { UnreadMessagesProvider } from "@/contexts/UnreadMessagesContext";
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 import type { ReactNode } from "react";
@@ -22,11 +23,13 @@ const CenteredPage = styled.div`
 export default async function Layout({ children }: { children: ReactNode }) {
   return (
     <TabBarProvider>
-      <CenteredPage>
-        <TabBar breakpoint="md" position="dynamic" />
-        {children}
-        <TabBar breakpoint="sm" />
-      </CenteredPage>
+      <UnreadMessagesProvider>
+        <CenteredPage>
+          <TabBar breakpoint="md" position="dynamic" />
+          {children}
+          <TabBar breakpoint="sm" />
+        </CenteredPage>
+      </UnreadMessagesProvider>
     </TabBarProvider>
   );
 }

--- a/src/app/(core)/(interact)/(stretched)/chats/[threadId]/page.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[threadId]/page.tsx
@@ -1,8 +1,7 @@
-import { createClient } from "@/utils/supabase/server";
 import { ChatConversationClient } from "@/components/ChatPageClient";
-import { getSelectedChatThread, isUuid } from "@/features/chat/chatData";
+import { isUuid } from "@/features/chat/chatData";
+import { getCurrentSelectedChatThread } from "@/features/chat/chatPageData";
 import { redirect } from "next/navigation";
-import { cache } from "react";
 import type { Metadata } from "next";
 import { siteConfig } from "@/config/site";
 import { createPeelsMetadata, noindexFollowMetadata } from "@/utils/seo";
@@ -13,33 +12,10 @@ type ChatThreadPageProps = {
   }>;
 };
 
-const getChatThreadPageData = cache(async (threadId: string) => {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return {
-      user: null,
-      selectedThread: null,
-    };
-  }
-
-  const selectedThread = await getSelectedChatThread(
-    supabase,
-    user.id,
-    threadId
-  );
-
-  return {
-    user,
-    selectedThread,
-  };
-});
-
 function getChatThreadTitle(
-  selectedThread: Awaited<ReturnType<typeof getSelectedChatThread>>,
+  selectedThread: Awaited<
+    ReturnType<typeof getCurrentSelectedChatThread>
+  >["selectedThread"],
   userId: string
 ) {
   if (!selectedThread) return "Chats";
@@ -65,7 +41,7 @@ export async function generateMetadata({
     });
   }
 
-  const { user, selectedThread } = await getChatThreadPageData(threadId);
+  const { user, selectedThread } = await getCurrentSelectedChatThread(threadId);
 
   if (!user) {
     return createPeelsMetadata({
@@ -98,7 +74,7 @@ export default async function ChatThreadPage({ params }: ChatThreadPageProps) {
     redirect("/chats");
   }
 
-  const { user, selectedThread } = await getChatThreadPageData(threadId);
+  const { user, selectedThread } = await getCurrentSelectedChatThread(threadId);
 
   if (!user) {
     redirect(`/sign-in?redirect_to=/chats/${threadId}`);

--- a/src/app/(core)/(interact)/(stretched)/chats/layout.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/layout.tsx
@@ -1,6 +1,5 @@
-import { createClient } from "@/utils/supabase/server";
 import ChatPageClient from "@/components/ChatPageClient";
-import { getChatThreads } from "@/features/chat/chatData";
+import { getCurrentChatThreads } from "@/features/chat/chatPageData";
 import { currentPathHeaderName } from "@/utils/supabase/authState";
 import { normaliseNextPath } from "@/utils/authRedirects";
 import { headers } from "next/headers";
@@ -16,18 +15,13 @@ export default async function ChatsLayout({
 }: {
   children: ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { user, threads } = await getCurrentChatThreads();
 
   if (!user) {
     const currentPath = (await headers()).get(currentPathHeaderName);
     const redirectTo = normaliseNextPath(currentPath, "/chats");
     redirect(`/sign-in?redirect_to=${encodeURIComponent(redirectTo)}`);
   }
-
-  const threads = await getChatThreads(supabase, user.id);
 
   return (
     <ChatPageClient user={user} initialThreads={threads}>

--- a/src/app/(core)/(interact)/(stretched)/layout.tsx
+++ b/src/app/(core)/(interact)/(stretched)/layout.tsx
@@ -1,5 +1,6 @@
 import TabBar from "@/components/TabBar";
 import { TabBarProvider } from "@/contexts/TabBarContext";
+import { UnreadMessagesProvider } from "@/contexts/UnreadMessagesContext";
 import { styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 import type { ReactNode } from "react";
@@ -20,11 +21,13 @@ const StretchedPage = styled.div`
 export default async function Layout({ children }: { children: ReactNode }) {
   return (
     <TabBarProvider>
-      <StretchedPage>
-        <TabBar breakpoint="md" />
-        {children}
-        <TabBar breakpoint="sm" />
-      </StretchedPage>
+      <UnreadMessagesProvider>
+        <StretchedPage>
+          <TabBar breakpoint="md" />
+          {children}
+          <TabBar breakpoint="sm" />
+        </StretchedPage>
+      </UnreadMessagesProvider>
     </TabBarProvider>
   );
 }

--- a/src/app/(core)/(static)/layout.tsx
+++ b/src/app/(core)/(static)/layout.tsx
@@ -1,5 +1,6 @@
 import TabBar from "@/components/TabBar";
 import { TabBarProvider } from "@/contexts/TabBarContext";
+import { UnreadMessagesProvider } from "@/contexts/UnreadMessagesContext";
 import SiteFooter from "@/components/SiteFooter";
 import { styled } from "next-yak";
 import AccountButton from "@/components/AccountButton";
@@ -25,13 +26,15 @@ const StaticPage = styled.div`
 export default async function Layout({ children }: { children: ReactNode }) {
   return (
     <TabBarProvider>
-      <StaticPage>
-        <StyledAccountButton />
-        <TabBar breakpoint="md" position="fixed" />
-        {children}
-        <SiteFooter />
-        <TabBar breakpoint="sm" />
-      </StaticPage>
+      <UnreadMessagesProvider>
+        <StaticPage>
+          <StyledAccountButton />
+          <TabBar breakpoint="md" position="fixed" />
+          {children}
+          <SiteFooter />
+          <TabBar breakpoint="sm" />
+        </StaticPage>
+      </UnreadMessagesProvider>
     </TabBarProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import "./theme.css";
 
-import { UnreadMessagesProvider } from "@/contexts/UnreadMessagesContext";
 import AttributionCapture from "@/components/AttributionCapture";
 import AuthHashCompletion from "@/components/AuthHashCompletion";
 import JsonLd from "@/components/JsonLd";
@@ -104,9 +103,7 @@ export default async function RootLayout({
         {inlineFontFaces ? <style>{inlineFontFaces}</style> : null}
         <AuthHashCompletion />
         <AttributionCapture />
-        <NextIntlClientProvider>
-          <UnreadMessagesProvider>{children}</UnreadMessagesProvider>
-        </NextIntlClientProvider>
+        <NextIntlClientProvider>{children}</NextIntlClientProvider>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/DeferredIntroHeaderRotator/DeferredIntroHeaderRotator.tsx
+++ b/src/components/DeferredIntroHeaderRotator/DeferredIntroHeaderRotator.tsx
@@ -2,39 +2,24 @@
 
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-
-type IdleWindow = Window & {
-  requestIdleCallback?: (
-    callback: () => void,
-    options?: { timeout?: number }
-  ) => number;
-  cancelIdleCallback?: (handle: number) => void;
-};
+import { scheduleIdleTask } from "@/utils/scheduleIdleTask";
 
 const IntroHeaderRotator = dynamic(
   () => import("@/components/IntroHeader/IntroHeaderRotator"),
   { ssr: false }
 );
 
-function scheduleIdleTask(callback: () => void) {
-  const idleWindow = window as IdleWindow;
-
-  if (typeof idleWindow.requestIdleCallback === "function") {
-    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
-      timeout: 1_500,
-    });
-
-    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
-  }
-
-  const timeoutId = globalThis.setTimeout(callback, 250);
-  return () => globalThis.clearTimeout(timeoutId);
-}
-
 export default function DeferredIntroHeaderRotator() {
   const [isReady, setIsReady] = useState(false);
 
-  useEffect(() => scheduleIdleTask(() => setIsReady(true)), []);
+  useEffect(
+    () =>
+      scheduleIdleTask(() => setIsReady(true), {
+        timeout: 1_500,
+        fallbackDelay: 250,
+      }),
+    []
+  );
 
   return isReady ? <IntroHeaderRotator /> : null;
 }

--- a/src/components/DeferredIntroHeaderRotator/DeferredIntroHeaderRotator.tsx
+++ b/src/components/DeferredIntroHeaderRotator/DeferredIntroHeaderRotator.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number }
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+const IntroHeaderRotator = dynamic(
+  () => import("@/components/IntroHeader/IntroHeaderRotator"),
+  { ssr: false }
+);
+
+function scheduleIdleTask(callback: () => void) {
+  const idleWindow = window as IdleWindow;
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
+      timeout: 1_500,
+    });
+
+    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = globalThis.setTimeout(callback, 250);
+  return () => globalThis.clearTimeout(timeoutId);
+}
+
+export default function DeferredIntroHeaderRotator() {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => scheduleIdleTask(() => setIsReady(true)), []);
+
+  return isReady ? <IntroHeaderRotator /> : null;
+}

--- a/src/components/DeferredIntroHeaderRotator/index.ts
+++ b/src/components/DeferredIntroHeaderRotator/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeferredIntroHeaderRotator";

--- a/src/components/DeferredPeelsChatDemo/DeferredPeelsChatDemo.tsx
+++ b/src/components/DeferredPeelsChatDemo/DeferredPeelsChatDemo.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import HomepageDemoPlaceholder from "@/components/HomepageDemoPlaceholder";
+import { useDeferredHomepageDemo } from "@/hooks/useDeferredHomepageDemo";
+
+const PeelsChatDemo = dynamic(() => import("@/components/PeelsChatDemo"), {
+  ssr: false,
+  loading: () => <HomepageDemoPlaceholder variant="chat" />,
+});
+
+export default function DeferredPeelsChatDemo() {
+  const { isReady, rootRef } = useDeferredHomepageDemo();
+
+  return (
+    <div ref={rootRef} data-testid="homepage-chat-demo-shell">
+      {isReady ? <PeelsChatDemo /> : <HomepageDemoPlaceholder variant="chat" />}
+    </div>
+  );
+}

--- a/src/components/DeferredPeelsChatDemo/index.ts
+++ b/src/components/DeferredPeelsChatDemo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeferredPeelsChatDemo";

--- a/src/components/DeferredPeelsFeaturedHostsPhotos/DeferredPeelsFeaturedHostsPhotos.tsx
+++ b/src/components/DeferredPeelsFeaturedHostsPhotos/DeferredPeelsFeaturedHostsPhotos.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import HomepageDemoPlaceholder from "@/components/HomepageDemoPlaceholder";
+import { useDeferredHomepageDemo } from "@/hooks/useDeferredHomepageDemo";
+
+const PeelsFeaturedHostsPhotos = dynamic(
+  () => import("@/components/PeelsFeaturedHostsPhotos"),
+  {
+    ssr: false,
+    loading: () => <HomepageDemoPlaceholder variant="photos" />,
+  }
+);
+
+export default function DeferredPeelsFeaturedHostsPhotos() {
+  const { isReady, rootRef } = useDeferredHomepageDemo();
+
+  return (
+    <div ref={rootRef} data-testid="homepage-featured-hosts-shell">
+      {isReady ? (
+        <PeelsFeaturedHostsPhotos />
+      ) : (
+        <HomepageDemoPlaceholder variant="photos" />
+      )}
+    </div>
+  );
+}

--- a/src/components/DeferredPeelsFeaturedHostsPhotos/index.ts
+++ b/src/components/DeferredPeelsFeaturedHostsPhotos/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeferredPeelsFeaturedHostsPhotos";

--- a/src/components/DeferredPeelsMapDemo/DeferredPeelsMapDemo.tsx
+++ b/src/components/DeferredPeelsMapDemo/DeferredPeelsMapDemo.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import HomepageDemoPlaceholder from "@/components/HomepageDemoPlaceholder";
+import { useDeferredHomepageDemo } from "@/hooks/useDeferredHomepageDemo";
+
+const PeelsMapDemo = dynamic(() => import("@/components/PeelsMapDemo"), {
+  ssr: false,
+  loading: () => <HomepageDemoPlaceholder variant="map" />,
+});
+
+export default function DeferredPeelsMapDemo() {
+  const { isReady, rootRef } = useDeferredHomepageDemo();
+
+  return (
+    <div ref={rootRef} data-testid="homepage-map-demo-shell">
+      {isReady ? <PeelsMapDemo /> : <HomepageDemoPlaceholder variant="map" />}
+    </div>
+  );
+}

--- a/src/components/DeferredPeelsMapDemo/index.ts
+++ b/src/components/DeferredPeelsMapDemo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeferredPeelsMapDemo";

--- a/src/components/FooterLocaleSlot/FooterLocaleSlot.tsx
+++ b/src/components/FooterLocaleSlot/FooterLocaleSlot.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import LocalePicker from "@/components/LocalePicker";
+import { useAuthUser } from "@/hooks/useAuthUser";
+
+export default function FooterLocaleSlot() {
+  const { user, isLoading } = useAuthUser();
+
+  if (isLoading || user) {
+    return null;
+  }
+
+  return <LocalePicker compact={true} />;
+}

--- a/src/components/FooterLocaleSlot/index.ts
+++ b/src/components/FooterLocaleSlot/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FooterLocaleSlot";

--- a/src/components/HeroButtons/HeroButtons.tsx
+++ b/src/components/HeroButtons/HeroButtons.tsx
@@ -15,17 +15,23 @@ export default function HeroButtons() {
         {t("browseMap")}
       </HeroActionButton>
       {user ? (
-        <HeroActionButton
+        <SecondaryHeroActionButton
           href="/profile/listings/new"
           variant="secondary"
           size="massive"
+          data-testid="hero-secondary-action"
         >
           {t("addListing")}
-        </HeroActionButton>
+        </SecondaryHeroActionButton>
       ) : (
-        <HeroActionButton href="/sign-up" variant="secondary" size="massive">
+        <SecondaryHeroActionButton
+          href="/sign-up"
+          variant="secondary"
+          size="massive"
+          data-testid="hero-secondary-action"
+        >
           {t("signUp")}
-        </HeroActionButton>
+        </SecondaryHeroActionButton>
       )}
     </ButtonContainer>
   );
@@ -38,6 +44,12 @@ const HeroActionButton = styled(Button)`
   @media (min-width: 768px) {
     width: auto;
     align-self: center;
+  }
+`;
+
+const SecondaryHeroActionButton = styled(HeroActionButton)`
+  @media (min-width: 768px) {
+    min-width: 13.5rem;
   }
 `;
 

--- a/src/components/HomepageDemoPlaceholder/HomepageDemoPlaceholder.tsx
+++ b/src/components/HomepageDemoPlaceholder/HomepageDemoPlaceholder.tsx
@@ -1,0 +1,53 @@
+import { styled } from "next-yak";
+import { theme } from "@/styles/theme.yak";
+import type { HTMLAttributes } from "react";
+
+export default function HomepageDemoPlaceholder({
+  variant = "panel",
+  ...props
+}: {
+  variant?: "map" | "chat" | "photos" | "panel";
+} & HTMLAttributes<HTMLDivElement>) {
+  return <Placeholder $variant={variant} aria-hidden="true" {...props} />;
+}
+
+const Placeholder = styled.div<{
+  $variant: "map" | "chat" | "photos" | "panel";
+}>`
+  width: ${({ $variant }) =>
+    $variant === "photos" ? "min(100%, 58rem)" : "95vw"};
+  max-width: ${({ $variant }) => ($variant === "photos" ? "58rem" : "400px")};
+  min-height: ${({ $variant }) => {
+    if ($variant === "map") return "32rem";
+    if ($variant === "photos") return "12rem";
+    return "28rem";
+  }};
+  border: 1px solid ${theme.colors.border.light};
+  border-radius: ${theme.corners.base};
+  background:
+    linear-gradient(
+      110deg,
+      transparent 0%,
+      color-mix(in srgb, ${theme.colors.background.top}, transparent 18%) 42%,
+      ${theme.colors.background.top} 50%,
+      color-mix(in srgb, ${theme.colors.background.top}, transparent 18%) 58%,
+      transparent 100%
+    ),
+    ${theme.colors.background.slight};
+  background-size: 220% 100%;
+  animation: placeholder-pulse 1.4s ease-in-out infinite;
+
+  @keyframes placeholder-pulse {
+    0% {
+      background-position: 120% 0;
+    }
+
+    100% {
+      background-position: -120% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;

--- a/src/components/HomepageDemoPlaceholder/index.ts
+++ b/src/components/HomepageDemoPlaceholder/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HomepageDemoPlaceholder";

--- a/src/components/IntroHeader/IntroHeader.tsx
+++ b/src/components/IntroHeader/IntroHeader.tsx
@@ -1,57 +1,10 @@
-import Avatar from "@/components/Avatar";
 import DeferredIntroHeaderRotator from "@/components/DeferredIntroHeaderRotator";
-import MapPin from "@/components/MapPin";
-import { css, keyframes, styled } from "next-yak";
-
-const avatarVisible = {
-  opacity: 1,
-  transform: "rotate(-15deg) translate(-1.5rem, -1rem) scale(1)",
-};
-const markerVisible = {
-  opacity: 1,
-  transform: "rotate(12deg) translate(2.75rem, 1rem) scale(1)",
-};
-const mapEnter = {
-  opacity: 0,
-  transform: "scale(1, 0.9) rotateX(-10deg) translateY(1rem)",
-};
-const mapVisible = {
-  opacity: 1,
-  transform: "scale(1, 1) rotateX(0deg) translateY(0)",
-};
-
-const mapEnterAnimation = keyframes`
-  from {
-    opacity: ${mapEnter.opacity};
-    transform: ${mapEnter.transform};
-  }
-
-  to {
-    opacity: ${mapVisible.opacity};
-    transform: ${mapVisible.transform};
-  }
-`;
-
-const staticHeroItem = {
-  type: "residential",
-  photo: "compost-collective-kc.jpg",
-} as const;
+import { styled } from "next-yak";
 
 export default function IntroHeader() {
   return (
     <Frame>
-      <MapContainer>
-        <MarkerDemo>
-          <MapPin selected={true} type={staticHeroItem.type} />
-        </MarkerDemo>
-        <StyledAvatar
-          isDemo={true}
-          src={`/avatars/featured/${staticHeroItem.photo}`}
-          alt=""
-          size="massive"
-          priority
-        />
-      </MapContainer>
+      <MapContainer />
       <RotatorLayer aria-hidden="true">
         <DeferredIntroHeaderRotator />
       </RotatorLayer>
@@ -67,7 +20,7 @@ const Frame = styled.div`
   margin-bottom: -2.5rem;
 `;
 
-const sharedMapContainerStyles = css`
+const MapContainer = styled.div`
   display: flex;
   flex-direction: row;
   gap: 1rem;
@@ -90,33 +43,13 @@ const sharedMapContainerStyles = css`
     mask-image: radial-gradient(black 0%, transparent 74%);
     border-radius: inherit;
     z-index: -1;
-    opacity: ${mapEnter.opacity};
-    transform: ${mapEnter.transform};
-    animation: ${mapEnterAnimation} 1100ms forwards;
-    animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.055);
+    opacity: 1;
+    transform: scale(1, 1) rotateX(0deg) translateY(0);
     transform-origin: bottom center;
   }
-`;
-
-const MapContainer = styled.div`
-  ${sharedMapContainerStyles}
 `;
 
 const RotatorLayer = styled.div`
   position: absolute;
   inset: 0;
-`;
-
-const StyledAvatar = styled(Avatar)`
-  position: absolute;
-  opacity: ${avatarVisible.opacity};
-  transform: ${avatarVisible.transform};
-  transform-origin: bottom right;
-`;
-
-const MarkerDemo = styled.div`
-  position: absolute;
-  opacity: ${markerVisible.opacity};
-  transform: ${markerVisible.transform};
-  transform-origin: bottom left;
 `;

--- a/src/components/IntroHeader/IntroHeader.tsx
+++ b/src/components/IntroHeader/IntroHeader.tsx
@@ -1,83 +1,16 @@
-"use client";
-import { useState, useEffect } from "react";
-import MapPin from "@/components/MapPin";
 import Avatar from "@/components/Avatar";
+import DeferredIntroHeaderRotator from "@/components/DeferredIntroHeaderRotator";
+import MapPin from "@/components/MapPin";
 import { css, keyframes, styled } from "next-yak";
-import { useTranslations } from "next-intl";
 
-const featuredItems = [
-  {
-    type: "residential",
-    photo: "compost-collective-kc.jpg",
-  },
-  {
-    type: "community",
-    photo: "scrapdogs-aerial.jpg",
-  },
-  {
-    type: "business",
-    photo: "scrapdogs-stand.jpg",
-  },
-  {
-    type: "community",
-    photo: "soil-sisters-singleton.jpg",
-  },
-  {
-    type: "community",
-    photo: "kensington.jpg",
-  },
-  {
-    type: "business",
-    photo: "shellworks.jpg",
-  },
-];
-
-const ANIMATION = {
-  TIMING: {
-    EXIT: "200ms",
-    ENTER: {
-      AVATAR: "400ms",
-      MARKER: "450ms",
-      MAP: "1100ms",
-    },
-  },
-  DELAY: {
-    MARKER: "220ms",
-    AVATAR: "420ms",
-  },
-  CURVE: "cubic-bezier(0.175, 0.885, 0.32, 1.055)",
-};
-
-const commonAnimationProps = {
-  animationTimingFunction: ANIMATION.CURVE,
-  willChange: "transform, opacity", // Improve performance for Safari
-};
-
-const avatarEnter = {
-  opacity: 0,
-  transform: "rotate(0deg) translate(-1.5rem, 2rem) scale(0.5)",
-};
 const avatarVisible = {
   opacity: 1,
   transform: "rotate(-15deg) translate(-1.5rem, -1rem) scale(1)",
-};
-const avatarExit = {
-  opacity: 0,
-  transform: "rotate(-15deg) translate(-1.5rem, -1rem) scale(0.9)",
-};
-const markerEnter = {
-  opacity: 0,
-  transform: "rotate(0deg) translate(2.75rem, 2rem) scale(0.5)",
 };
 const markerVisible = {
   opacity: 1,
   transform: "rotate(12deg) translate(2.75rem, 1rem) scale(1)",
 };
-const markerExit = {
-  opacity: 0,
-  transform: "rotate(12deg) translate(2.75rem, 1rem) scale(0.9)",
-};
-
 const mapEnter = {
   opacity: 0,
   transform: "scale(1, 0.9) rotateX(-10deg) translateY(1rem)",
@@ -87,150 +20,7 @@ const mapVisible = {
   transform: "scale(1, 1) rotateX(0deg) translateY(0)",
 };
 
-const exitAvatarAnimation = keyframes`
-  from {
-    opacity: ${avatarVisible.opacity};
-    transform: ${avatarVisible.transform};
-  }
-
-  to {
-    opacity: ${avatarExit.opacity};
-    transform: ${avatarExit.transform};
-  }
-`;
-
-const exitMarkerAnimation = keyframes`
-  from {
-    opacity: ${markerVisible.opacity};
-    transform: ${markerVisible.transform};
-  }
-
-  to {
-    opacity: ${markerExit.opacity};
-    transform: ${markerExit.transform};
-  }
-`;
-
-const enterAvatarAnimation = keyframes`
-  from {
-    opacity: ${avatarEnter.opacity};
-    transform: ${avatarEnter.transform};
-  }
-
-  to {
-    opacity: ${avatarVisible.opacity};
-    transform: ${avatarVisible.transform};
-  }
-`;
-
-const enterMarkerAnimation = keyframes`
-  from {
-    opacity: ${markerEnter.opacity};
-    transform: ${markerEnter.transform};
-  }
-
-  to {
-    opacity: ${markerVisible.opacity};
-    transform: ${markerVisible.transform};
-  }
-`;
-
-const enteringAvatarStyles = css`
-  animation: ${enterAvatarAnimation} ${ANIMATION.TIMING.ENTER.AVATAR}
-    ${ANIMATION.CURVE} forwards;
-  animation-delay: ${ANIMATION.DELAY.AVATAR};
-`;
-
-const exitingAvatarStyles = css`
-  animation: ${exitAvatarAnimation} ${ANIMATION.TIMING.EXIT} forwards;
-`;
-
-const enteringMarkerStyles = css`
-  animation: ${enterMarkerAnimation} ${ANIMATION.TIMING.ENTER.MARKER}
-    ${ANIMATION.CURVE} forwards;
-  animation-delay: ${ANIMATION.DELAY.MARKER};
-`;
-
-const exitingMarkerStyles = css`
-  animation: ${exitMarkerAnimation} ${ANIMATION.TIMING.EXIT} forwards;
-`;
-
-function IntroHeader() {
-  const t = useTranslations("Index");
-  const [itemIndex, setItemIndex] = useState(0);
-  const [prevItemIndex, setPrevItemIndex] = useState<number | null>(null);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setPrevItemIndex(itemIndex);
-      setItemIndex((current) => (current + 1) % featuredItems.length);
-    }, 5500);
-
-    return () => clearInterval(interval);
-  }, [itemIndex]);
-
-  return (
-    <MapContainer>
-      {/* Checking for prevItemIndex prevents exit animation on initial render */}
-      {/* Unique keys on MarkerDemo and StyledAvatar cause desired re-renders */}
-      {prevItemIndex !== null && (
-        <>
-          <MarkerDemo key={`marker-exit-${prevItemIndex}`} $isExiting={true}>
-            <MapPin selected={true} type={featuredItems[prevItemIndex].type} />
-          </MarkerDemo>
-          <StyledAvatar
-            key={`avatar-exit-${prevItemIndex}`}
-            $isExiting={true}
-            isDemo={true}
-            src={`/avatars/featured/${featuredItems[prevItemIndex].photo}`}
-            alt={t("hostAvatarAlt")}
-            size="massive"
-          />
-        </>
-      )}
-
-      <MarkerDemo key={`marker-enter-${itemIndex}`} $isExiting={false}>
-        <MapPin selected={true} type={featuredItems[itemIndex].type} />
-      </MarkerDemo>
-      <StyledAvatar
-        key={`avatar-enter-${itemIndex}`}
-        $isExiting={false}
-        isDemo={true}
-        src={`/avatars/featured/${featuredItems[itemIndex].photo}`}
-        alt={t("hostAvatarAlt")}
-        size="massive"
-      />
-    </MapContainer>
-  );
-}
-
-export default IntroHeader;
-
-const StyledAvatar = styled(Avatar)<{ $isExiting?: boolean }>`
-  position: absolute;
-  opacity: ${avatarEnter.opacity};
-  transform: ${avatarEnter.transform};
-  animation-timing-function: ${ANIMATION.CURVE};
-  will-change: ${commonAnimationProps.willChange};
-  transform-origin: bottom right;
-
-  ${({ $isExiting = false }) =>
-    $isExiting ? exitingAvatarStyles : enteringAvatarStyles}
-`;
-
-const MarkerDemo = styled.div<{ $isExiting?: boolean }>`
-  position: absolute;
-  opacity: ${markerEnter.opacity};
-  transform: ${markerEnter.transform};
-  animation-timing-function: ${ANIMATION.CURVE};
-  will-change: ${commonAnimationProps.willChange};
-  transform-origin: bottom left;
-
-  ${({ $isExiting = false }) =>
-    $isExiting ? exitingMarkerStyles : enteringMarkerStyles}
-`;
-
-const enterMapAnimation = keyframes`
+const mapEnterAnimation = keyframes`
   from {
     opacity: ${mapEnter.opacity};
     transform: ${mapEnter.transform};
@@ -242,7 +32,42 @@ const enterMapAnimation = keyframes`
   }
 `;
 
-const MapContainer = styled.div`
+const staticHeroItem = {
+  type: "residential",
+  photo: "compost-collective-kc.jpg",
+} as const;
+
+export default function IntroHeader() {
+  return (
+    <Frame>
+      <MapContainer>
+        <MarkerDemo>
+          <MapPin selected={true} type={staticHeroItem.type} />
+        </MarkerDemo>
+        <StyledAvatar
+          isDemo={true}
+          src={`/avatars/featured/${staticHeroItem.photo}`}
+          alt=""
+          size="massive"
+          priority
+        />
+      </MapContainer>
+      <RotatorLayer aria-hidden="true">
+        <DeferredIntroHeaderRotator />
+      </RotatorLayer>
+    </Frame>
+  );
+}
+
+const Frame = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 36rem;
+  height: 16rem;
+  margin-bottom: -2.5rem;
+`;
+
+const sharedMapContainerStyles = css`
   display: flex;
   flex-direction: row;
   gap: 1rem;
@@ -267,9 +92,31 @@ const MapContainer = styled.div`
     z-index: -1;
     opacity: ${mapEnter.opacity};
     transform: ${mapEnter.transform};
-    animation-timing-function: ${ANIMATION.CURVE};
-    will-change: ${commonAnimationProps.willChange};
-    animation: ${enterMapAnimation} ${ANIMATION.TIMING.ENTER.MAP} forwards;
+    animation: ${mapEnterAnimation} 1100ms forwards;
+    animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.055);
     transform-origin: bottom center;
   }
+`;
+
+const MapContainer = styled.div`
+  ${sharedMapContainerStyles}
+`;
+
+const RotatorLayer = styled.div`
+  position: absolute;
+  inset: 0;
+`;
+
+const StyledAvatar = styled(Avatar)`
+  position: absolute;
+  opacity: ${avatarVisible.opacity};
+  transform: ${avatarVisible.transform};
+  transform-origin: bottom right;
+`;
+
+const MarkerDemo = styled.div`
+  position: absolute;
+  opacity: ${markerVisible.opacity};
+  transform: ${markerVisible.transform};
+  transform-origin: bottom left;
 `;

--- a/src/components/IntroHeader/IntroHeader.tsx
+++ b/src/components/IntroHeader/IntroHeader.tsx
@@ -4,7 +4,6 @@ import { styled } from "next-yak";
 export default function IntroHeader() {
   return (
     <Frame>
-      <MapContainer />
       <RotatorLayer aria-hidden="true">
         <DeferredIntroHeaderRotator />
       </RotatorLayer>
@@ -18,35 +17,6 @@ const Frame = styled.div`
   max-width: 36rem;
   height: 16rem;
   margin-bottom: -2.5rem;
-`;
-
-const MapContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  border-radius: 1rem;
-  width: 100%;
-  max-width: 36rem;
-  height: 16rem;
-  margin-bottom: -2.5rem;
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: url("/map-tiles/hero.jpg");
-    background-size: cover;
-    background-position: center;
-    mask-image: radial-gradient(black 0%, transparent 74%);
-    border-radius: inherit;
-    z-index: -1;
-    opacity: 1;
-    transform: scale(1, 1) rotateX(0deg) translateY(0);
-    transform-origin: bottom center;
-  }
 `;
 
 const RotatorLayer = styled.div`

--- a/src/components/IntroHeader/IntroHeaderRotator.tsx
+++ b/src/components/IntroHeader/IntroHeaderRotator.tsx
@@ -155,7 +155,7 @@ const exitingMarkerStyles = css`
   animation: ${exitMarkerAnimation} ${ANIMATION.TIMING.EXIT} forwards;
 `;
 
-function IntroHeader() {
+function IntroHeaderRotator() {
   const t = useTranslations("Index");
   const [itemIndex, setItemIndex] = useState(0);
   const [prevItemIndex, setPrevItemIndex] = useState<number | null>(null);
@@ -204,7 +204,7 @@ function IntroHeader() {
   );
 }
 
-export default IntroHeader;
+export default IntroHeaderRotator;
 
 const StyledAvatar = styled(Avatar)<{ $isExiting?: boolean }>`
   position: absolute;

--- a/src/components/IntroHeader/IntroHeaderRotator.tsx
+++ b/src/components/IntroHeader/IntroHeaderRotator.tsx
@@ -1,0 +1,275 @@
+"use client";
+import { useState, useEffect } from "react";
+import MapPin from "@/components/MapPin";
+import Avatar from "@/components/Avatar";
+import { css, keyframes, styled } from "next-yak";
+import { useTranslations } from "next-intl";
+
+const featuredItems = [
+  {
+    type: "residential",
+    photo: "compost-collective-kc.jpg",
+  },
+  {
+    type: "community",
+    photo: "scrapdogs-aerial.jpg",
+  },
+  {
+    type: "business",
+    photo: "scrapdogs-stand.jpg",
+  },
+  {
+    type: "community",
+    photo: "soil-sisters-singleton.jpg",
+  },
+  {
+    type: "community",
+    photo: "kensington.jpg",
+  },
+  {
+    type: "business",
+    photo: "shellworks.jpg",
+  },
+];
+
+const ANIMATION = {
+  TIMING: {
+    EXIT: "200ms",
+    ENTER: {
+      AVATAR: "400ms",
+      MARKER: "450ms",
+      MAP: "1100ms",
+    },
+  },
+  DELAY: {
+    MARKER: "220ms",
+    AVATAR: "420ms",
+  },
+  CURVE: "cubic-bezier(0.175, 0.885, 0.32, 1.055)",
+};
+
+const commonAnimationProps = {
+  animationTimingFunction: ANIMATION.CURVE,
+  willChange: "transform, opacity", // Improve performance for Safari
+};
+
+const avatarEnter = {
+  opacity: 0,
+  transform: "rotate(0deg) translate(-1.5rem, 2rem) scale(0.5)",
+};
+const avatarVisible = {
+  opacity: 1,
+  transform: "rotate(-15deg) translate(-1.5rem, -1rem) scale(1)",
+};
+const avatarExit = {
+  opacity: 0,
+  transform: "rotate(-15deg) translate(-1.5rem, -1rem) scale(0.9)",
+};
+const markerEnter = {
+  opacity: 0,
+  transform: "rotate(0deg) translate(2.75rem, 2rem) scale(0.5)",
+};
+const markerVisible = {
+  opacity: 1,
+  transform: "rotate(12deg) translate(2.75rem, 1rem) scale(1)",
+};
+const markerExit = {
+  opacity: 0,
+  transform: "rotate(12deg) translate(2.75rem, 1rem) scale(0.9)",
+};
+
+const mapEnter = {
+  opacity: 0,
+  transform: "scale(1, 0.9) rotateX(-10deg) translateY(1rem)",
+};
+const mapVisible = {
+  opacity: 1,
+  transform: "scale(1, 1) rotateX(0deg) translateY(0)",
+};
+
+const exitAvatarAnimation = keyframes`
+  from {
+    opacity: ${avatarVisible.opacity};
+    transform: ${avatarVisible.transform};
+  }
+
+  to {
+    opacity: ${avatarExit.opacity};
+    transform: ${avatarExit.transform};
+  }
+`;
+
+const exitMarkerAnimation = keyframes`
+  from {
+    opacity: ${markerVisible.opacity};
+    transform: ${markerVisible.transform};
+  }
+
+  to {
+    opacity: ${markerExit.opacity};
+    transform: ${markerExit.transform};
+  }
+`;
+
+const enterAvatarAnimation = keyframes`
+  from {
+    opacity: ${avatarEnter.opacity};
+    transform: ${avatarEnter.transform};
+  }
+
+  to {
+    opacity: ${avatarVisible.opacity};
+    transform: ${avatarVisible.transform};
+  }
+`;
+
+const enterMarkerAnimation = keyframes`
+  from {
+    opacity: ${markerEnter.opacity};
+    transform: ${markerEnter.transform};
+  }
+
+  to {
+    opacity: ${markerVisible.opacity};
+    transform: ${markerVisible.transform};
+  }
+`;
+
+const enteringAvatarStyles = css`
+  animation: ${enterAvatarAnimation} ${ANIMATION.TIMING.ENTER.AVATAR}
+    ${ANIMATION.CURVE} forwards;
+  animation-delay: ${ANIMATION.DELAY.AVATAR};
+`;
+
+const exitingAvatarStyles = css`
+  animation: ${exitAvatarAnimation} ${ANIMATION.TIMING.EXIT} forwards;
+`;
+
+const enteringMarkerStyles = css`
+  animation: ${enterMarkerAnimation} ${ANIMATION.TIMING.ENTER.MARKER}
+    ${ANIMATION.CURVE} forwards;
+  animation-delay: ${ANIMATION.DELAY.MARKER};
+`;
+
+const exitingMarkerStyles = css`
+  animation: ${exitMarkerAnimation} ${ANIMATION.TIMING.EXIT} forwards;
+`;
+
+function IntroHeader() {
+  const t = useTranslations("Index");
+  const [itemIndex, setItemIndex] = useState(0);
+  const [prevItemIndex, setPrevItemIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPrevItemIndex(itemIndex);
+      setItemIndex((current) => (current + 1) % featuredItems.length);
+    }, 5500);
+
+    return () => clearInterval(interval);
+  }, [itemIndex]);
+
+  return (
+    <MapContainer>
+      {/* Checking for prevItemIndex prevents exit animation on initial render */}
+      {/* Unique keys on MarkerDemo and StyledAvatar cause desired re-renders */}
+      {prevItemIndex !== null && (
+        <>
+          <MarkerDemo key={`marker-exit-${prevItemIndex}`} $isExiting={true}>
+            <MapPin selected={true} type={featuredItems[prevItemIndex].type} />
+          </MarkerDemo>
+          <StyledAvatar
+            key={`avatar-exit-${prevItemIndex}`}
+            $isExiting={true}
+            isDemo={true}
+            src={`/avatars/featured/${featuredItems[prevItemIndex].photo}`}
+            alt={t("hostAvatarAlt")}
+            size="massive"
+          />
+        </>
+      )}
+
+      <MarkerDemo key={`marker-enter-${itemIndex}`} $isExiting={false}>
+        <MapPin selected={true} type={featuredItems[itemIndex].type} />
+      </MarkerDemo>
+      <StyledAvatar
+        key={`avatar-enter-${itemIndex}`}
+        $isExiting={false}
+        isDemo={true}
+        src={`/avatars/featured/${featuredItems[itemIndex].photo}`}
+        alt={t("hostAvatarAlt")}
+        size="massive"
+      />
+    </MapContainer>
+  );
+}
+
+export default IntroHeader;
+
+const StyledAvatar = styled(Avatar)<{ $isExiting?: boolean }>`
+  position: absolute;
+  opacity: ${avatarEnter.opacity};
+  transform: ${avatarEnter.transform};
+  animation-timing-function: ${ANIMATION.CURVE};
+  will-change: ${commonAnimationProps.willChange};
+  transform-origin: bottom right;
+
+  ${({ $isExiting = false }) =>
+    $isExiting ? exitingAvatarStyles : enteringAvatarStyles}
+`;
+
+const MarkerDemo = styled.div<{ $isExiting?: boolean }>`
+  position: absolute;
+  opacity: ${markerEnter.opacity};
+  transform: ${markerEnter.transform};
+  animation-timing-function: ${ANIMATION.CURVE};
+  will-change: ${commonAnimationProps.willChange};
+  transform-origin: bottom left;
+
+  ${({ $isExiting = false }) =>
+    $isExiting ? exitingMarkerStyles : enteringMarkerStyles}
+`;
+
+const enterMapAnimation = keyframes`
+  from {
+    opacity: ${mapEnter.opacity};
+    transform: ${mapEnter.transform};
+  }
+
+  to {
+    opacity: ${mapVisible.opacity};
+    transform: ${mapVisible.transform};
+  }
+`;
+
+const MapContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border-radius: 1rem;
+  width: 100%;
+  max-width: 36rem;
+  height: 16rem;
+  margin-bottom: -2.5rem;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: url("/map-tiles/hero.jpg");
+    background-size: cover;
+    background-position: center;
+    mask-image: radial-gradient(black 0%, transparent 74%);
+    border-radius: inherit;
+    z-index: -1;
+    opacity: ${mapEnter.opacity};
+    transform: ${mapEnter.transform};
+    animation-timing-function: ${ANIMATION.CURVE};
+    will-change: ${commonAnimationProps.willChange};
+    animation: ${enterMapAnimation} ${ANIMATION.TIMING.ENTER.MAP} forwards;
+    transform-origin: bottom center;
+  }
+`;

--- a/src/components/PeelsHowItWorks/PeelsHowItWorks.tsx
+++ b/src/components/PeelsHowItWorks/PeelsHowItWorks.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import PeelsMapDemo from "@/components/PeelsMapDemo";
-import PeelsChatDemo from "@/components/PeelsChatDemo";
-import PeelsFeaturedHostsPhotos from "@/components/PeelsFeaturedHostsPhotos";
+import DeferredPeelsMapDemo from "@/components/DeferredPeelsMapDemo";
+import DeferredPeelsChatDemo from "@/components/DeferredPeelsChatDemo";
+import DeferredPeelsFeaturedHostsPhotos from "@/components/DeferredPeelsFeaturedHostsPhotos";
 import { css, styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 import type { LiHTMLAttributes, ReactNode } from "react";
@@ -12,14 +12,11 @@ function PeelsHowItWorks() {
   return (
     <OrderedList>
       <Step>
-        <PeelsMapDemo
-          stepHeader={
-            <StepHeader>
-              <h3>{t("findAHost.title")}</h3>
-              <p>{t("findAHost.subtitle")}</p>
-            </StepHeader>
-          }
-        />
+        <StepHeader>
+          <h3>{t("findAHost.title")}</h3>
+          <p>{t("findAHost.subtitle")}</p>
+        </StepHeader>
+        <DeferredPeelsMapDemo />
       </Step>
 
       <Step anchor="left" id="contact">
@@ -27,7 +24,7 @@ function PeelsHowItWorks() {
           <h3>{t("contact.title")}</h3>
           <p>{t("contact.subtitle")}</p>
         </StepHeader>
-        <PeelsChatDemo />
+        <DeferredPeelsChatDemo />
       </Step>
 
       <Step id="drop-off">
@@ -36,7 +33,7 @@ function PeelsHowItWorks() {
           <p>{t("dropOff.subtitle")}</p>
         </StepHeader>
 
-        <PeelsFeaturedHostsPhotos />
+        <DeferredPeelsFeaturedHostsPhotos />
 
         <StepFooter>
           <p>
@@ -79,6 +76,7 @@ const StyledStep = styled.li<{ $anchor?: "left" }>`
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 1rem;
 
   ${({ $anchor }) => $anchor === "left" && anchoredStepStyles}
 `;

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -1,23 +1,15 @@
 import { siteConfig } from "@/config/site";
 import Link from "next/link";
-import { headers } from "next/headers";
 import PeelsLogo from "@/components/PeelsLogo";
-import LocalePicker from "@/components/LocalePicker";
+import FooterLocaleSlot from "@/components/FooterLocaleSlot";
 import { styled } from "next-yak";
 import { getTranslations } from "next-intl/server";
-import {
-  authStateHeaderName,
-  authStateSignedIn,
-} from "@/utils/supabase/authState";
 import { theme } from "@/styles/theme.yak";
 
 const currentYear = new Date().getFullYear();
 
 export default async function SiteFooter() {
   const t = await getTranslations();
-  const headersList = await headers();
-  const hasSignedInSession =
-    headersList.get(authStateHeaderName) === authStateSignedIn;
 
   return (
     <StyledFooter>
@@ -26,7 +18,7 @@ export default async function SiteFooter() {
         © {currentYear} {siteConfig.name}
       </p>
 
-      {!hasSignedInSession && <LocalePicker compact={true} />}
+      <FooterLocaleSlot />
 
       <StyledNav>
         <Link href={siteConfig.links.about}>{t("App.about")}</Link>

--- a/src/components/TabBarTab/TabBarTab.tsx
+++ b/src/components/TabBarTab/TabBarTab.tsx
@@ -64,7 +64,7 @@ export default function TabBarTab({
     >
       <StyledTabBarTabIcon>
         {icon}
-        {unreadDot && <UnreadDot />}
+        {unreadDot && <UnreadDot data-testid="tab-unread-dot" />}
       </StyledTabBarTabIcon>
       {title && <StyledTabBarTabTitle>{title}</StyledTabBarTabTitle>}
     </StyledTabBarTab>

--- a/src/contexts/UnreadMessagesContext.tsx
+++ b/src/contexts/UnreadMessagesContext.tsx
@@ -21,14 +21,6 @@ type ChatMessagePayload = {
   thread_id: string | null;
 };
 
-type ChatThreadRow = {
-  id: string;
-};
-
-type UnreadThreadRow = {
-  thread_id: string | null;
-};
-
 type UnreadMessagesContextValue = {
   unreadCount: number;
   setUnreadCount: Dispatch<SetStateAction<number>>;
@@ -133,39 +125,19 @@ export function UnreadMessagesProvider({ children }: PropsWithChildren) {
           return;
         }
 
-        const { data: threads, error: threadsError } = await supabase
-          .from("chat_threads")
-          .select("id")
-          .or(`initiator_id.eq.${userId},owner_id.eq.${userId}`);
+        const { count, error } = await supabase
+          .from("chat_messages")
+          .select("id", { count: "exact", head: true })
+          .neq("sender_id", userId)
+          .is("read_at", null);
 
-        if (threadsError) {
-          console.error("Error checking chat threads:", threadsError);
+        if (error) {
+          console.error("Error checking unread messages:", error);
           return;
         }
-
-        const threadIds = ((threads as ChatThreadRow[] | null) ?? []).map(
-          (thread) => thread.id
-        );
-        const { data: unreadThreads, error: unreadThreadsError } =
-          threadIds.length > 0
-            ? await supabase.rpc("unread_chat_thread_ids", {
-                thread_ids: threadIds,
-              })
-            : { data: [], error: null };
-
-        if (unreadThreadsError) {
-          console.error("Error checking unread messages:", unreadThreadsError);
-          return;
-        }
-
-        const unreadThreadIds = new Set(
-          ((unreadThreads as UnreadThreadRow[] | null) ?? [])
-            .map((thread) => thread.thread_id)
-            .filter((threadId): threadId is string => Boolean(threadId))
-        );
 
         if (!isActive) return;
-        setUnreadCount(unreadThreadIds.size);
+        setUnreadCount(count ?? 0);
       } catch (error) {
         console.error("Error in checkUnreadMessages:", error);
       }

--- a/src/contexts/UnreadMessagesContext.tsx
+++ b/src/contexts/UnreadMessagesContext.tsx
@@ -11,6 +11,7 @@ import {
 import { createClient } from "@/utils/supabase/client";
 import { usePathname } from "next/navigation";
 import { getChatThreadIdFromPathname } from "@/features/chat/chatRoutes";
+import { scheduleIdleTask } from "@/utils/scheduleIdleTask";
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react";
 
 type ThreadReadStatus = Record<string, boolean>;
@@ -33,29 +34,6 @@ const UnreadMessagesContext = createContext<
   UnreadMessagesContextValue | undefined
 >(undefined);
 const isAuthDebugEnabled = process.env.NEXT_PUBLIC_AUTH_DEBUG === "true";
-
-type IdleWindow = Window & {
-  requestIdleCallback?: (
-    callback: () => void,
-    options?: { timeout?: number }
-  ) => number;
-  cancelIdleCallback?: (handle: number) => void;
-};
-
-function scheduleIdleTask(callback: () => void) {
-  const idleWindow = window as IdleWindow;
-
-  if (typeof idleWindow.requestIdleCallback === "function") {
-    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
-      timeout: 2_000,
-    });
-
-    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
-  }
-
-  const timeoutId = globalThis.setTimeout(callback, 250);
-  return () => globalThis.clearTimeout(timeoutId);
-}
 
 export function UnreadMessagesProvider({ children }: PropsWithChildren) {
   const [unreadCount, setUnreadCount] = useState(0);

--- a/src/contexts/UnreadMessagesContext.tsx
+++ b/src/contexts/UnreadMessagesContext.tsx
@@ -21,6 +21,14 @@ type ChatMessagePayload = {
   thread_id: string | null;
 };
 
+type ChatThreadRow = {
+  id: string;
+};
+
+type UnreadThreadRow = {
+  thread_id: string | null;
+};
+
 type UnreadMessagesContextValue = {
   unreadCount: number;
   setUnreadCount: Dispatch<SetStateAction<number>>;
@@ -33,6 +41,29 @@ const UnreadMessagesContext = createContext<
   UnreadMessagesContextValue | undefined
 >(undefined);
 const isAuthDebugEnabled = process.env.NEXT_PUBLIC_AUTH_DEBUG === "true";
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number }
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function scheduleIdleTask(callback: () => void) {
+  const idleWindow = window as IdleWindow;
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
+      timeout: 2_000,
+    });
+
+    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = globalThis.setTimeout(callback, 250);
+  return () => globalThis.clearTimeout(timeoutId);
+}
 
 export function UnreadMessagesProvider({ children }: PropsWithChildren) {
   const [unreadCount, setUnreadCount] = useState(0);
@@ -64,7 +95,9 @@ export function UnreadMessagesProvider({ children }: PropsWithChildren) {
       });
     }
 
-    void loadUserId();
+    const cancelInitialLoad = scheduleIdleTask(() => {
+      void loadUserId();
+    });
 
     if (isAuthDebugEnabled) {
       console.log("Setting up auth listener");
@@ -83,6 +116,7 @@ export function UnreadMessagesProvider({ children }: PropsWithChildren) {
 
     return () => {
       isActive = false;
+      cancelInitialLoad();
       subscription.unsubscribe();
     };
   }, [supabase]);
@@ -99,19 +133,39 @@ export function UnreadMessagesProvider({ children }: PropsWithChildren) {
           return;
         }
 
-        const { count, error } = await supabase
-          .from("chat_messages")
-          .select("*", { count: "exact", head: true })
-          .neq("sender_id", userId)
-          .is("read_at", null);
+        const { data: threads, error: threadsError } = await supabase
+          .from("chat_threads")
+          .select("id")
+          .or(`initiator_id.eq.${userId},owner_id.eq.${userId}`);
 
-        if (error) {
-          console.error("Error checking unread messages:", error);
+        if (threadsError) {
+          console.error("Error checking chat threads:", threadsError);
           return;
         }
 
+        const threadIds = ((threads as ChatThreadRow[] | null) ?? []).map(
+          (thread) => thread.id
+        );
+        const { data: unreadThreads, error: unreadThreadsError } =
+          threadIds.length > 0
+            ? await supabase.rpc("unread_chat_thread_ids", {
+                thread_ids: threadIds,
+              })
+            : { data: [], error: null };
+
+        if (unreadThreadsError) {
+          console.error("Error checking unread messages:", unreadThreadsError);
+          return;
+        }
+
+        const unreadThreadIds = new Set(
+          ((unreadThreads as UnreadThreadRow[] | null) ?? [])
+            .map((thread) => thread.thread_id)
+            .filter((threadId): threadId is string => Boolean(threadId))
+        );
+
         if (!isActive) return;
-        setUnreadCount(count ?? 0);
+        setUnreadCount(unreadThreadIds.size);
       } catch (error) {
         console.error("Error in checkUnreadMessages:", error);
       }

--- a/src/features/chat/chatPageData.ts
+++ b/src/features/chat/chatPageData.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import { cache } from "react";
+import { createClient } from "@/utils/supabase/server";
+import {
+  getChatThreads,
+  getSelectedChatThread,
+} from "@/features/chat/chatData";
+
+export const getAuthenticatedChatUser = cache(async () => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase, user };
+});
+
+export const getCurrentChatThreads = cache(async () => {
+  const { supabase, user } = await getAuthenticatedChatUser();
+
+  if (!user) {
+    return {
+      user: null,
+      threads: [],
+    };
+  }
+
+  const threads = await getChatThreads(supabase, user.id);
+
+  return {
+    user,
+    threads,
+  };
+});
+
+export const getCurrentSelectedChatThread = cache(async (threadId: string) => {
+  const { supabase, user } = await getAuthenticatedChatUser();
+
+  if (!user) {
+    return {
+      user: null,
+      selectedThread: null,
+    };
+  }
+
+  const selectedThread = await getSelectedChatThread(
+    supabase,
+    user.id,
+    threadId
+  );
+
+  return {
+    user,
+    selectedThread,
+  };
+});

--- a/src/hooks/useDeferredHomepageDemo.ts
+++ b/src/hooks/useDeferredHomepageDemo.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number }
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function scheduleIdleTask(callback: () => void) {
+  const idleWindow = window as IdleWindow;
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
+      timeout: 2_000,
+    });
+
+    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = globalThis.setTimeout(callback, 300);
+  return () => globalThis.clearTimeout(timeoutId);
+}
+
+export function useDeferredHomepageDemo() {
+  const [isReady, setIsReady] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isReady) {
+      return;
+    }
+
+    const markReady = () => setIsReady(true);
+    const cancelIdleTask = scheduleIdleTask(markReady);
+    const observer =
+      "IntersectionObserver" in window
+        ? new IntersectionObserver(
+            (entries) => {
+              if (entries.some((entry) => entry.isIntersecting)) {
+                markReady();
+              }
+            },
+            { rootMargin: "600px 0px" }
+          )
+        : null;
+
+    if (observer && rootRef.current) {
+      observer.observe(rootRef.current);
+    }
+
+    return () => {
+      cancelIdleTask();
+      observer?.disconnect();
+    };
+  }, [isReady]);
+
+  return { isReady, rootRef };
+}

--- a/src/hooks/useDeferredHomepageDemo.ts
+++ b/src/hooks/useDeferredHomepageDemo.ts
@@ -1,29 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-
-type IdleWindow = Window & {
-  requestIdleCallback?: (
-    callback: () => void,
-    options?: { timeout?: number }
-  ) => number;
-  cancelIdleCallback?: (handle: number) => void;
-};
-
-function scheduleIdleTask(callback: () => void) {
-  const idleWindow = window as IdleWindow;
-
-  if (typeof idleWindow.requestIdleCallback === "function") {
-    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
-      timeout: 2_000,
-    });
-
-    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
-  }
-
-  const timeoutId = globalThis.setTimeout(callback, 300);
-  return () => globalThis.clearTimeout(timeoutId);
-}
+import { scheduleIdleTask } from "@/utils/scheduleIdleTask";
 
 export function useDeferredHomepageDemo() {
   const [isReady, setIsReady] = useState(false);
@@ -35,7 +13,10 @@ export function useDeferredHomepageDemo() {
     }
 
     const markReady = () => setIsReady(true);
-    const cancelIdleTask = scheduleIdleTask(markReady);
+    const cancelIdleTask = scheduleIdleTask(markReady, {
+      timeout: 2_000,
+      fallbackDelay: 300,
+    });
     const observer =
       "IntersectionObserver" in window
         ? new IntersectionObserver(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -33,6 +33,8 @@ const authRequiredPathPrefixes = [
   "/auth",
   "/chats",
   "/forgot-password",
+  "/listings",
+  "/map",
   "/profile",
   "/sign-in",
   "/sign-up",
@@ -46,7 +48,7 @@ function shouldUpdateSession(request: NextRequest) {
 
 export async function proxy(request: NextRequest) {
   // Public routes deliberately skip Supabase auth refresh for first-paint
-  // performance. Auth-aware client slots converge after hydration.
+  // performance. Routes that server-render auth-aware data stay above.
   const response = shouldUpdateSession(request)
     ? await updateSession(request)
     : createSignedOutResponse(request);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,8 @@
 import { type NextRequest } from "next/server";
-import { updateSession } from "@/utils/supabase/middleware";
+import {
+  createSignedOutResponse,
+  updateSession,
+} from "@/utils/supabase/middleware";
 
 const INITIAL_REFERRER_COOKIE = "initial_referrer";
 const INITIAL_REFERRER_MAX_AGE = 60 * 60 * 24 * 90;
@@ -26,8 +29,25 @@ function getExternalReferrer(request: NextRequest) {
   }
 }
 
+const authRequiredPathPrefixes = [
+  "/auth",
+  "/chats",
+  "/forgot-password",
+  "/profile",
+  "/sign-in",
+  "/sign-up",
+];
+
+function shouldUpdateSession(request: NextRequest) {
+  return authRequiredPathPrefixes.some((pathPrefix) =>
+    request.nextUrl.pathname.startsWith(pathPrefix)
+  );
+}
+
 export async function proxy(request: NextRequest) {
-  const response = await updateSession(request);
+  const response = shouldUpdateSession(request)
+    ? await updateSession(request)
+    : createSignedOutResponse(request);
   const hasInitialReferrerCookie = request.cookies.get(INITIAL_REFERRER_COOKIE);
   const externalReferrer = getExternalReferrer(request);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -45,6 +45,8 @@ function shouldUpdateSession(request: NextRequest) {
 }
 
 export async function proxy(request: NextRequest) {
+  // Public routes deliberately skip Supabase auth refresh for first-paint
+  // performance. Auth-aware client slots converge after hydration.
   const response = shouldUpdateSession(request)
     ? await updateSession(request)
     : createSignedOutResponse(request);

--- a/src/utils/scheduleIdleTask.ts
+++ b/src/utils/scheduleIdleTask.ts
@@ -1,0 +1,30 @@
+type IdleWindow = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number }
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+type ScheduleIdleTaskOptions = {
+  timeout?: number;
+  fallbackDelay?: number;
+};
+
+export function scheduleIdleTask(
+  callback: () => void,
+  { timeout = 2_000, fallbackDelay = 250 }: ScheduleIdleTaskOptions = {}
+) {
+  const idleWindow = window as IdleWindow;
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const idleCallbackId = idleWindow.requestIdleCallback(callback, {
+      timeout,
+    });
+
+    return () => idleWindow.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = globalThis.setTimeout(callback, fallbackDelay);
+  return () => globalThis.clearTimeout(timeoutId);
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -7,6 +7,25 @@ import {
   currentPathHeaderName,
 } from "@/utils/supabase/authState";
 
+function createForwardedResponse(request: NextRequest, authState: string) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(
+    currentPathHeaderName,
+    `${request.nextUrl.pathname}${request.nextUrl.search}`
+  );
+  requestHeaders.set(authStateHeaderName, authState);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+export function createSignedOutResponse(request: NextRequest) {
+  return createForwardedResponse(request, authStateSignedOut);
+}
+
 export const updateSession = async (request: NextRequest) => {
   // This `try/catch` block is only here for the interactive tutorial.
   // Feel free to remove once you have Supabase connected.
@@ -88,17 +107,6 @@ export const updateSession = async (request: NextRequest) => {
     // If you are here, a Supabase client could not be created!
     // This is likely because you have not set up environment variables.
     // Check out http://localhost:3000 for Next Steps.
-    const requestHeaders = new Headers(request.headers);
-    requestHeaders.set(authStateHeaderName, authStateSignedOut);
-    requestHeaders.set(
-      currentPathHeaderName,
-      `${request.nextUrl.pathname}${request.nextUrl.search}`
-    );
-
-    return NextResponse.next({
-      request: {
-        headers: requestHeaders,
-      },
-    });
+    return createSignedOutResponse(request);
   }
 };


### PR DESCRIPTION
## Summary

- skips proxy-level Supabase session refresh on public routes that do not need server auth, while keeping auth refresh for protected/auth-aware server routes like `/map`, `/listings`, `/chats`, and `/profile`
- moves footer locale/auth detection and unread chat checks to scoped client work that resolves after first paint
- defers the decorative homepage hero visual plus below-the-fold homepage demo bundles until idle/intersection while keeping headline, copy, CTAs, and how-it-works content in the initial render
- shares cached chat server lookups for selected chat pages

## Validation

- `npm run typecheck`
- `npm run check`
- `npm run test:e2e:prod -- e2e/home.spec.ts`
- `npm run test:e2e:prod -- e2e/seo.spec.ts e2e/chat.spec.ts`
- `npm run test:e2e:prod -- e2e/i18n.spec.ts`
- `npm run test:e2e:prod -- e2e/home.spec.ts e2e/seo.spec.ts e2e/chat.spec.ts`
