### PR TITLE
add residential listing limit

### DIFF
--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -66,6 +66,30 @@ test("listing type chooser routes signed-in hosts to the selected form", async (
   await expect(page.locator("#name")).toBeVisible();
 });
 
+test("listing type chooser hides residential option at the residential limit", async ({
+  page,
+}) => {
+  await signIn(page, {
+    email: DONOR_EMAIL,
+    redirectTo: "/profile/listings/new?type=host",
+  });
+
+  const chooser = page.getByTestId("listing-type-chooser");
+  const communityOption = page.getByTestId("listing-type-option-community");
+  const continueButton = page.getByTestId("listing-type-chooser-submit");
+
+  await expect(chooser).toBeVisible();
+  await expect(page.getByTestId("listing-type-option-residential")).toHaveCount(
+    0
+  );
+  await expect(communityOption).toBeVisible();
+  await communityOption.click();
+  await expect(continueButton).toBeEnabled();
+  await continueButton.click();
+
+  await expect(page).toHaveURL(/\/profile\/listings\/new\/community$/);
+});
+
 test("new listing form shows validation feedback when location is missing", async ({
   page,
 }) => {

--- a/messages/de.json
+++ b/messages/de.json
@@ -98,7 +98,7 @@
     "resetPasswordSuccess": "Dein Passwort wurde aktualisiert. Zurück zum Kompostieren!",
     "savePhotosFailed": "Der Eintrag wurde erstellt, aber die Fotos konnten nicht gespeichert werden.",
     "signUpFailed": "Registrierung fehlgeschlagen",
-    "tooManyListings": "Du hast die maximale Anzahl erlaubter Einträge erreicht. Lösche einen deiner aktuellen drei Einträge, um einen neuen zu erstellen.",
+    "tooManyListings": "Du hast die maximale Anzahl erlaubter Einträge erreicht. Lösche einen deiner bestehenden Einträge, um einen neuen zu erstellen.",
     "tooManyMessages": "Du hast zu viele Nachrichten gesendet. Bitte versuche es später erneut.",
     "tooManyThreads": "Du hast in der letzten Stunde zu viele neue Unterhaltungen begonnen. Bitte versuche es später erneut.",
     "firstNameTooShort": "Bitte verwende mindestens 2 Zeichen für deinen Vornamen.",
@@ -329,6 +329,7 @@
       "hostTypeTitle": "Wo nimmst du Essensreste an?",
       "listingTypeLabel": "Eintragstyp",
       "hostTypeLabel": "Gastgebertyp",
+      "noAvailableOptions": "Du hast die maximale Anzahl erlaubter Einträge erreicht.",
       "options": {
         "host": {
           "title": "Ich nehme Essensreste an",

--- a/messages/en.json
+++ b/messages/en.json
@@ -98,7 +98,7 @@
     "resetPasswordSuccess": "Your password has been updated. Let’s get back to composting!",
     "savePhotosFailed": "Created listing but couldn’t save photos.",
     "signUpFailed": "Sign up failed",
-    "tooManyListings": "You’ve reached the maximum number of listings allowed. Delete one of your current three to create a new one.",
+    "tooManyListings": "You’ve reached the maximum number of listings allowed. Delete one of your existing listings to create a new one.",
     "tooManyMessages": "You’ve sent too many messages. Please try again later.",
     "tooManyThreads": "You’ve started too many new conversations in the last hour. Please try again later.",
     "firstNameTooShort": "Please use at least 2 characters for your first name.",
@@ -329,6 +329,7 @@
       "hostTypeTitle": "Where will you accept food scraps?",
       "listingTypeLabel": "Listing type",
       "hostTypeLabel": "Host type",
+      "noAvailableOptions": "You’ve reached the maximum number of listings allowed.",
       "options": {
         "host": {
           "title": "I accept food scraps",

--- a/messages/es.json
+++ b/messages/es.json
@@ -98,7 +98,7 @@
     "resetPasswordSuccess": "Tu contraseña ha sido actualizada. ¡Volvamos al compostaje!",
     "savePhotosFailed": "Se creó el anuncio, pero no se pudieron guardar las fotos.",
     "signUpFailed": "No se pudo completar el registro",
-    "tooManyListings": "Has alcanzado el número máximo de anuncios permitidos. Elimina uno de tus tres anuncios actuales para crear uno nuevo.",
+    "tooManyListings": "Has alcanzado el número máximo de anuncios permitidos. Elimina uno de tus anuncios existentes para crear uno nuevo.",
     "tooManyMessages": "Has enviado demasiados mensajes. Inténtalo de nuevo más tarde.",
     "tooManyThreads": "Has iniciado demasiadas conversaciones nuevas en la última hora. Inténtalo de nuevo más tarde.",
     "firstNameTooShort": "Usa al menos 2 caracteres para tu nombre.",
@@ -329,6 +329,7 @@
       "hostTypeTitle": "¿Dónde recibirás restos de comida?",
       "listingTypeLabel": "Tipo de anuncio",
       "hostTypeLabel": "Tipo de anfitrión",
+      "noAvailableOptions": "Has alcanzado el número máximo de anuncios permitidos.",
       "options": {
         "host": {
           "title": "Acepto restos de comida",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -98,7 +98,7 @@
     "resetPasswordSuccess": "Votre mot de passe a été mis à jour. Retour au compostage !",
     "savePhotosFailed": "L’annonce a été créée, mais les photos n’ont pas pu être enregistrées.",
     "signUpFailed": "Échec de l’inscription",
-    "tooManyListings": "Vous avez atteint le nombre maximal d’annonces autorisées. Supprimez-en une parmi vos trois annonces actuelles pour en créer une nouvelle.",
+    "tooManyListings": "Vous avez atteint le nombre maximal d’annonces autorisées. Supprimez l’une de vos annonces existantes pour en créer une nouvelle.",
     "tooManyMessages": "Vous avez envoyé trop de messages. Veuillez réessayer plus tard.",
     "tooManyThreads": "Vous avez lancé trop de nouvelles conversations au cours de la dernière heure. Veuillez réessayer plus tard.",
     "firstNameTooShort": "Veuillez utiliser au moins 2 caractères pour votre prénom.",
@@ -329,6 +329,7 @@
       "hostTypeTitle": "Où acceptez-vous des restes alimentaires ?",
       "listingTypeLabel": "Type d’annonce",
       "hostTypeLabel": "Type d’hôte",
+      "noAvailableOptions": "Vous avez atteint le nombre maximal d’annonces autorisées.",
       "options": {
         "host": {
           "title": "J’accepte des restes alimentaires",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -98,7 +98,7 @@
     "resetPasswordSuccess": "A sua senha foi atualizada. Vamos voltar à compostagem!",
     "savePhotosFailed": "O anúncio foi criado, mas não foi possível salvar as fotos.",
     "signUpFailed": "Não foi possível concluir o cadastro",
-    "tooManyListings": "Você atingiu o número máximo de anúncios permitidos. Exclua um dos seus três anúncios atuais para criar um novo.",
+    "tooManyListings": "Você atingiu o número máximo de anúncios permitidos. Exclua um dos seus anúncios existentes para criar um novo.",
     "tooManyMessages": "Você enviou mensagens demais. Tente novamente mais tarde.",
     "tooManyThreads": "Você iniciou conversas demais na última hora. Tente novamente mais tarde.",
     "firstNameTooShort": "Use pelo menos 2 caracteres no seu nome.",
@@ -329,6 +329,7 @@
       "hostTypeTitle": "Onde você aceita restos de comida?",
       "listingTypeLabel": "Tipo de anúncio",
       "hostTypeLabel": "Tipo de anfitrião",
+      "noAvailableOptions": "Você atingiu o número máximo de anúncios permitidos.",
       "options": {
         "host": {
           "title": "Eu aceito restos de comida",

--- a/src/app/(forms)/profile/listings/new/page.tsx
+++ b/src/app/(forms)/profile/listings/new/page.tsx
@@ -1,5 +1,10 @@
+import { createClient } from "@/utils/supabase/server";
 import FormHeader from "@/components/FormHeader";
 import ListingTypeChooser from "@/components/ListingTypeChooser";
+import {
+  MAX_LISTINGS_PER_USER,
+  MAX_RESIDENTIAL_LISTINGS_PER_USER,
+} from "@/config/listingLimits";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
@@ -19,20 +24,50 @@ export default async function AddListingPage({
   const t = await getTranslations();
   const { type } = await searchParams;
   const isHostSelection = type === "host";
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  const options = isHostSelection
-    ? [
-        {
-          key: "residential",
-          title: t("Listings.new.options.residential.title"),
-          description: t("Listings.new.options.residential.description"),
-        },
-        {
-          key: "community",
-          title: t("Listings.new.options.community.title"),
-          description: t("Listings.new.options.community.description"),
-        },
-      ]
+  const [{ data: profile }, { data: listings }] = user
+    ? await Promise.all([
+        supabase.from("profiles").select("is_admin").eq("id", user.id).single(),
+        supabase.from("listings").select("type").eq("owner_id", user.id),
+      ])
+    : [{ data: null }, { data: null }];
+
+  const isAdmin = profile?.is_admin === true;
+  const totalListingCount = listings?.length ?? 0;
+  const residentialListingCount =
+    listings?.filter((listing) => listing.type === "residential").length ?? 0;
+  const hasReachedListingLimit =
+    !isAdmin && totalListingCount >= MAX_LISTINGS_PER_USER;
+  const hasReachedResidentialListingLimit =
+    !isAdmin && residentialListingCount >= MAX_RESIDENTIAL_LISTINGS_PER_USER;
+
+  const hostOptions = [
+    ...(!hasReachedListingLimit && !hasReachedResidentialListingLimit
+      ? [
+          {
+            key: "residential",
+            title: t("Listings.new.options.residential.title"),
+            description: t("Listings.new.options.residential.description"),
+          },
+        ]
+      : []),
+    ...(!hasReachedListingLimit
+      ? [
+          {
+            key: "community",
+            title: t("Listings.new.options.community.title"),
+            description: t("Listings.new.options.community.description"),
+          },
+        ]
+      : []),
+  ];
+
+  const listingOptions = hasReachedListingLimit
+    ? []
     : [
         {
           key: "host",
@@ -45,6 +80,8 @@ export default async function AddListingPage({
           description: t("Listings.new.options.business.description"),
         },
       ];
+
+  const options = isHostSelection ? hostOptions : listingOptions;
 
   return (
     <>
@@ -60,6 +97,7 @@ export default async function AddListingPage({
         mode={isHostSelection ? "host" : "listing"}
         options={options}
         continueLabel={t("Actions.continue")}
+        emptyMessage={t("Listings.new.noAvailableOptions")}
         ariaLabel={
           isHostSelection
             ? t("Listings.new.hostTypeLabel")

--- a/src/components/ListingTypeChooser.tsx
+++ b/src/components/ListingTypeChooser.tsx
@@ -18,6 +18,7 @@ type ListingTypeChooserProps = {
   mode: "listing" | "host";
   options: ListingTypeOption[];
   continueLabel: string;
+  emptyMessage: string;
   ariaLabel: string;
 };
 
@@ -25,6 +26,7 @@ export default function ListingTypeChooser({
   mode,
   options,
   continueLabel,
+  emptyMessage,
   ariaLabel,
 }: ListingTypeChooserProps) {
   const router = useRouter();
@@ -63,21 +65,25 @@ export default function ListingTypeChooser({
       data-testid="listing-type-chooser"
       data-hydrated={isHydrated ? "true" : "false"}
     >
-      <RadioGroup
-        value={selectedOption}
-        onChange={(value) => setSelectedOption(value as ListingTypeOption)}
-        aria-label={ariaLabel}
-      >
-        {options.map((option) => (
-          <Radio
-            key={option.key}
-            value={option}
-            data-testid={`listing-type-option-${option.key}`}
-            title={option.title}
-            description={option.description}
-          />
-        ))}
-      </RadioGroup>
+      {options.length > 0 ? (
+        <RadioGroup
+          value={selectedOption}
+          onChange={(value) => setSelectedOption(value as ListingTypeOption)}
+          aria-label={ariaLabel}
+        >
+          {options.map((option) => (
+            <Radio
+              key={option.key}
+              value={option}
+              data-testid={`listing-type-option-${option.key}`}
+              title={option.title}
+              description={option.description}
+            />
+          ))}
+        </RadioGroup>
+      ) : (
+        <p>{emptyMessage}</p>
+      )}
 
       <SubmitButton
         width="full"

--- a/src/components/ProfileListings/ProfileListings.tsx
+++ b/src/components/ProfileListings/ProfileListings.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Avatar from "@/components/Avatar";
 import Lozenge from "@/components/Lozenge";
+import { MAX_LISTINGS_PER_USER } from "@/config/listingLimits";
 import { css, styled } from "next-yak";
 import { theme } from "@/styles/theme.yak";
 import type { Listing, ListingType } from "@/types/listing";
@@ -20,8 +21,6 @@ type ProfileListingsCopy = {
   listingPrompt: string;
   addAnotherListing: string;
 };
-
-const MAX_LISTINGS = 12; // TODO: Store this value on Supabase and use in the related RLS policy, so they are always in sync
 
 const ListingsList = styled.ul`
   display: flex;
@@ -180,7 +179,7 @@ export default function ProfileListings({
         );
       })}
       {/* Only show the "add a/another listing" link if there are less than the maximum amount of allowed listings OR the user is an admin*/}
-      {listings.length < MAX_LISTINGS || profile?.is_admin ? (
+      {listings.length < MAX_LISTINGS_PER_USER || profile?.is_admin ? (
         <li>
           {listings.length === 0 ? (
             <AddYourFirstListingLink href="/profile/listings/new">

--- a/src/config/listingLimits.ts
+++ b/src/config/listingLimits.ts
@@ -1,0 +1,2 @@
+export const MAX_LISTINGS_PER_USER = 12;
+export const MAX_RESIDENTIAL_LISTINGS_PER_USER = 3;

--- a/supabase/migrations/20260515061033_add_residential_listing_limit.sql
+++ b/supabase/migrations/20260515061033_add_residential_listing_limit.sql
@@ -1,0 +1,60 @@
+create or replace function public.count_user_listings_by_type(
+  _user_id uuid,
+  _listing_type text
+)
+returns integer
+language sql
+stable
+set search_path = public
+as $$
+  select count(*)::integer
+  from public.listings
+  where owner_id = _user_id
+    and type = _listing_type
+$$;
+
+create index if not exists listings_owner_id_type_idx
+on public.listings (owner_id, type);
+
+drop policy if exists "Users can create their own listings within limits" on public.listings;
+create policy "Users can create their own listings within limits"
+on public.listings
+for insert
+to authenticated
+with check (
+  owner_id = (select auth.uid())
+  and type = any (array['residential'::text, 'community'::text, 'business'::text])
+  and (
+    public.count_user_listings((select auth.uid())) < 12
+    or exists (
+      select 1
+      from public.profiles
+      where profiles.id = (select auth.uid())
+        and profiles.is_admin = true
+    )
+  )
+  and (
+    type <> 'residential'
+    or public.count_user_listings_by_type((select auth.uid()), 'residential') < 3
+    or exists (
+      select 1
+      from public.profiles
+      where profiles.id = (select auth.uid())
+        and profiles.is_admin = true
+    )
+  )
+  and (
+    coalesce(is_stub, false) = false
+    or exists (
+      select 1
+      from public.profiles
+      where profiles.id = (select auth.uid())
+        and profiles.is_admin = true
+    )
+  )
+);
+
+revoke all privileges on function public.count_user_listings_by_type(uuid, text)
+from anon, authenticated, public;
+grant execute on function public.count_user_listings_by_type(uuid, text)
+to authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -337,6 +337,44 @@ values
     false,
     false,
     '{}'::integer[]
+  ),
+  (
+    1007,
+    '9a0c62fc-bf50-4f45-ba6c-5b9051c2712a',
+    null,
+    'A hidden residential listing used to exercise residential listing limits locally.',
+    extensions.st_setsrid(extensions.st_makepoint(151.1790, -33.8990), 4326)::extensions.geography,
+    array['Fruit scraps', 'Coffee grounds'],
+    array['Meat', 'Dairy'],
+    array[]::text[],
+    array[]::text[],
+    false,
+    'residential',
+    null,
+    'AU',
+    'Newtown',
+    false,
+    false,
+    '{}'::integer[]
+  ),
+  (
+    1008,
+    '9a0c62fc-bf50-4f45-ba6c-5b9051c2712a',
+    null,
+    'A second hidden residential listing used to exercise residential listing limits locally.',
+    extensions.st_setsrid(extensions.st_makepoint(151.1792, -33.8992), 4326)::extensions.geography,
+    array['Fruit scraps', 'Tea leaves'],
+    array['Meat', 'Dairy'],
+    array[]::text[],
+    array[]::text[],
+    false,
+    'residential',
+    null,
+    'AU',
+    'Newtown',
+    false,
+    false,
+    '{}'::integer[]
   )
 on conflict (id) do update
 set
@@ -365,10 +403,12 @@ set slug = case id
   when 1004 then 'demo-tempe-share-shed'
   when 1005 then 'demo-stanmore-bakery'
   when 1006 then 'demo-camperdown-community-garden'
+  when 1007 then 'demo-hidden-newtown-worm-farm-one'
+  when 1008 then 'demo-hidden-newtown-worm-farm-two'
 end
-where id in (1001, 1002, 1003, 1004, 1005, 1006);
+where id in (1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008);
 
-select setval('public.listings_id_seq', 1006, true);
+select setval('public.listings_id_seq', 1008, true);
 
 insert into public.chat_threads (
   id,


### PR DESCRIPTION
## Summary

- keep the 12 total listing cap and add a 3 residential listing cap for non-admin users
- hide capped residential creation paths in the listing chooser while keeping direct form submissions protected by RLS
- update listing-limit copy so it no longer references “current three” listings
- add hidden seed fixtures and focused Playwright coverage for the capped residential chooser state

## Validation

- npm run check
- npm run typecheck
- NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331 NEXT_PUBLIC_SUPABASE_ANON_KEY=... npx playwright test e2e/listings.spec.ts -g "listing type chooser hides residential option"
- Applied the new migration SQL locally with psql and checked the key RLS cases in rollback transactions.

Note: `supabase migration up --local` is blocked by a pre-existing local migration history mismatch for remote migration `20260514043101`, so I validated this migration directly against the local database instead.
