### PR TITLE
fix hosted chat webhook URL

### DIFF
--- a/docs/supabase-data-architecture.md
+++ b/docs/supabase-data-architecture.md
@@ -161,10 +161,16 @@ The current helper functions refresh read-model rows, enforce chat message/threa
 
 Chat message email notifications are sent through the `send-email-for-new-chat-message` Edge Function. That function is invoked by a database trigger, not by browser clients, so it has `verify_jwt = false` and performs its own shared-secret check with `PEELS_CHAT_MESSAGE_WEBHOOK_SECRET`.
 
-The same secret must exist in two places:
+The same webhook secret must exist in two places:
 
 - Supabase Edge Function secrets as `PEELS_CHAT_MESSAGE_WEBHOOK_SECRET`.
 - Supabase Vault as `PEELS_CHAT_MESSAGE_WEBHOOK_SECRET`, so the database trigger can send it in the `x-peels-webhook-secret` header.
+
+The database trigger also needs the hosted project URL in Vault:
+
+- Supabase Vault as `PEELS_SUPABASE_PROJECT_URL`, for example `https://<project-ref>.supabase.co`.
+
+Do not use local Supabase Docker hostnames such as `kong:8000` in migrations that run in hosted environments. They work during local `supabase db reset`, but hosted Postgres cannot resolve them.
 
 Do not use the public anon key as the protection boundary for this webhook. The function holds a service-role client so the caller must be authenticated by a non-public secret.
 

--- a/supabase/migrations/20260512024109_use_vault_project_url_for_chat_webhook.sql
+++ b/supabase/migrations/20260512024109_use_vault_project_url_for_chat_webhook.sql
@@ -1,0 +1,71 @@
+-- Hosted Postgres cannot resolve the local Supabase Docker hostname
+-- `kong:8000`. Read the project URL from Vault so the chat email webhook can
+-- call the deployed Edge Function in every environment.
+
+create or replace function private.notify_new_chat_message()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  webhook_secret text;
+  project_url text;
+begin
+  if to_regprocedure('net.http_post(text,jsonb,jsonb,jsonb,integer)') is null then
+    raise warning 'Skipping chat message email webhook because pg_net is unavailable.';
+    return new;
+  end if;
+
+  if to_regclass('vault.decrypted_secrets') is not null then
+    execute
+      'select decrypted_secret from vault.decrypted_secrets where name = $1 limit 1'
+      into webhook_secret
+      using 'PEELS_CHAT_MESSAGE_WEBHOOK_SECRET';
+
+    execute
+      'select decrypted_secret from vault.decrypted_secrets where name = $1 limit 1'
+      into project_url
+      using 'PEELS_SUPABASE_PROJECT_URL';
+  end if;
+
+  if webhook_secret is null or webhook_secret = '' then
+    raise warning 'Skipping chat message email webhook because PEELS_CHAT_MESSAGE_WEBHOOK_SECRET is not set in Vault.';
+    return new;
+  end if;
+
+  if project_url is null or project_url = '' then
+    raise warning 'Skipping chat message email webhook because PEELS_SUPABASE_PROJECT_URL is not set in Vault.';
+    return new;
+  end if;
+
+  begin
+    perform net.http_post(
+      url := rtrim(project_url, '/') || '/functions/v1/send-email-for-new-chat-message',
+      body := jsonb_build_object(
+        'type', tg_op,
+        'table', tg_table_name,
+        'schema', tg_table_schema,
+        'record', jsonb_build_object('id', new.id),
+        'old_record', null
+      ),
+      params := '{}'::jsonb,
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'x-peels-webhook-secret', webhook_secret
+      ),
+      timeout_milliseconds := 5000
+    );
+  exception
+    when others then
+      raise warning 'Skipping chat message email webhook because the request failed: %', sqlerrm;
+  end;
+
+  return new;
+end;
+$$;
+
+alter function private.notify_new_chat_message() owner to postgres;
+
+revoke all privileges on function private.notify_new_chat_message()
+  from anon, authenticated, public;


### PR DESCRIPTION
## Summary
- replace the local-only `kong:8000` chat email webhook URL with a hosted project URL read from Vault
- document the required `PEELS_SUPABASE_PROJECT_URL` Vault setting alongside the chat webhook secret

## Verification
- `supabase db reset`
- inspected `private.notify_new_chat_message()` locally to confirm the final function uses `PEELS_SUPABASE_PROJECT_URL` and no longer references `kong:8000`
- `npm run check`

## Notes
- production was hotfixed in the Supabase dashboard; this PR records the same behaviour as a forward migration
- audit of the recently merged Supabase work found no other hosted Postgres HTTP calls depending on local-only hostnames in the final schema