### PR TITLE
flip canonical SEO origin to peels.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # The site URL should be localhost for development, and the canonical domain for production
 # Development: http://localhost:3000
-# Production during the dual-host period: https://www.peels.app
+# Production canonical domain: https://www.peels.org
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # Local-first Supabase workflow:

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -4,9 +4,9 @@ import { DONOR_EMAIL, SEEDED_THREAD_ID, signIn } from "./helpers";
 const LISTING_PATH = "/listings/demo-marrickville-compost";
 const MAP_LISTING_PATH = "/map?listing=demo-marrickville-compost";
 const RESIDENTIAL_LISTING_PATH = "/listings/demo-newtown-worm-farm";
-const SITE_URL = "https://www.peels.app";
+const SITE_URL = "https://www.peels.org";
 const DEFAULT_OG_IMAGE_PATTERN =
-  /^https:\/\/www\.peels\.app\/opengraph-image\.jpg/;
+  /^https:\/\/www\.peels\.org\/opengraph-image\.jpg/;
 
 async function getMetaDescription(page: import("@playwright/test").Page) {
   return page.locator('head meta[name="description"]').getAttribute("content");
@@ -205,7 +205,7 @@ test("public listing pages expose crawlable listing metadata", async ({
   const listingJsonLd = parseJsonLdScripts(jsonLdScripts).find(
     (data) =>
       data["@id"] ===
-      "https://www.peels.app/listings/demo-marrickville-compost#webpage"
+      "https://www.peels.org/listings/demo-marrickville-compost#webpage"
   );
   expect(listingJsonLd?.about?.additionalProperty).toEqual(
     expect.arrayContaining([
@@ -263,7 +263,7 @@ test("anonymous residential listing pages expose indexable public content withou
   const listingJsonLd = parseJsonLdScripts(jsonLdScripts).find(
     (data) =>
       data["@id"] ===
-      "https://www.peels.app/listings/demo-newtown-worm-farm#webpage"
+      "https://www.peels.org/listings/demo-newtown-worm-farm#webpage"
   );
 
   expect(listingJsonLd).toEqual(
@@ -317,7 +317,7 @@ test("public listing pages localise Spanish SEO metadata", async ({
     const listingJsonLd = parseJsonLdScripts(jsonLdScripts).find(
       (data) =>
         data["@id"] ===
-        "https://www.peels.app/listings/demo-marrickville-compost#webpage"
+        "https://www.peels.org/listings/demo-marrickville-compost#webpage"
     );
     expect(listingJsonLd?.about?.additionalProperty).toEqual(
       expect.arrayContaining([
@@ -537,5 +537,5 @@ test("robots.txt allows crawling and advertises the sitemap", async ({
 
   const robots = await response.text();
   expect(robots).toContain("Allow: /");
-  expect(robots).toContain("Sitemap: https://www.peels.app/sitemap.xml");
+  expect(robots).toContain("Sitemap: https://www.peels.org/sitemap.xml");
 });

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Peels",
   description: "Find a home for your food scraps, wherever you are.",
-  url: "https://www.peels.app",
+  url: "https://www.peels.org",
   repoUrl: "https://github.com/dnywh/peels",
   links: {
     about: "/",

--- a/src/utils/listingUtils.test.ts
+++ b/src/utils/listingUtils.test.ts
@@ -150,8 +150,8 @@ test("listing metadata uses the listing name with the site title template", () =
 test("root metadata canonical matches the sitemap homepage URL", () => {
   const metadata = createPeelsMetadata({ canonicalPath: "/" });
 
-  assert.equal(metadata.alternates?.canonical, "https://www.peels.app");
-  assert.equal(metadata.openGraph?.url, "https://www.peels.app");
+  assert.equal(metadata.alternates?.canonical, "https://www.peels.org");
+  assert.equal(metadata.openGraph?.url, "https://www.peels.org");
 });
 
 test("shared metadata uses the page title for social previews", () => {
@@ -193,11 +193,11 @@ test("listing metadata includes the canonical listing path", () => {
 
   assert.equal(
     metadata.alternates?.canonical,
-    "https://www.peels.app/listings/test-community-compost"
+    "https://www.peels.org/listings/test-community-compost"
   );
   assert.equal(
     metadata.openGraph?.url,
-    "https://www.peels.app/listings/test-community-compost"
+    "https://www.peels.org/listings/test-community-compost"
   );
 });
 
@@ -421,7 +421,7 @@ test("listing JSON-LD describes the public listing page and place conservatively
   assert.equal(jsonLd.name, "Neighbourhood compost drop-off");
   assert.equal(
     jsonLd.url,
-    "https://www.peels.app/listings/test-community-compost"
+    "https://www.peels.org/listings/test-community-compost"
   );
   assert.equal(jsonLd.about["@type"], "Place");
   assert.ok(jsonLd.about.address);


### PR DESCRIPTION
## Summary

- Point `siteConfig.url` at `https://www.peels.org` so canonical tags, sitemap, robots, JSON-LD, and Open Graph all signal `.org` as the primary origin on both hosts.
- Update unit and e2e SEO test assertions to match.

## Deploy checklist (Step 1 only)

**Before or immediately after merging**, in Supabase Dashboard → Auth → URL configuration:

- Set **Site URL** to `https://www.peels.org`
- **Keep** `https://www.peels.app/**` and `https://www.peels.org/**` in Redirect URLs
- **Do not** change `PEELS_PUBLIC_SITE_URL` yet (Step 2 follow-up)

## Post-deploy verification

```bash
curl -s https://www.peels.org/listings/QE4QxdJ4y5YE | grep 'rel="canonical"'
curl -s https://www.peels.app/listings/QE4QxdJ4y5YE | grep 'rel="canonical"'
curl -s https://www.peels.app/sitemap.xml | head
curl -s https://www.peels.org/robots.txt
```

Both listing pages should canonicalise to `.org`; `.app` sitemap should also emit `.org` URLs.

Manual smoke test: sign-up, sign-in, and password reset from both `.org` and `.app`.

## Search Console (after verification)

1. Submit `https://www.peels.org/sitemap.xml`
2. Request indexing for `https://www.peels.org/`

## Test plan

- [x] `npm run check`
- [x] `npm run test:e2e:prod` (SEO tests pass; one unrelated media test failure pre-existing)
- [ ] Merge + Vercel production deploy
- [ ] Supabase Auth Site URL updated
- [ ] Production curl checks above
- [ ] Auth smoke test on both hosts
