### PR TITLE
update share copy and documents peels.org migration next steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,17 @@
-Thank you for your contribution to Peels! Before submitting this PR, please make sure you have:
+## Summary
 
-- [ ] Run `npm run format` on your changes
-- [ ] Run `npm run build` without any errors or warnings
+<!-- Replace this comment. Lead with why the change exists, not just what changed. -->
+<!-- One to three short bullets. Mention user-visible impact when there is one. -->
 
-Once that’s all done, go ahead and replace the contents of this template with a description of your changes. Thanks again!
+-
+
+## Test plan
+
+<!-- Check what you ran. Leave unchecked items for the reviewer if you could not run them. -->
+
+- [ ] `npm run check`
+- [ ] Other (describe):
+
+## Notes
+
+<!-- Optional: deploy steps, Supabase dashboard changes, follow-up work, or screenshots. Omit if nothing useful to add. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,14 @@
+Thank you for your contribution to Peels! Before submitting, please:
+
+- [ ] Run `npm run format` on your changes
+- [ ] Run `npm run build` without errors or warnings
+- [ ] Run `npm run check` when the change touches app logic, messages, or tests
+
+Then replace the placeholder below with a description of your changes.
+
 ## Summary
 
-<!-- Replace this comment. Lead with why the change exists, not just what changed. -->
-<!-- One to three short bullets. Mention user-visible impact when there is one. -->
+<!-- Lead with why the change exists, not just what changed. One to three short bullets. -->
 
 -
 
@@ -9,9 +16,8 @@
 
 <!-- Check what you ran. Leave unchecked items for the reviewer if you could not run them. -->
 
-- [ ] `npm run check`
-- [ ] Other (describe):
+- [ ]
 
 ## Notes
 
-<!-- Optional: deploy steps, Supabase dashboard changes, follow-up work, or screenshots. Omit if nothing useful to add. -->
+<!-- Optional: deploy steps, Supabase dashboard changes, follow-up work, or screenshots. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ These instructions apply to the whole repository.
 - Do not merge pull requests unless the human explicitly asks you to merge.
 - When opening a pull request, follow
   [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+- Do not put harvestable email addresses in docs, commits, plans, or other public
+  repo text. Reference env var names, `siteConfig.encodedEmail`, or generic
+  `local-part@domain` placeholders instead.
 
 ## Frontend
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,15 @@ These instructions apply to the whole repository.
 
 - Use Australian/British English over US English.
 
+## Git, commits, and pull requests
+
+- Start commit and PR titles with a lowercase actionable verb, such as `fixes`,
+  `updates`, `adds`, `removes`, or `improves`. Use title case only for proper
+  nouns (Peels, Supabase, Vercel, and so on).
+- Do not merge pull requests unless the human explicitly asks you to merge.
+- When opening a pull request, follow
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
 ## Frontend
 
 - Prefer Server Components by default. Only add `"use client"` when the component needs browser-only APIs, state/effects, event handlers, or client-only libraries.

--- a/docs/dual-hosting-peels-org.md
+++ b/docs/dual-hosting-peels-org.md
@@ -63,15 +63,18 @@ high-volume transactional mail from Resend.
 
 **Do now**
 
-- Add a **DMARC monitor** record for `peels.org`, for example  
-  `_dmarc.peels.org TXT "v=DMARC1; p=none; rua=mailto:…"`.
+- Add a **DMARC monitor** record for `peels.org` at `p=none`, with an `rua`
+  reporting address you keep private (do not commit real mailbox addresses to
+  the repo).
 - Host **`@peels.org` on iCloud Mail** (or similar) for low-volume personal /
   manual mail — partner replies, support, one-to-one outreach. This is a good
   way to start real, human sending on the domain.
 - Use **`@peels.org` in new signatures and partner comms** so outbound human mail
   consistently comes from the new domain.
-- Plan **inbound aliases** early if useful, for example  
-  `support@peels.org` and forward `support@peels.app` → `support@peels.org`.
+- Plan **inbound aliases** early if useful: mirror each `@peels.app` mailbox
+  to the matching `@peels.org` address using your mail host’s forwarding
+  settings (use the same local parts you already use; keep addresses out of
+  public docs).
 
 **Keep in mind**
 
@@ -206,10 +209,11 @@ sending domain yet, there is no useful Resend DKIM record to add.
 
 Useful preparation:
 
-- Add or keep a low-impact DMARC monitor record for `peels.org`, for example
-  `_dmarc.peels.org TXT "v=DMARC1; p=none; rua=mailto:..."`
-- Configure inbound forwarding or aliases so `local-part@peels.app` forwards
-  to `local-part@peels.org`, if inbound mail should move before outbound mail.
+- Add or keep a low-impact DMARC monitor record for `peels.org` at `p=none`,
+  with a private `rua` reporting address (not committed to the repo).
+- Configure inbound forwarding or aliases so each `@peels.app` mailbox forwards
+  to the matching `@peels.org` address, if inbound mail should move before
+  outbound mail.
 
 ## Redirecting peels.app later
 

--- a/docs/dual-hosting-peels-org.md
+++ b/docs/dual-hosting-peels-org.md
@@ -29,15 +29,114 @@ Done:
 - Both hosts emit `.org` canonical URLs, sitemap URLs, and robots sitemap
   references.
 - `https://www.peels.org/sitemap.xml` submitted in Search Console (180 pages).
+- `PEELS_PUBLIC_SITE_URL` is `https://www.peels.org`.
+- Transactional email links (chat, newsletter, feature) use `.org`.
+- Share-page copy examples and JSON-LD `alternateName` use `peels.org`.
 
 Still intentional:
 
-- Keep `PEELS_PUBLIC_SITE_URL` as `https://www.peels.app` until the
-  transactional-email URL cutover below is complete.
 - Keep `GENERAL_EMAIL_ADDRESS` on the currently verified `@peels.app` sender
-  until the email cutover.
+  until the Resend cutover below.
 - Do not redirect `peels.app` to `peels.org` yet.
 - Do not add a global `noindex` rule to `.org`.
+
+## Next steps
+
+Work through these in order. None of them block the others except the Resend
+cutover, which should wait until `@peels.org` has basic domain reputation and
+DNS is planned for both personal mail and Resend.
+
+### 1. Monitor SEO (now — a few weeks)
+
+- Watch the **`.org`** Search Console property: indexed pages, impressions, and
+  coverage on `.org` URLs.
+- Keep the **`.app`** property for reference; indexed `.app` URLs should decline
+  over time as Google respects the `.org` canonical tags. No Change of Address
+  or URL-removal action is needed yet.
+- Do not submit a separate `.app` sitemap; both hosts already advertise the
+  `.org` sitemap in `robots.txt`.
+
+### 2. Warm up `@peels.org` as a mail domain (now — parallel)
+
+Goal: build legitimate sending history on `peels.org` before moving
+high-volume transactional mail from Resend.
+
+**Do now**
+
+- Add a **DMARC monitor** record for `peels.org`, for example  
+  `_dmarc.peels.org TXT "v=DMARC1; p=none; rua=mailto:…"`.
+- Host **`@peels.org` on iCloud Mail** (or similar) for low-volume personal /
+  manual mail — partner replies, support, one-to-one outreach. This is a good
+  way to start real, human sending on the domain.
+- Use **`@peels.org` in new signatures and partner comms** so outbound human mail
+  consistently comes from the new domain.
+- Plan **inbound aliases** early if useful, for example  
+  `support@peels.org` and forward `support@peels.app` → `support@peels.org`.
+
+**Keep in mind**
+
+- **Do not** send app transactional volume (auth, chat, newsletter) through
+  iCloud. That stays on Resend `@peels.app` until cutover.
+- Before verifying **`peels.org` in Resend**, plan DNS so **SPF can authorise
+  both** iCloud and Resend in one record, for example  
+  `v=spf1 include:icloud.com include:amazonses.com -all` (use Resend’s exact
+  include when they provide it). Do not add Resend DKIM until you are ready to
+  cut over; DKIM is per provider.
+- Warm-up is **low and slow**: real recipients, replies welcome, no bulk blasts
+  from the new domain before Resend cutover.
+
+### 3. Resend cutover to `@peels.org` (when ready — not urgent)
+
+Do this after a few weeks of monitoring and some human `@peels.org` mail, when
+you are ready to change the From address users see on automated emails.
+
+**Resend / DNS**
+
+1. Verify `peels.org` as a sending domain in Resend.
+2. Add only the **SPF and DKIM** records Resend provides (merge SPF with iCloud
+   as above).
+3. Keep DMARC at **`p=none`** until test sends pass; tighten gradually if
+   wanted.
+
+**App / Supabase**
+
+1. Change `GENERAL_EMAIL_ADDRESS` to the chosen `@peels.org` address (Supabase
+   Edge Function secret).
+2. Update `encodedEmail` in [`src/config/site.ts`](../src/config/site.ts).
+3. Redeploy email Edge Functions:
+   - `send-email-for-auth-action`
+   - `send-email-for-new-chat-message`
+   - `send-email-for-new-feature`
+   - `send-email-for-newsletter-issue-supabase-users`
+   - `send-email-for-newsletter-issue-resend-audience`
+4. Smoke-test every email type: sign-up, sign-in, password reset, email change,
+   chat notification, newsletter, feature announcement.
+5. Stop using the `peels.app` Resend sending domain once satisfied.
+6. Keep `@peels.app` **inbound forwarding** for stale threads if needed.
+
+**Code tidy-up after cutover**
+
+- Search for remaining `.app` references:  
+  `rg "peels\\.app|Peels\\.app|encodedEmail" src supabase docs`
+
+### 4. Partner and public links (gradual — low urgency)
+
+- Use `https://www.peels.org/...` in everything Peels publishes going forward.
+- Optionally ask high-value partners (councils, orgs on the Partners page) to
+  update links when convenient. Old `.app` links still work; canonical tags
+  and a future redirect handle SEO. Partner updates mainly help **humans** who
+  copy URLs from council pages.
+
+### 5. Redirect `.app` → `.org` (later)
+
+Do this only after `.org` has been canonical for a while and you no longer need
+`.app` to serve the app directly. See [Redirecting peels.app later](#redirecting-peelsapp-later).
+
+After redirects are live:
+
+- Use **Change of Address** in Search Console (`.app` → `.org` property).
+- Remove `.app` from app origin allow-lists and Supabase redirect URLs once old
+  auth links and cached emails are no longer relevant.
 
 ## Why the code changes matter
 
@@ -112,80 +211,6 @@ Useful preparation:
 - Configure inbound forwarding or aliases so `local-part@peels.app` forwards
   to `local-part@peels.org`, if inbound mail should move before outbound mail.
 
-## Making peels.org canonical
-
-Done:
-
-1. `siteConfig.url` is `https://www.peels.org`.
-2. Supabase Auth Site URL is `https://www.peels.org`.
-3. `.app` and `.org` remain in the redirect allow-list.
-4. Tests expect `.org` canonical URLs.
-5. `https://www.peels.org/sitemap.xml` submitted in Search Console.
-
-Next: transactional email URL cutover (`PEELS_PUBLIC_SITE_URL`):
-
-1. Change `PEELS_PUBLIC_SITE_URL` to `https://www.peels.org` in Supabase Edge
-   Function secrets.
-2. Redeploy the functions that call `getPublicSiteUrl()`:
-   - `send-email-for-new-chat-message`
-   - `send-email-for-new-feature`
-   - `send-email-for-newsletter-issue-supabase-users`
-   - `send-email-for-newsletter-issue-resend-audience`
-3. Smoke-test one chat notification or newsletter link points to `.org`.
-
-Example CLI after `supabase login` and `supabase link --project-ref mfnaqdyunuafbwukbbyr`:
-
-```bash
-supabase secrets set PEELS_PUBLIC_SITE_URL=https://www.peels.org
-supabase functions deploy send-email-for-new-chat-message
-supabase functions deploy send-email-for-new-feature
-supabase functions deploy send-email-for-newsletter-issue-supabase-users
-supabase functions deploy send-email-for-newsletter-issue-resend-audience
-```
-
-Later canonical / email work still deferred:
-
-1. Change `encodedEmail` in `src/config/site.ts` once the email cutover is
-   complete.
-2. Search for remaining `.app` references in app code and content:
-   `rg "peels\\.app|Peels\\.app|siteConfig\\.url|encodedEmail" src supabase docs`
-3. If email sending has cut over, change `GENERAL_EMAIL_ADDRESS` to the chosen
-   `@peels.org` sender.
-4. Redeploy `send-email-for-auth-action` after any auth email code or secret
-   changes.
-
-Email cutover:
-
-1. Verify `peels.org` as the single Resend sending domain.
-2. Add only the SPF and DKIM records Resend gives for `peels.org`.
-3. Keep DMARC at `p=none` until test sends pass, then tighten gradually if
-   wanted.
-4. Stop using the `peels.app` sending domain once `GENERAL_EMAIL_ADDRESS` has
-   moved and test sends pass.
-
-External setup:
-
-- Make `www.peels.org` the primary production domain in Vercel if useful.
-- Keep `www.peels.app` attached to the project for now.
-- Check Cloudflare DNS, Turnstile, MapTiler, Protomaps, Vercel Analytics, and
-  any monitoring or uptime checks for `.org`.
-- Verify `www.peels.org` in search tools and submit
-  `https://www.peels.org/sitemap.xml`.
-- Ask partners to add or update links to `.org`, but do not require existing
-  `.app` links to change immediately.
-
-Verification after the canonical flip:
-
-- `https://www.peels.org/listings/QE4QxdJ4y5YE` renders correctly.
-- `https://www.peels.app/listings/QE4QxdJ4y5YE` still renders correctly.
-- Both domains emit canonical links pointing to `.org`.
-- `/robots.txt` on both domains references the `.org` sitemap.
-- `/sitemap.xml` contains `.org` URLs.
-- JSON-LD, Open Graph, RSS, and newsletter feed URLs use `.org`.
-- Sign-up, sign-in, password reset, email confirmation, email change, chat
-  notifications, and newsletter sends work.
-- UTM parameters are captured on whichever domain receives the first visit.
-
 ## Redirecting peels.app later
 
 Do this only after `.org` has been canonical for a while and there is no need
@@ -229,7 +254,7 @@ Before merging or shortly after deployment, verify:
 
 - `https://www.peels.org/listings/QE4QxdJ4y5YE` renders the same listing as
   `.app`.
-- The same listing on `.org` emits a `.app` canonical link during dual-hosting.
+- The same listing on `.org` emits a `.org` canonical link.
 - Sign-up works from `.org`.
 - Sign-in works from `.org`.
 - Password reset and email confirmation return to `.org`.

--- a/docs/dual-hosting-peels-org.md
+++ b/docs/dual-hosting-peels-org.md
@@ -31,7 +31,7 @@ Done:
 - `https://www.peels.org/sitemap.xml` submitted in Search Console (180 pages).
 - `PEELS_PUBLIC_SITE_URL` is `https://www.peels.org`.
 - Transactional email links (chat, newsletter, feature) use `.org`.
-- Share-page copy examples and JSON-LD `alternateName` use `peels.org`.
+- Share-page copy examples use `peels.org`.
 
 Still intentional:
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -226,11 +226,11 @@
         },
         "medium": {
           "title": "Mittel",
-          "body": "Peels verbindet Menschen mit Lebensmittelresten mit Menschen, die sie kompostieren können. Geh auf peels.app, um Nachbarinnen, Nachbarn oder Gemeinschaftsgärten in deiner Nähe zu finden, die Lebensmittelreste annehmen, oder selbst so einen Ort einzutragen."
+          "body": "Peels verbindet Menschen mit Lebensmittelresten mit Menschen, die sie kompostieren können. Geh auf peels.org, um Nachbarinnen, Nachbarn oder Gemeinschaftsgärten in deiner Nähe zu finden, die Lebensmittelreste annehmen, oder selbst so einen Ort einzutragen."
         },
         "long": {
           "title": "Lang",
-          "body": "Suchst du eine Abgabestelle für Kompost? Finde über Peels Nachbarinnen, Nachbarn oder Gemeinschaftsgärten, die Lebensmittelreste annehmen. Du kannst selbst nicht genug Kompost herstellen oder möchtest, dass weniger Lebensmittelabfälle auf der Deponie landen? Erstelle einen Eintrag und nimm Reste aus deiner Nachbarschaft an. Mehr unter peels.app."
+          "body": "Suchst du eine Abgabestelle für Kompost? Finde über Peels Nachbarinnen, Nachbarn oder Gemeinschaftsgärten, die Lebensmittelreste annehmen. Du kannst selbst nicht genug Kompost herstellen oder möchtest, dass weniger Lebensmittelabfälle auf der Deponie landen? Erstelle einen Eintrag und nimm Reste aus deiner Nachbarschaft an. Mehr unter peels.org."
         }
       },
       "partnersNote": "Sieh dir unsere <partners>Partnerseite</partners> an, um reale Beispiele dafür zu sehen, wie Kommunen und Organisationen über Peels sprechen."

--- a/messages/en.json
+++ b/messages/en.json
@@ -226,11 +226,11 @@
         },
         "medium": {
           "title": "Medium",
-          "body": "Peels connects folks with food scraps to those who can compost them. Go to peels.app to find (or become) a neighbour or community garden that accepts food scraps near you."
+          "body": "Peels connects folks with food scraps to those who can compost them. Go to peels.org to find (or become) a neighbour or community garden that accepts food scraps near you."
         },
         "long": {
           "title": "Long",
-          "body": "Looking for a compost drop-off? Find a neighbour or community garden that accepts food scraps via Peels. Can’t produce enough compost of your own, or want to see less food waste go to landfill? Create a listing to accept scraps from neighbours. Learn more at peels.app."
+          "body": "Looking for a compost drop-off? Find a neighbour or community garden that accepts food scraps via Peels. Can’t produce enough compost of your own, or want to see less food waste go to landfill? Create a listing to accept scraps from neighbours. Learn more at peels.org."
         }
       },
       "partnersNote": "See our <partners>Partners page</partners> for real-world examples of how councils and organisations talk about Peels."

--- a/messages/es.json
+++ b/messages/es.json
@@ -226,11 +226,11 @@
         },
         "medium": {
           "title": "Medio",
-          "body": "Peels conecta a personas con restos de comida con quienes pueden compostarlos. Ve a peels.app para encontrar, o convertirte en, un vecino o huerto comunitario que acepta restos de comida cerca de ti."
+          "body": "Peels conecta a personas con restos de comida con quienes pueden compostarlos. Ve a peels.org para encontrar, o convertirte en, un vecino o huerto comunitario que acepta restos de comida cerca de ti."
         },
         "long": {
           "title": "Largo",
-          "body": "¿Buscas dónde dejar tus restos para compostar? Encuentra mediante Peels un vecino o huerto comunitario que acepte restos de comida. ¿No produces suficiente compost por tu cuenta, o quieres que menos residuos alimentarios acaben en el vertedero? Crea un anuncio para aceptar restos de tus vecinos. Más información en peels.app."
+          "body": "¿Buscas dónde dejar tus restos para compostar? Encuentra mediante Peels un vecino o huerto comunitario que acepte restos de comida. ¿No produces suficiente compost por tu cuenta, o quieres que menos residuos alimentarios acaben en el vertedero? Crea un anuncio para aceptar restos de tus vecinos. Más información en peels.org."
         }
       },
       "partnersNote": "Visita nuestra <partners>página de socios</partners> para ver ejemplos reales de cómo gobiernos locales y organizaciones hablan de Peels."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -226,11 +226,11 @@
         },
         "medium": {
           "title": "Moyen",
-          "body": "Peels met en relation les personnes qui ont des restes alimentaires avec celles qui peuvent les composter. Rendez-vous sur peels.app pour trouver, ou devenir, un·e voisin·e ou jardin communautaire qui accepte les restes alimentaires près de chez vous."
+          "body": "Peels met en relation les personnes qui ont des restes alimentaires avec celles qui peuvent les composter. Rendez-vous sur peels.org pour trouver, ou devenir, un·e voisin·e ou jardin communautaire qui accepte les restes alimentaires près de chez vous."
         },
         "long": {
           "title": "Long",
-          "body": "Vous cherchez un point de dépôt pour le compost ? Trouvez via Peels un·e voisin·e ou un jardin communautaire qui accepte les restes alimentaires. Vous ne produisez pas assez de compost, ou vous voulez voir moins de gaspillage alimentaire finir en décharge ? Créez une annonce pour accepter les restes de vos voisin·es. En savoir plus sur peels.app."
+          "body": "Vous cherchez un point de dépôt pour le compost ? Trouvez via Peels un·e voisin·e ou un jardin communautaire qui accepte les restes alimentaires. Vous ne produisez pas assez de compost, ou vous voulez voir moins de gaspillage alimentaire finir en décharge ? Créez une annonce pour accepter les restes de vos voisin·es. En savoir plus sur peels.org."
         }
       },
       "partnersNote": "Consultez notre <partners>page Partenaires</partners> pour voir des exemples concrets de la façon dont des collectivités et organisations parlent de Peels."

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -226,11 +226,11 @@
         },
         "medium": {
           "title": "Médio",
-          "body": "O Peels conecta pessoas com restos de comida a quem pode compostá-los. Acesse peels.app para encontrar, ou se tornar, uma pessoa vizinha ou horta comunitária que aceita restos de comida perto de você."
+          "body": "O Peels conecta pessoas com restos de comida a quem pode compostá-los. Acesse peels.org para encontrar, ou se tornar, uma pessoa vizinha ou horta comunitária que aceita restos de comida perto de você."
         },
         "long": {
           "title": "Longo",
-          "body": "Procurando um ponto de entrega para compostagem? Encontre pelo Peels uma pessoa vizinha ou horta comunitária que aceita restos de comida. Não consegue produzir composto suficiente por conta própria, ou quer ver menos desperdício alimentar ir para o aterro? Crie um anúncio para aceitar restos de vizinhos. Saiba mais em peels.app."
+          "body": "Procurando um ponto de entrega para compostagem? Encontre pelo Peels uma pessoa vizinha ou horta comunitária que aceita restos de comida. Não consegue produzir composto suficiente por conta própria, ou quer ver menos desperdício alimentar ir para o aterro? Crie um anúncio para aceitar restos de vizinhos. Saiba mais em peels.org."
         }
       },
       "partnersNote": "Acesse a nossa <partners>página de parceiros</partners> para ver exemplos reais de como conselhos municipais e organizações falam sobre o Peels."

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,7 +58,6 @@ const websiteJsonLd = {
   "@type": "WebSite",
   "@id": `${siteConfig.url}/#website`,
   name: siteConfig.name,
-  alternateName: "Peels.org",
   url: siteConfig.url,
   publisher: {
     "@id": `${siteConfig.url}/#organization`,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,7 +58,7 @@ const websiteJsonLd = {
   "@type": "WebSite",
   "@id": `${siteConfig.url}/#website`,
   name: siteConfig.name,
-  alternateName: "Peels.app",
+  alternateName: "Peels.org",
   url: siteConfig.url,
   publisher: {
     "@id": `${siteConfig.url}/#organization`,


### PR DESCRIPTION
Thank you for your contribution to Peels! Before submitting, please:

- [x] Run `npm run format` on your changes
- [x] Run `npm run build` without errors or warnings
- [x] Run `npm run check` when the change touches app logic, messages, or tests

## Summary

- Point share-page copy examples at `peels.org` now that `.org` is the canonical domain, so partner-facing starter text matches what we publish elsewhere.
- Expand `docs/dual-hosting-peels-org.md` with ordered next steps: SEO monitoring, `@peels.org` email warm-up, Resend cutover, partner links, and eventual `.app` redirects.
- Document commit/PR conventions in `AGENTS.md` and refresh the pull request template; remove WebSite JSON-LD `alternateName` so the brand stays Peels rather than a domain-style label.

## Test plan

- [x] `npm run i18n:check`
- [x] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e:prod`

## Notes

No deploy or Supabase changes. Docs-only plus message copy and one JSON-LD field removal.