### PR TITLE
fix chat thread noindex metadata

### DIFF
--- a/src/app/(core)/(interact)/(stretched)/chats/[threadId]/layout.tsx
+++ b/src/app/(core)/(interact)/(stretched)/chats/[threadId]/layout.tsx
@@ -1,0 +1,13 @@
+import { noindexFollowMetadata } from "@/utils/seo";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = noindexFollowMetadata;
+
+export default function ChatThreadLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
## Summary

- Add a static layout-level `noindex, follow` metadata boundary for `/chats/[threadId]`.
- Keep the chat detail page free to generate its route-specific signed-in title, such as `Avery · Chats`.

## Testing

- `npm run check`
- `npm run test:e2e:prod -- e2e/seo.spec.ts --grep "signed-in private pages keep noindex metadata"`
- `npm run test:e2e:prod`