### PR TITLE
fix email character references

### DIFF
--- a/supabase/functions/_shared/email-character-references.ts
+++ b/supabase/functions/_shared/email-character-references.ts
@@ -1,0 +1,6 @@
+export const encodeEmailHtmlCharacterReferences = (html: string) =>
+  html.replace(/[^\x00-\x7F]/gu, (character) => {
+    const codePoint = character.codePointAt(0);
+
+    return codePoint ? `&#${codePoint};` : character;
+  });

--- a/supabase/functions/_shared/email-html.ts
+++ b/supabase/functions/_shared/email-html.ts
@@ -1,0 +1,13 @@
+import { render } from "npm:@react-email/render";
+import type { ReactElement } from "npm:react";
+import { encodeEmailHtmlCharacterReferences } from "./email-character-references.ts";
+
+export { encodeEmailHtmlCharacterReferences };
+
+export const renderEmailHtml = async (email: ReactElement) =>
+  encodeEmailHtmlCharacterReferences(await render(email));
+
+export const renderEmailText = (email: ReactElement) =>
+  render(email, {
+    plainText: true,
+  });

--- a/supabase/functions/send-email-for-auth-action/index.ts
+++ b/supabase/functions/send-email-for-auth-action/index.ts
@@ -12,6 +12,7 @@ import { InviteEmail } from "../_templates/invite-email.tsx";
 import { ReauthenticationEmail } from "../_templates/reauthentication-email.tsx";
 import { renderAsync } from "npm:@react-email/components@0.0.22";
 import { getAuthEmailCopy, resolveEmailLocale } from "../_shared/i18n.ts";
+import { encodeEmailHtmlCharacterReferences } from "../_shared/email-character-references.ts";
 
 declare const EdgeRuntime: {
   waitUntil: (promise: Promise<unknown>) => void;
@@ -75,6 +76,9 @@ const json = (status: number, body: Record<string, unknown>) =>
 
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0;
+
+const renderAuthEmailHtml = async (email: React.ReactElement) =>
+  encodeEmailHtmlCharacterReferences(await renderAsync(email));
 
 const toErrorShape = (error: unknown) => {
   if (error && typeof error === "object") {
@@ -174,7 +178,7 @@ const prepareEmail = async (
     return {
       to: userEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(ResetPasswordEmail, {
           locale,
           supabase_url: supabaseUrl,
@@ -202,7 +206,7 @@ const prepareEmail = async (
     return {
       to: userEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(SignUpEmail, {
           email: userEmail,
           firstName,
@@ -240,7 +244,7 @@ const prepareEmail = async (
     return {
       to: userNewEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(EmailChangeEmail, {
           email: userEmail,
           newEmail: userNewEmail,
@@ -272,7 +276,7 @@ const prepareEmail = async (
     return {
       to: userEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(MagicLinkEmail, {
           locale,
           supabase_url: supabaseUrl,
@@ -300,7 +304,7 @@ const prepareEmail = async (
     return {
       to: userEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(InviteEmail, {
           locale,
           supabase_url: supabaseUrl,
@@ -328,7 +332,7 @@ const prepareEmail = async (
     return {
       to: userEmail,
       subject: copy.subject,
-      html: await renderAsync(
+      html: await renderAuthEmailHtml(
         React.createElement(ReauthenticationEmail, {
           locale,
           token,
@@ -350,7 +354,7 @@ const prepareEmail = async (
   return {
     to: userEmail,
     subject: copy.genericSubject,
-    html: await renderAsync(
+    html: await renderAuthEmailHtml(
       React.createElement(ReauthenticationEmail, {
         locale,
         token,

--- a/supabase/functions/send-email-for-new-chat-message/index.ts
+++ b/supabase/functions/send-email-for-new-chat-message/index.ts
@@ -4,8 +4,7 @@ import { Resend } from "npm:resend";
 import { NewChatMessageEmail } from "../_templates/new-chat-message-email.tsx";
 import { getChatEmailCopy, resolveEmailLocale } from "../_shared/i18n.ts";
 import { isMissingPreferredLocaleColumn } from "../_shared/postgrest.ts";
-// Temporarily required, see below PR comment
-import { render } from "npm:@react-email/render";
+import { renderEmailHtml, renderEmailText } from "../_shared/email-html.ts";
 
 // Look up required env variables and API keys from Supabase secrets
 const generalEmailAddress = Deno.env.get("GENERAL_EMAIL_ADDRESS");
@@ -223,50 +222,30 @@ const handler = async (_request: Request): Promise<Response> => {
       preferredLocale: recipientProfile?.preferred_locale,
     });
     const copy = getChatEmailCopy(locale);
+    const email = NewChatMessageEmail({
+      locale,
+      senderName,
+      recipientName,
+      // messageContent: record.content,
+      threadId: threadData.id,
+      listingSlug,
+      listingAreaName,
+      recipientRole,
+      listingName,
+      listingType,
+      ownerHasMultipleNonResidentialListings,
+      avatarMajorUrl: avatarMajorUrl || undefined,
+      avatarMajorBucket: avatarMajorBucket || undefined,
+      avatarMinorUrl: avatarMinorUrl || undefined,
+    });
 
     // Prepare and send Resend email via React Email
     const { data, error } = await resend.emails.send({
       from: `Peels <${generalEmailAddress}>`,
       to: [recipientEmail],
       subject: copy.subject.replace("{senderName}", senderName),
-      react: NewChatMessageEmail({
-        locale,
-        senderName,
-        recipientName,
-        // messageContent: record.content,
-        threadId: threadData.id,
-        listingSlug,
-        listingAreaName,
-        recipientRole,
-        listingName,
-        listingType,
-        ownerHasMultipleNonResidentialListings,
-        avatarMajorUrl: avatarMajorUrl || undefined,
-        avatarMajorBucket: avatarMajorBucket || undefined,
-        avatarMinorUrl: avatarMinorUrl || undefined,
-      }),
-      // Plain text version
-      // Can be removed once this PR is merged
-      // https://github.com/resend/resend-node/pull/469#issue-2871291956
-      text: await render(
-        NewChatMessageEmail({
-          locale,
-          senderName,
-          recipientName,
-          // messageContent: record.content,
-          threadId: threadData.id,
-          listingSlug,
-          listingAreaName,
-          recipientRole,
-          listingName,
-          listingType,
-          ownerHasMultipleNonResidentialListings,
-          avatarMajorUrl: avatarMajorUrl || undefined,
-          avatarMajorBucket: avatarMajorBucket || undefined,
-          avatarMinorUrl: avatarMinorUrl || undefined,
-        }),
-        { plainText: true }
-      ),
+      html: await renderEmailHtml(email),
+      text: await renderEmailText(email),
     });
 
     if (error) {

--- a/supabase/functions/send-email-for-new-feature/index.ts
+++ b/supabase/functions/send-email-for-new-feature/index.ts
@@ -2,10 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "npm:resend";
 import { NewFeatureEmail } from "../_templates/new-feature-email.tsx";
-// Temporarily required for rendering a text version
-// The `react` email sending method does not yet supports text version
-// https://github.com/resend/resend-node/pull/469
-import { render } from "npm:@react-email/render";
+import { renderEmailHtml, renderEmailText } from "../_shared/email-html.ts";
 
 // Look up required env variables and API keys from Supabase secrets
 const generalEmailAddress = Deno.env.get("GENERAL_EMAIL_ADDRESS");
@@ -78,22 +75,17 @@ const handler = async (_request: Request): Promise<Response> => {
         //   `TEST MODE: Would email ${userEmail}, but sending to ${testEmail} instead`,
         // );
 
+        const email = NewFeatureEmail({
+          recipientName: profile.first_name || "there",
+        });
+
         const { data, error } = await resend.emails.send({
           from: `Peels <${generalEmailAddress}>`,
           // to: [testEmail], // Send to yourself instead of userEmail
           to: [userEmail],
           subject: "An update to Peels",
-          react: NewFeatureEmail({
-            recipientName: profile.first_name || "there",
-          }),
-          text: await render(
-            NewFeatureEmail({
-              recipientName: profile.first_name || "there",
-            }),
-            {
-              plainText: true,
-            }
-          ),
+          html: await renderEmailHtml(email),
+          text: await renderEmailText(email),
           headers: {
             "List-Unsubscribe": "<https://www.peels.app/profile>",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click", // Required for deliverability, even if irrelevant

--- a/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-resend-audience/index.ts
@@ -5,10 +5,7 @@ import {
   getNewsletterAudienceConfigs,
   getNewsletterEmailSubject,
 } from "../_shared/newsletter.ts";
-// Temporarily required for rendering a text version
-// The `react` email sending method does not yet supports text version
-// https://github.com/resend/resend-node/pull/469
-import { render } from "npm:@react-email/render";
+import { renderEmailHtml, renderEmailText } from "../_shared/email-html.ts";
 
 const newsletterEmailAddress = Deno.env.get("NEWSLETTER_EMAIL_ADDRESS");
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
@@ -39,14 +36,16 @@ const handler = async (_request: Request): Promise<Response> => {
         recipientName: "there",
         externalAudience: true,
       });
+      const html = await renderEmailHtml(reactEmail);
+      const text = await renderEmailText(textEmail);
 
       const { data: broadcast, error: broadcastError } =
         await resend.broadcasts.create({
           audienceId,
           from: `Danny from Peels <${newsletterEmailAddress}>`,
           subject: getNewsletterEmailSubject(locale),
-          react: reactEmail,
-          text: await render(textEmail, { plainText: true }),
+          html,
+          text,
           headers: {
             "List-Unsubscribe": "{{{RESEND_UNSUBSCRIBE_URL}}}",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",

--- a/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
+++ b/supabase/functions/send-email-for-newsletter-issue-supabase-users/index.ts
@@ -7,10 +7,7 @@ import {
   resolveNewsletterLocale,
 } from "../_shared/newsletter.ts";
 import { isMissingPreferredLocaleColumn } from "../_shared/postgrest.ts";
-// Temporarily required for rendering a text version
-// The `react` email sending method does not yet supports text version
-// https://github.com/resend/resend-node/pull/469
-import { render } from "npm:@react-email/render";
+import { renderEmailHtml, renderEmailText } from "../_shared/email-html.ts";
 
 // Look up required API keys from Supabase secrets
 const newsletterEmailAddress = Deno.env.get("NEWSLETTER_EMAIL_ADDRESS");
@@ -128,6 +125,8 @@ const handler = async (_request: Request): Promise<Response> => {
           recipientName: profile.first_name || "there",
           externalAudience: false,
         });
+        const html = await renderEmailHtml(email);
+        const text = await renderEmailText(email);
 
         // Add delay to respect rate limit (at most 2 per second)
         await new Promise((resolve) => setTimeout(resolve, 750));
@@ -144,10 +143,8 @@ const handler = async (_request: Request): Promise<Response> => {
           from: `Danny from Peels <${newsletterEmailAddress}>`,
           to: [recipientEmail],
           subject: getNewsletterEmailSubject(locale),
-          react: email,
-          text: await render(email, {
-            plainText: true,
-          }),
+          html,
+          text,
           headers: {
             "List-Unsubscribe": "<https://www.peels.app/profile>",
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click", // Required for deliverability, even if irrelevant


### PR DESCRIPTION
## Summary

- Render outgoing React email HTML before handing it to Resend.
- Encode non-ASCII characters in HTML output as numeric character references so typographic punctuation does not cross the email path as raw UTF-8 bytes.
- Keep source copy and plain-text email output using proper typographic punctuation.

## Testing

- npm run check
- Rendered newsletter probe confirmed the HTML has no raw non-ASCII bytes, contains &#8217; for smart apostrophes, and the plain-text alternative still keeps ’.

fixes issue #11
