### PR TITLE
fix newsletter image dark mode

### DIFF
--- a/supabase/functions/_templates/components/EmailImage.tsx
+++ b/supabase/functions/_templates/components/EmailImage.tsx
@@ -42,6 +42,7 @@ const imgSectionWithMargin = {
 };
 
 const imgContainer = {
+  backgroundColor: assignments.colors.background.top,
   boxShadow: `0 0 0 2px ${assignments.colors.border.elevated} inset`, // Matches gallery, Apple Mail only
   borderRadius: 9, // 1px more than img
   border: `1px solid ${assignments.colors.border.elevated}`,
@@ -49,7 +50,6 @@ const imgContainer = {
 
 const img = {
   margin: 0,
-  mixBlendMode: "multiply", // So boxShadow on parent is visible in email clients that support it
   width: "100%",
   borderRadius: 8, // Should ideally match theme.corners.thumbnail (6px),
   objectFit: "cover",

--- a/supabase/functions/_templates/components/EmailImageSixUp.tsx
+++ b/supabase/functions/_templates/components/EmailImageSixUp.tsx
@@ -77,6 +77,7 @@ export default EmailImageSixUp;
 
 const imgContainer = {
   margin: "40px 0",
+  backgroundColor: assignments.colors.background.top,
   boxShadow: `0 0 0 2px ${assignments.colors.border.elevated} inset`, // Matches gallery, Apple Mail only
   borderRadius: 9, // 1px more than img
   border: `1px solid ${assignments.colors.border.elevated}`,
@@ -84,7 +85,6 @@ const imgContainer = {
 
 const img = {
   margin: 0,
-  mixBlendMode: "multiply", // So boxShadow on parent is visible in email clients that support it
   width: "100%",
   borderRadius: 8,
   objectFit: "cover",


### PR DESCRIPTION
## Summary

- Removes `mixBlendMode: "multiply"` from shared newsletter image styles so forced dark mode clients do not dim photos as aggressively.
- Adds an explicit light background to newsletter image wrappers so Gmail and Outlook iOS have a stable fill behind images.

Fixes issue #10 (Fixes #10).

## Validation

- Rendered `NewsletterIssueOneEmail` locally: `imageCount: 9`, `mixBlendModeCount: 0`, `backgroundCount: 9`.
- `npm run format:check`
- `npm run check`
- `npm run typecheck`
- `npm run build`
