### PR TITLE
fix map search bounds

### DIFF
--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -73,6 +73,25 @@ async function readStoredMapViewCookie(page: Page) {
     : null;
 }
 
+async function mockMapTilerIpCountry(page: Page, countryCode: string) {
+  await page.route(/api\.maptiler\.com\/geolocation/i, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        country_code: countryCode,
+        latitude: 19.4326,
+        longitude: -99.1332,
+      }),
+    });
+  });
+}
+
+function parseNumberParam(url: URL, name: string) {
+  const value = url.searchParams.get(name);
+  return value ? value.split(",").map(Number) : null;
+}
+
 function roundCookieExpectation(value: number) {
   const roundedValue = Number(value.toFixed(2));
   return Object.is(roundedValue, -0) ? 0 : roundedValue;
@@ -322,6 +341,129 @@ test("map search palette flies to a picked geocoding result", async ({
       { timeout: 5000 }
     )
     .toBeCloseTo(-33.8985, 1);
+});
+
+test("map search is bounded by the current map instead of IP country", async ({
+  page,
+}) => {
+  const geocodingRequests: URL[] = [];
+  const feature = createMockGeocodingFeature({
+    text: "Newtown",
+    placeName: "Newtown, New South Wales, Australia",
+    center: [151.1781, -33.8985],
+  });
+
+  await seedStoredMapView(page, INNER_WEST_MAP_VIEW);
+  await mockMapTilerIpCountry(page, "MX");
+  await page.route("**/geocoding/**", async (route) => {
+    geocodingRequests.push(new URL(route.request().url()));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        type: "FeatureCollection",
+        query: [],
+        features: [feature],
+        attribution: "Mock MapTiler geocoding",
+      }),
+    });
+  });
+
+  try {
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByTestId("map-view").locator(".maplibregl-canvas")
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByTestId("map-control-search").click();
+    await page.getByTestId("geocoding-search-input").fill("Newtown");
+    await expect(page.getByRole("option", { name: /Newtown/ })).toBeVisible();
+
+    expect(geocodingRequests).toHaveLength(1);
+    const [boundedRequest] = geocodingRequests;
+    expect(boundedRequest.searchParams.get("country")).toBeNull();
+    expect(boundedRequest.searchParams.get("proximity")).not.toBe("ip");
+
+    const proximity = parseNumberParam(boundedRequest, "proximity");
+    expect(proximity).not.toBeNull();
+    expect(proximity?.[0]).toBeCloseTo(INNER_WEST_MAP_VIEW.longitude, 1);
+    expect(proximity?.[1]).toBeCloseTo(INNER_WEST_MAP_VIEW.latitude, 1);
+
+    const bbox = parseNumberParam(boundedRequest, "bbox");
+    expect(bbox).not.toBeNull();
+    if (!bbox) throw new Error("Expected map search request to include bbox");
+    const [west, south, east, north] = bbox;
+    expect(west).toBeLessThan(INNER_WEST_MAP_VIEW.longitude);
+    expect(east).toBeGreaterThan(INNER_WEST_MAP_VIEW.longitude);
+    expect(south).toBeLessThan(INNER_WEST_MAP_VIEW.latitude);
+    expect(north).toBeGreaterThan(INNER_WEST_MAP_VIEW.latitude);
+  } finally {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  }
+});
+
+test("map search retries without bounds when the bounded search is empty", async ({
+  page,
+}) => {
+  const geocodingRequests: URL[] = [];
+  const fallbackFeature = createMockGeocodingFeature({
+    id: "place.fallback",
+    text: "Melbourne",
+    placeName: "Melbourne, Victoria, Australia",
+    center: [144.9631, -37.8136],
+  });
+
+  await seedStoredMapView(page, INNER_WEST_MAP_VIEW);
+  await mockMapTilerIpCountry(page, "MX");
+  await page.route("**/geocoding/**", async (route) => {
+    const url = new URL(route.request().url());
+    geocodingRequests.push(url);
+    const isBoundedRequest = url.searchParams.has("bbox");
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        type: "FeatureCollection",
+        query: [],
+        features: isBoundedRequest ? [] : [fallbackFeature],
+        attribution: "Mock MapTiler geocoding",
+      }),
+    });
+  });
+
+  try {
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByTestId("map-view").locator(".maplibregl-canvas")
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByTestId("map-control-search").click();
+    await page.getByTestId("geocoding-search-input").fill("Melbourne");
+    await page.getByRole("option", { name: /Melbourne/ }).click();
+
+    expect(geocodingRequests).toHaveLength(2);
+    expect(geocodingRequests[0].searchParams.has("bbox")).toBe(true);
+    expect(geocodingRequests[1].searchParams.has("bbox")).toBe(false);
+    expect(geocodingRequests[1].searchParams.get("country")).toBeNull();
+    expect(geocodingRequests[1].searchParams.get("proximity")).not.toBe("ip");
+
+    await expect
+      .poll(
+        async () => {
+          const storedView = await readStoredMapView(page);
+          return storedView?.latitude ?? null;
+        },
+        { timeout: 5000 }
+      )
+      .toBeCloseTo(-37.8136, 1);
+  } finally {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  }
 });
 
 test("map pins minify at country zoom, then grow and animate selection", async ({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,13 +158,74 @@ html.map {
   margin: 0rem 0rem 0 0;
 }
 
+.maplibregl-ctrl-attrib {
+  color: var(--color-text-ui-tertiary) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--color-bg-top),
+    transparent 12%
+  ) !important;
+  border: 1px solid var(--color-border-base);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+.maplibregl-ctrl.maplibregl-ctrl-attrib,
+.maplibregl-ctrl-attrib.maplibregl-compact,
+.maplibregl-ctrl-attrib.maplibregl-compact-show,
+.maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-inner {
+  color: var(--color-text-ui-tertiary) !important;
+}
+
+.maplibregl-ctrl-attrib a {
+  color: inherit !important;
+  text-decoration-line: underline !important;
+  text-decoration-color: transparent !important;
+  text-underline-offset: 0.12em;
+  transition: text-decoration-color 140ms ease;
+}
+
+.maplibregl-ctrl-attrib a:hover,
+.maplibregl-ctrl-attrib a:focus-visible {
+  text-decoration-color: color-mix(
+    in srgb,
+    currentColor,
+    transparent 45%
+  ) !important;
+}
+
 /* Misc */
 summary.maplibregl-ctrl-attrib-button {
   opacity: 0.24;
+  background-color: transparent !important;
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E") !important;
 
   &:hover {
     opacity: 1;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .maplibregl-ctrl-attrib {
+    color: var(--color-text-ui-quaternary) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--color-bg-sunk),
+      transparent 18%
+    ) !important;
+    border-color: var(--color-border-base);
+    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.24);
+  }
+
+  .maplibregl-ctrl.maplibregl-ctrl-attrib,
+  .maplibregl-ctrl-attrib.maplibregl-compact,
+  .maplibregl-ctrl-attrib.maplibregl-compact-show,
+  .maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-inner {
+    color: var(--color-text-ui-quaternary) !important;
+  }
+
+  summary.maplibregl-ctrl-attrib-button {
+    filter: invert(1);
+    opacity: 0.44;
   }
 }
 

--- a/src/features/map/components/GeocodingSearch.tsx
+++ b/src/features/map/components/GeocodingSearch.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import { X } from "lucide-react";
 import { css, styled } from "next-yak";
-import type { GeocodingFeature, Position } from "@maptiler/client";
+import type { BBox, GeocodingFeature, Position } from "@maptiler/client";
 
 import { theme } from "@/styles/theme.yak";
 import {
@@ -34,6 +34,7 @@ type GeocodingSearchProps = {
   ariaLabelledBy?: string;
   ariaInvalid?: "true" | "false";
   autoFocus?: boolean;
+  bbox?: BBox;
   clearLabel: string;
   countryCode?: string | null;
   error?: string;
@@ -233,6 +234,7 @@ const GeocodingSearch = forwardRef<GeocodingSearchHandle, GeocodingSearchProps>(
       ariaLabelledBy,
       ariaInvalid,
       autoFocus,
+      bbox,
       clearLabel,
       countryCode,
       error,
@@ -263,6 +265,7 @@ const GeocodingSearch = forwardRef<GeocodingSearchHandle, GeocodingSearchProps>(
     const showResults = hasSearchableQuery && canShowResults;
     const { features, isError, isLoading, isReady } = useGeocodingSearch({
       query,
+      bbox,
       countryCode,
       enabled: showResults,
       proximity,

--- a/src/features/map/components/MapPageClient.tsx
+++ b/src/features/map/components/MapPageClient.tsx
@@ -68,7 +68,7 @@ export default function MapPageClient({
     closeListing,
   } = useMapListingUrl({ user, initialListingSlug, initialListing });
 
-  const { initialCoordinates, countryCode } = useIpInitialLocation({
+  const { initialCoordinates } = useIpInitialLocation({
     initialCoordinates: initialMapCoordinates,
     skip: Boolean(initialListingSlug),
   });
@@ -140,7 +140,6 @@ export default function MapPageClient({
             onMapClick={handleMapClick}
             onMarkerClick={handleMarkerClick}
             isDesktop={isDesktop}
-            countryCode={countryCode}
           />
 
           <MapListingDrawerPanel

--- a/src/features/map/components/MapSearch.tsx
+++ b/src/features/map/components/MapSearch.tsx
@@ -4,16 +4,21 @@ import * as Dialog from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useTranslations } from "next-intl";
 import { keyframes, styled } from "next-yak";
-import type { GeocodingFeature } from "@maptiler/client";
+import type { BBox, GeocodingFeature, Position } from "@maptiler/client";
 
 import { theme } from "@/styles/theme.yak";
 import GeocodingSearch from "./GeocodingSearch";
 
 type MapSearchProps = {
-  countryCode?: string | null;
+  searchContext: MapSearchContext | null;
   onOpenChange: (open: boolean) => void;
   onPick: (feature: GeocodingFeature) => void;
   open: boolean;
+};
+
+export type MapSearchContext = {
+  bbox?: BBox;
+  proximity: Position;
 };
 
 const overlayEnter = keyframes`
@@ -116,10 +121,10 @@ const DialogContent = styled(Dialog.Content)`
 `;
 
 export default function MapSearch({
-  countryCode,
   onOpenChange,
   onPick,
   open,
+  searchContext,
 }: MapSearchProps) {
   const mapT = useTranslations("Map");
 
@@ -135,8 +140,8 @@ export default function MapSearch({
           <GeocodingSearch
             ariaLabel={mapT("searchDialogTitle")}
             autoFocus={true}
+            bbox={searchContext?.bbox}
             clearLabel={mapT("searchClear")}
-            countryCode={countryCode}
             errorMessage={mapT("searchError")}
             loadingMessage={mapT("searchLoading")}
             noResultsMessage={mapT("searchNoResults")}
@@ -145,7 +150,7 @@ export default function MapSearch({
               onOpenChange(false);
             }}
             placeholder={mapT("searchPlaceholder")}
-            proximity="ip"
+            proximity={searchContext?.proximity}
             variant="palette"
           />
         </DialogContent>

--- a/src/features/map/components/MapView.tsx
+++ b/src/features/map/components/MapView.tsx
@@ -12,7 +12,7 @@ import Map, {
   type MapLayerMouseEvent,
 } from "react-map-gl/maplibre";
 import type { LngLatBounds } from "maplibre-gl";
-import type { GeocodingFeature } from "@maptiler/client";
+import type { BBox, GeocodingFeature, Position } from "@maptiler/client";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useLocale, useTranslations } from "next-intl";
 import { styled } from "next-yak";
@@ -21,7 +21,7 @@ import Button from "@/components/Button";
 import type { ListingMarker, SelectedListing } from "@/types/listing";
 
 import MapPinLayer from "./MapPinLayer";
-import MapSearch from "./MapSearch";
+import MapSearch, { type MapSearchContext } from "./MapSearch";
 import MapControls from "./MapControls";
 import {
   MAP_MAX_ZOOM,
@@ -29,6 +29,7 @@ import {
   ZOOM_LEVEL_SELECTED,
   getListingCoordinates,
   hasValidCoordinates,
+  padBounds,
   wrapLongitude,
 } from "../lib/mapUtils";
 import { useListingsInView } from "../hooks/useListingsInView";
@@ -51,7 +52,6 @@ type MapViewProps = {
   onMapClick: () => void;
   onMarkerClick: (listing: ListingMarker) => void;
   isDesktop: boolean;
-  countryCode: string | null;
 };
 
 const MapContainer = styled.div`
@@ -114,6 +114,7 @@ const PIN_HALO_MIN_SCALE = 0.18;
 const PIN_HALO_FULL_ZOOM = MAP_MAX_ZOOM;
 const PIN_HALO_GROWTH_EXPONENT = 2.2;
 const MAP_ZOOM_DISABLED_EPSILON = 0.001;
+const SEARCH_BOUNDS_PAD_FACTOR = 0.5;
 
 type MapPinZoomStyle = CSSProperties & {
   "--map-pin-compact-scale": string;
@@ -172,6 +173,45 @@ function isMapZoomAtMax(zoom: number) {
   return zoom >= MAP_MAX_ZOOM - MAP_ZOOM_DISABLED_EPSILON;
 }
 
+function areNumberArraysEqual(
+  first: readonly number[] | undefined,
+  second: readonly number[] | undefined
+) {
+  if (!first || !second) return first === second;
+  if (first.length !== second.length) return false;
+
+  return first.every((value, index) => value === second[index]);
+}
+
+function areSearchContextsEqual(
+  first: MapSearchContext | null,
+  second: MapSearchContext | null
+) {
+  if (!first || !second) return first === second;
+
+  return (
+    areNumberArraysEqual(first.bbox, second.bbox) &&
+    areNumberArraysEqual(first.proximity, second.proximity)
+  );
+}
+
+function resolveMapSearchContext(bounds: LngLatBounds): MapSearchContext {
+  const center = bounds.getCenter();
+  const paddedBoxes = padBounds(bounds, SEARCH_BOUNDS_PAD_FACTOR);
+  const bbox: BBox | undefined =
+    paddedBoxes.length === 1
+      ? [
+          paddedBoxes[0].west,
+          paddedBoxes[0].south,
+          paddedBoxes[0].east,
+          paddedBoxes[0].north,
+        ]
+      : undefined;
+  const proximity: Position = [wrapLongitude(center.lng), center.lat];
+
+  return { bbox, proximity };
+}
+
 function resolveInitialViewState(
   selectedListing: SelectedListing | null,
   initialCoordinates: InitialMapCoordinates | null
@@ -204,7 +244,6 @@ export default function MapView({
   onMapClick,
   onMarkerClick,
   isDesktop,
-  countryCode,
 }: MapViewProps) {
   const t = useTranslations("Map");
   const locale = useLocale();
@@ -212,6 +251,9 @@ export default function MapView({
   const mapRef = useRef<MapRef | null>(null);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchContext, setSearchContext] = useState<MapSearchContext | null>(
+    null
+  );
   const [userCoordinates, setUserCoordinates] = useState<{
     latitude: number;
     longitude: number;
@@ -266,6 +308,16 @@ export default function MapView({
     },
     [requestBounds]
   );
+
+  const syncSearchContext = useCallback((bounds: LngLatBounds) => {
+    const nextSearchContext = resolveMapSearchContext(bounds);
+
+    setSearchContext((currentSearchContext) =>
+      areSearchContextsEqual(currentSearchContext, nextSearchContext)
+        ? currentSearchContext
+        : nextSearchContext
+    );
+  }, []);
 
   const syncZoomControlState = useCallback((zoom: number) => {
     const nextIsZoomInDisabled = isMapZoomAtMax(zoom);
@@ -344,10 +396,17 @@ export default function MapView({
 
     applyMapPinZoomVariables(map.getZoom());
     syncZoomControlState(map.getZoom());
-    emitBoundsChange(map.getBounds());
+    const bounds = map.getBounds();
+    emitBoundsChange(bounds);
+    syncSearchContext(bounds);
 
     return map;
-  }, [applyMapPinZoomVariables, emitBoundsChange, syncZoomControlState]);
+  }, [
+    applyMapPinZoomVariables,
+    emitBoundsChange,
+    syncSearchContext,
+    syncZoomControlState,
+  ]);
 
   const handleLoad = useCallback(() => {
     handleMapLoad();
@@ -427,10 +486,17 @@ export default function MapView({
       if (!map) return;
 
       scheduleStoredMapViewSave();
-      emitBoundsChange(map.getBounds());
+      const bounds = map.getBounds();
+      emitBoundsChange(bounds);
+      syncSearchContext(bounds);
       handleMapMoveEnd();
     },
-    [emitBoundsChange, handleMapMoveEnd, scheduleStoredMapViewSave]
+    [
+      emitBoundsChange,
+      handleMapMoveEnd,
+      scheduleStoredMapViewSave,
+      syncSearchContext,
+    ]
   );
 
   const handleMapClickInternal = useCallback(
@@ -557,7 +623,7 @@ export default function MapView({
           />
           <MapSearch
             onPick={handleSearchPick}
-            countryCode={countryCode}
+            searchContext={searchContext}
             open={isSearchOpen}
             onOpenChange={setIsSearchOpen}
           />

--- a/src/features/map/hooks/useGeocodingSearch.ts
+++ b/src/features/map/hooks/useGeocodingSearch.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import {
   geocoding,
+  type BBox,
   type GeocodingFeature,
   type GeocodingPlaceType,
   type Position,
@@ -22,6 +23,7 @@ type GeocodingSearchStatus = "idle" | "loading" | "success" | "error";
 
 type UseGeocodingSearchOptions = {
   query: string;
+  bbox?: BBox;
   countryCode?: string | null;
   proximity?: Position | "ip";
   enabled?: boolean;
@@ -32,6 +34,7 @@ type UseGeocodingSearchOptions = {
 
 export function useGeocodingSearch({
   query,
+  bbox,
   countryCode,
   proximity,
   enabled = true,
@@ -74,11 +77,32 @@ export function useGeocodingSearch({
         .forward(trimmedQuery, {
           apiKey,
           autocomplete: true,
+          bbox,
           country: countryCode ? [countryCode] : undefined,
           fuzzyMatch: true,
           limit,
           proximity,
           types: MAP_GEOCODING_TYPES,
+        })
+        .then(async (result) => {
+          if (
+            result.features.length > 0 ||
+            !bbox ||
+            cancelled ||
+            requestIdRef.current !== requestId
+          ) {
+            return result;
+          }
+
+          return geocoding.forward(trimmedQuery, {
+            apiKey,
+            autocomplete: true,
+            country: countryCode ? [countryCode] : undefined,
+            fuzzyMatch: true,
+            limit,
+            proximity,
+            types: MAP_GEOCODING_TYPES,
+          });
         })
         .then((result) => {
           if (cancelled || requestIdRef.current !== requestId) return;
@@ -102,7 +126,16 @@ export function useGeocodingSearch({
       }
       window.clearTimeout(timeout);
     };
-  }, [countryCode, debounceMs, enabled, limit, minLength, proximity, query]);
+  }, [
+    bbox,
+    countryCode,
+    debounceMs,
+    enabled,
+    limit,
+    minLength,
+    proximity,
+    query,
+  ]);
 
   return {
     features,

--- a/src/features/map/lib/protomapsStyle.ts
+++ b/src/features/map/lib/protomapsStyle.ts
@@ -47,7 +47,7 @@ export function createProtomapsStyle({
         maxzoom: MAP_MAX_ZOOM,
         tiles: [tileUrl],
         attribution:
-          '<a href="https://protomaps.com">Protomaps</a> • <a href="https://osm.org/copyright">OpenStreetMap</a>',
+          '<a href="https://protomaps.com" target="_blank" rel="noopener noreferrer">Protomaps</a> • <a href="https://osm.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a>',
       },
     },
     layers: layers("protomaps", namedFlavor(flavorName), {

--- a/src/features/map/lib/protomapsStyle.ts
+++ b/src/features/map/lib/protomapsStyle.ts
@@ -47,7 +47,7 @@ export function createProtomapsStyle({
         maxzoom: MAP_MAX_ZOOM,
         tiles: [tileUrl],
         attribution:
-          '<a href="https://protomaps.com">Protomaps</a> | <a href="https://osm.org/copyright">OpenStreetMap</a>',
+          '<a href="https://protomaps.com">Protomaps</a> • <a href="https://osm.org/copyright">OpenStreetMap</a>',
       },
     },
     layers: layers("protomaps", namedFlavor(flavorName), {


### PR DESCRIPTION
## Summary

- bias /map geocoding search to the current padded map bounds instead of the user's IP country
- retry search without bounds when the bounded search returns no results
- restyle MapLibre attribution for dark mode and update the separator to a bullet

## Testing

- npm run check
- git diff --check
