### PR TITLE
harden media and unread RPC access

### DIFF
--- a/supabase/migrations/20260519013246_enforce_listing_photo_rpc_limit_and_unread_acl.sql
+++ b/supabase/migrations/20260519013246_enforce_listing_photo_rpc_limit_and_unread_acl.sql
@@ -1,0 +1,54 @@
+begin;
+
+create or replace function public.append_listing_photo(
+  p_listing_slug text,
+  p_photo text,
+  p_owner_id uuid
+)
+returns table (
+  id bigint,
+  photos text[]
+)
+language plpgsql
+set search_path = public
+as $$
+declare
+  updated_listing record;
+begin
+  update public.listings
+  set photos = array_append(coalesce(public.listings.photos, array[]::text[]), p_photo)
+  where public.listings.slug = p_listing_slug
+    and public.listings.owner_id = p_owner_id
+    and cardinality(coalesce(public.listings.photos, array[]::text[])) < 5
+  returning public.listings.id, public.listings.photos
+    into updated_listing;
+
+  if found then
+    return query select updated_listing.id, updated_listing.photos;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from public.listings
+    where listings.slug = p_listing_slug
+      and listings.owner_id = p_owner_id
+      and cardinality(coalesce(listings.photos, array[]::text[])) >= 5
+  ) then
+    raise exception 'max_photos_per_listing'
+      using errcode = '23514', constraint = 'max_photos_per_listing';
+  end if;
+end;
+$$;
+
+revoke all on function public.append_listing_photo(text, text, uuid)
+  from anon, authenticated, public;
+grant execute on function public.append_listing_photo(text, text, uuid)
+  to service_role;
+
+revoke all on function public.unread_chat_thread_ids(uuid[])
+  from public, anon;
+grant execute on function public.unread_chat_thread_ids(uuid[])
+  to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
## Summary

- add a forward Supabase migration that keeps listing photo appends within the five-photo cap at the RPC layer
- explicitly remove leftover PUBLIC/anon execute access from unread_chat_thread_ids while keeping authenticated and service_role access

## Why

PR #86 moved listing media updates through server-side RPCs, but the append helper could still append past the intended photo cap before the table check failed. The unread chat helper also still inherited PUBLIC execute from the default function ACL path.

## Validation

- supabase migration up --local
- SQL probe for append-under-limit and sixth-photo rejection
- ACL probe for unread_chat_thread_ids and append_listing_photo
- supabase db advisors --local --type security --level warn
- npm run check
- git diff --check