### PR TITLE
fix homepage demo avatar and local media seed issue

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Start local Supabase stack
         run: supabase start
 
-      - name: Replay migrations and seed data
+      - name: Replay migrations, seed data, and demo media
         run: npm run supabase:reset
 
       - name: Write local app env
@@ -75,9 +75,6 @@ jobs:
           NEXT_PUBLIC_PROTOMAPS_API_KEY=playwright-local
           NEXT_PUBLIC_TURNSTILE_ENABLED=
           EOF
-
-      - name: Seed local demo media
-        run: npm run seed:local-media
 
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,6 @@ const uniqueStorageRemotePatterns = storageRemotePatterns.filter(
 );
 
 const shouldAllowLocalStorageImages =
-  process.env.NODE_ENV === "development" ||
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("127.0.0.1") ||
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("localhost") ||
   false;

--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,7 @@ const uniqueStorageRemotePatterns = storageRemotePatterns.filter(
 );
 
 const shouldAllowLocalStorageImages =
+  process.env.NODE_ENV === "development" ||
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("127.0.0.1") ||
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("localhost") ||
   false;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "supabase:stop": "supabase stop",
     "supabase:status": "supabase status",
     "supabase:env": "supabase status -o env",
-    "supabase:reset": "supabase db reset",
+    "supabase:reset": "supabase db reset && npm run seed:local-media",
     "seed:local-media": "node scripts/seed-local-media.mjs",
     "media:cleanup-orphans": "node scripts/cleanup-orphaned-media.mjs",
     "supabase:diff": "supabase db diff",

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -16,7 +16,7 @@ type AvatarSize = "massive" | "large" | "medium" | "small" | "tiny";
 type AvatarRotation = "normal" | "reverse";
 
 type AvatarListing = {
-  type?: "residential" | "community" | "business" | string;
+  type?: "residential" | "community" | "business" | string | null;
   owner_avatar?: string | null;
   avatar?: string | null;
 };

--- a/src/components/AvatarPair/AvatarPair.tsx
+++ b/src/components/AvatarPair/AvatarPair.tsx
@@ -14,7 +14,7 @@ type AvatarPairWidth = "fixed";
 
 type AvatarPairListing = {
   is_demo?: boolean;
-  type?: "residential" | "community" | "business" | string;
+  type?: "residential" | "community" | "business" | string | null;
   avatar?: string | null;
   owner_avatar?: string | null;
 };

--- a/src/components/AvatarPair/AvatarPair.tsx
+++ b/src/components/AvatarPair/AvatarPair.tsx
@@ -13,6 +13,7 @@ type AvatarPairSmallest = "small" | "tiny";
 type AvatarPairWidth = "fixed";
 
 type AvatarPairListing = {
+  is_demo?: boolean;
   type?: "residential" | "community" | "business" | string;
   avatar?: string | null;
   owner_avatar?: string | null;

--- a/src/components/ChatHeader/ChatHeader.tsx
+++ b/src/components/ChatHeader/ChatHeader.tsx
@@ -209,15 +209,7 @@ function ChatHeader({
         {/* Handle either listing avatar and owner avatar combo OR initiator's avatar */}
         <AvatarContainer>
           <AvatarPair
-            listing={
-              role === "initiator"
-                ? {
-                    type: listing.type ?? undefined,
-                    avatar: listing.avatar,
-                    owner_avatar: chatListing?.owner_avatar,
-                  }
-                : undefined
-            }
+            listing={role === "initiator" ? listing : undefined}
             profile={
               role === "owner"
                 ? { avatar: thread?.initiator_avatar }

--- a/src/utils/listingUtils.test.ts
+++ b/src/utils/listingUtils.test.ts
@@ -413,6 +413,22 @@ test("anonymous residential avatars can use localised private-host alt text", ()
   assert.doesNotMatch(avatar?.alt ?? "", /Private Host/);
 });
 
+test("demo residential listings use bundled demo avatar paths", () => {
+  const avatar = getListingAvatar(
+    {
+      is_demo: true,
+      type: "residential",
+      owner_first_name: "Becca",
+      avatar: "sunflowers.jpg",
+    },
+    null
+  );
+
+  assert.equal(avatar?.isDemo, true);
+  assert.equal(avatar?.path, "/avatars/demo/sunflowers.jpg");
+  assert.match(avatar?.alt ?? "", /Becca/);
+});
+
 test("listing JSON-LD describes the public listing page and place conservatively", () => {
   const jsonLd = generateListingJsonLd(communityListing, null);
 


### PR DESCRIPTION
## Summary

- Pass the full demo listing into the homepage chat header so Becca’s avatar resolves via `is_demo` instead of falling back to a blank residential profile image.
- Chain `seed:local-media` into `supabase:reset` so local demo listing photos are uploaded automatically after a database reset, avoiding broken drop-off thumbnails when that step is skipped.
- Fold the redundant CI media seed step into the reset workflow step.

## Test plan

- [x] `npm run check`
- [ ] Homepage step 2 chat demo shows Becca’s avatar after a fresh `npm run supabase:reset` and `npm run dev`
- [ ] Homepage drop-off section shows three featured listing photos after reset without a separate `seed:local-media` run

## Notes

The drop-off photo issue turned out to be missing seeded storage objects, not Next.js local IP image optimisation. No change to `dangerouslyAllowLocalIP` config.