### PR TITLE
update github repo links to peels-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Peels is built on top of Next.js and Supabase. The code is [open source](#forkin
 
 ```bash
 # Clone the repository
-git clone https://github.com/dnywh/peels.git
+git clone https://github.com/peels-org/peels.git
 cd peels
 
 # Install dependencies
@@ -65,11 +65,11 @@ peels/
 
 ## Contributing to Peels
 
-Thank you for contributing! Please read our [Code of Conduct](https://github.com/dnywh/peels/blob/main/.github/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/dnywh/peels/contribute) before you start.
+Thank you for contributing! Please read our [Code of Conduct](https://github.com/peels-org/peels/blob/main/.github/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/peels-org/peels/contribute) before you start.
 
-Check out the list of [issues](https://github.com/dnywh/peels/issues) you could help out on, [discussions](https://github.com/dnywh/peels/discussions) about future improvements, and our [Wiki](https://peels.notion.site/207b37e1678f80259217f54cd9d1f637) for information on how things are set up.
+Check out the list of [issues](https://github.com/peels-org/peels/issues) you could help out on, [discussions](https://github.com/peels-org/peels/discussions) about future improvements, and our [Wiki](https://peels.notion.site/207b37e1678f80259217f54cd9d1f637) for information on how things are set up.
 
-For minor improvements, feel free to just go ahead and create a pull request. For major changes, please [open an issue](https://github.com/dnywh/peels/issues) first to discuss what you would like to change.
+For minor improvements, feel free to just go ahead and create a pull request. For major changes, please [open an issue](https://github.com/peels-org/peels/issues) first to discuss what you would like to change.
 
 ### Environment Variables
 
@@ -87,7 +87,7 @@ For local-first Supabase development:
 The repo defaults `NEXT_PUBLIC_SUPABASE_URL` to `http://127.0.0.1:54331` so local development does not need to point at the hosted Peels project. If you already had a `.env.local` from hosted development, update that value manually because copying `.env.example` later may not overwrite your existing file.
 Peels intentionally uses the `54331`-`54334` local port range so it can run alongside other Supabase projects that still use the CLI defaults.
 
-If you need to serve [Supabase edge functions](https://github.com/dnywh/peels/blob/main/supabase/functions) locally, copy `supabase/.env.example` to `supabase/.env` and add only the secrets you actually need. Production secrets should remain dashboard-managed for now.
+If you need to serve [Supabase edge functions](https://github.com/peels-org/peels/blob/main/supabase/functions) locally, copy `supabase/.env.example` to `supabase/.env` and add only the secrets you actually need. Production secrets should remain dashboard-managed for now.
 
 For the fuller operational walkthrough, including GitHub/Vercel dashboard setup and fresh-computer bootstrap, see [docs/supabase-local-first.md](./docs/supabase-local-first.md).
 
@@ -98,7 +98,7 @@ For how auth/session forwarding, public-page performance, footer locale state, u
 1. Clone and set up codebase:
 
    ```bash
-   git clone https://github.com/dnywh/peels.git
+   git clone https://github.com/peels-org/peels.git
    cd peels
    npm install
    ```
@@ -313,9 +313,9 @@ Map changes are still a manual smoke-check area. When you touch `/map`, verify t
 
 ### Getting Help
 
-- Check existing [issues](https://github.com/dnywh/peels/issues) for known problems
-- Create a [new issue](https://github.com/dnywh/peels/issues/new) if you find a bug or have a feature request
-- Join our [discussion board](https://github.com/dnywh/peels/discussions) for anything else
+- Check existing [issues](https://github.com/peels-org/peels/issues) for known problems
+- Create a [new issue](https://github.com/peels-org/peels/issues/new) if you find a bug or have a feature request
+- Join our [discussion board](https://github.com/peels-org/peels/discussions) for anything else
 
 ## Forking Peels
 

--- a/docs/supabase-local-first.md
+++ b/docs/supabase-local-first.md
@@ -216,7 +216,7 @@ Right now the changes are only in your working tree on `main`. The safe path is:
 Suggested branch name:
 
 ```bash
-git switch -c dnywh/supabase-local-first
+git switch -c your-handle/supabase-local-first
 ```
 
 Then review what is staged before committing:

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -439,7 +439,7 @@ export const signUpAction = async (formData: FormData, request?: Request) => {
 
   if (error || !user) {
     // Temporary check and special handling for Supabase hook timeout errors
-    // See https://github.com/dnywh/peels/issues/3
+    // See https://github.com/peels-org/peels/issues/3
     const hookTimeoutPatterns = [
       "Error running hook URI",
       "Failed to reach hook within maximum time",

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
+import { siteConfig } from "@/config/site";
+
 export default function ContributePage() {
-  redirect(
-    "https://github.com/dnywh/peels?tab=readme-ov-file#contributing-to-peels"
-  );
+  redirect(`${siteConfig.repoUrl}?tab=readme-ov-file#contributing-to-peels`);
 }

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -2,7 +2,7 @@ export const siteConfig = {
   name: "Peels",
   description: "Find a home for your food scraps, wherever you are.",
   url: "https://www.peels.org",
-  repoUrl: "https://github.com/dnywh/peels",
+  repoUrl: "https://github.com/peels-org/peels",
   links: {
     about: "/",
     newsletter: "/newsletter",

--- a/supabase/functions/_templates/newsletter-issue-one-email.tsx
+++ b/supabase/functions/_templates/newsletter-issue-one-email.tsx
@@ -27,7 +27,7 @@ export const NewsletterIssueOneEmail = ({
   externalAudience,
 }: NewsletterIssueOneEmailProps) => {
   const siteUrl = getPublicSiteUrl();
-  const repoUrl = "https://github.com/dnywh/peels";
+  const repoUrl = "https://github.com/peels-org/peels";
   const issueAssetUrl = `${staticAssetUrl}/newsletter/1`;
   return (
     <EmailBody

--- a/supabase/functions/_templates/newsletter-issue-two-email.tsx
+++ b/supabase/functions/_templates/newsletter-issue-two-email.tsx
@@ -27,7 +27,7 @@ export const NewsletterIssueTwoEmail = ({
   externalAudience,
 }: NewsletterIssueTwoEmailProps) => {
   const siteUrl = getPublicSiteUrl();
-  const repoUrl = "https://github.com/dnywh/peels";
+  const repoUrl = "https://github.com/peels-org/peels";
   const issueAssetUrl = `${staticAssetUrl}/newsletter/2`;
   return (
     <EmailBody


### PR DESCRIPTION
Thank you for your contribution to Peels! Before submitting, please:

- [x] Run `npm run format` on your changes
- [ ] Run `npm run build` without errors or warnings
- [x] Run `npm run check` when the change touches app logic, messages, or tests

## Summary

- Point repo URLs at `peels-org/peels` after the GitHub org transfer so docs, site config, newsletter templates, and contribute links stay correct.
- Route the `/contribute` redirect through `siteConfig.repoUrl` so future repo moves only need one update.

## Test plan

- [x] `npm run format`
- [x] `npm run check`
- [ ] `npm run build` (not run locally; CI should cover this on the PR)

## Notes

Vercel and Supabase Git integrations were reconnected to `peels-org/peels` in the dashboards before opening this PR. Redeploy Supabase edge functions after merge if you want the newsletter template repo links updated in sent mail.