### PR TITLE
persist null for listing country placeholder

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { expect, type Page } from "@playwright/test";
 
 export const HOST_EMAIL = "demo-host@peels.local";
@@ -8,6 +10,34 @@ export const SECOND_SEEDED_THREAD_ID = "77777777-7777-4777-8777-777777777777";
 export const HOST_SECOND_SEEDED_THREAD_ID =
   "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 export const PROFILE_RENDER_TIMEOUT_MS = 15_000;
+
+export function parseLocalSupabaseEnv() {
+  const output = execFileSync("supabase", ["status", "-o", "env"], {
+    encoding: "utf8",
+  });
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((env, line) => {
+      const separatorIndex = line.indexOf("=");
+      if (separatorIndex === -1) return env;
+
+      const key = line.slice(0, separatorIndex);
+      const value = line.slice(separatorIndex + 1).replace(/^"(.*)"$/, "$1");
+      env[key] = value;
+      return env;
+    }, {});
+}
+
+export function createAdminClient(): SupabaseClient {
+  const env = parseLocalSupabaseEnv();
+
+  return createClient(env.API_URL, env.SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
 
 type MockGeocodingFeatureOptions = {
   id?: string;

--- a/e2e/listings.spec.ts
+++ b/e2e/listings.spec.ts
@@ -3,6 +3,7 @@ import {
   DONOR_EMAIL,
   HOST_EMAIL,
   PROFILE_RENDER_TIMEOUT_MS,
+  createAdminClient,
   createMockGeocodingFeature,
   delayServerActionRequests,
   mockMapTilerGeocoding,
@@ -10,6 +11,7 @@ import {
 } from "./helpers";
 
 const BUSINESS_LISTING_EDIT_PATH = "/profile/listings/demo-inner-west-cafe";
+const BUSINESS_LISTING_SLUG = "demo-inner-west-cafe";
 const MAP_MULTI_PHOTO_LISTING_PATH = "/map?listing=demo-marrickville-compost";
 const PUBLIC_MULTI_PHOTO_LISTING_PATH = "/listings/demo-marrickville-compost";
 const RESIDENTIAL_LISTING_EDIT_PATH =
@@ -160,6 +162,73 @@ test("listing location search picks a geocoding result", async ({ page }) => {
     timeout: 10_000,
   });
   await expect(page.getByText(/Drag the pin/)).toBeVisible();
+});
+
+test("listing edit clears a legacy country placeholder to null and round-trips ISO codes", async ({
+  page,
+}) => {
+  const admin = createAdminClient();
+
+  const { error: seedPlaceholderError } = await admin
+    .from("listings")
+    .update({ country_code: "initial" })
+    .eq("slug", BUSINESS_LISTING_SLUG);
+
+  expect(seedPlaceholderError).toBeNull();
+
+  try {
+    await signIn(page, {
+      email: HOST_EMAIL,
+      redirectTo: BUSINESS_LISTING_EDIT_PATH,
+    });
+
+    const listingWriteForm = page.getByTestId("listing-write-form");
+    await expect(listingWriteForm).toBeVisible();
+    await expect(page.locator("#country")).toHaveValue("initial");
+
+    await Promise.all([
+      page.waitForURL(/\/listings\/demo-inner-west-cafe\?status=updated$/),
+      page.getByTestId("listing-write-submit").click(),
+    ]);
+
+    const { data: clearedListing, error: clearedError } = await admin
+      .from("listings")
+      .select("country_code")
+      .eq("slug", BUSINESS_LISTING_SLUG)
+      .single();
+
+    expect(clearedError).toBeNull();
+    expect(clearedListing?.country_code).toBeNull();
+
+    await page.goto(BUSINESS_LISTING_EDIT_PATH);
+    await expect(listingWriteForm).toBeVisible();
+    await expect(page.locator("#country")).toHaveValue("initial");
+    await page.locator("#country").selectOption("NZ");
+
+    await Promise.all([
+      page.waitForURL(/\/listings\/demo-inner-west-cafe\?status=updated$/),
+      page.getByTestId("listing-write-submit").click(),
+    ]);
+
+    const { data: updatedListing, error: updatedError } = await admin
+      .from("listings")
+      .select("country_code")
+      .eq("slug", BUSINESS_LISTING_SLUG)
+      .single();
+
+    expect(updatedError).toBeNull();
+    expect(updatedListing?.country_code).toBe("NZ");
+
+    await page.goto(BUSINESS_LISTING_EDIT_PATH);
+    await expect(page.locator("#country")).toHaveValue("NZ");
+  } finally {
+    const { error: restoreError } = await admin
+      .from("listings")
+      .update({ country_code: "AU" })
+      .eq("slug", BUSINESS_LISTING_SLUG);
+
+    expect(restoreError).toBeNull();
+  }
 });
 
 test("listing edit saves and restores seeded business fields", async ({

--- a/e2e/media.spec.ts
+++ b/e2e/media.spec.ts
@@ -1,39 +1,16 @@
-import { execFileSync } from "node:child_process";
 import { createClient } from "@supabase/supabase-js";
 import { expect, type Page, test } from "@playwright/test";
-import { HOST_EMAIL, SEEDED_PASSWORD, signIn } from "./helpers";
+import {
+  HOST_EMAIL,
+  SEEDED_PASSWORD,
+  createAdminClient,
+  parseLocalSupabaseEnv,
+  signIn,
+} from "./helpers";
 
 const BUSINESS_LISTING_SLUG = "demo-inner-west-cafe";
 const BUSINESS_LISTING_EDIT_PATH = `/profile/listings/${BUSINESS_LISTING_SLUG}`;
 const HOST_USER_ID = "2c9ae20c-2469-4e60-84b3-39268697717c";
-
-function parseLocalSupabaseEnv() {
-  const output = execFileSync("supabase", ["status", "-o", "env"], {
-    encoding: "utf8",
-  });
-
-  return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .reduce<Record<string, string>>((env, line) => {
-      const separatorIndex = line.indexOf("=");
-      if (separatorIndex === -1) return env;
-
-      const key = line.slice(0, separatorIndex);
-      const value = line.slice(separatorIndex + 1).replace(/^"(.*)"$/, "$1");
-      env[key] = value;
-      return env;
-    }, {});
-}
-
-function createAdminClient() {
-  const env = parseLocalSupabaseEnv();
-
-  return createClient(env.API_URL, env.SERVICE_ROLE_KEY, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
 
 async function uploadTestMedia(
   page: Page,

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -30,6 +30,7 @@ import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { normaliseListingCountryCode } from "@/utils/listingCountry";
 
 function translateFirstNameFieldError(
   t: Awaited<ReturnType<typeof getTranslations>>,
@@ -87,6 +88,7 @@ function getListingMutationData(
   } = listingData;
   return {
     ...mutationData,
+    country_code: normaliseListingCountryCode(listingData.country_code),
     owner_id: ownerId,
   };
 }
@@ -254,7 +256,7 @@ async function updateExistingListingWithMediaReferences({
       p_avatar: normaliseListingAvatar(listingData.avatar),
       p_accepted_items: listingData.accepted_items,
       p_area_name: listingData.area_name,
-      p_country_code: listingData.country_code,
+      p_country_code: normaliseListingCountryCode(listingData.country_code),
       p_description: listingData.description,
       p_is_stub: listingData.is_stub ?? null,
       p_links: listingData.links,

--- a/src/components/ListingWrite/ListingWrite.tsx
+++ b/src/components/ListingWrite/ListingWrite.tsx
@@ -38,6 +38,7 @@ import { styled } from "next-yak";
 import { useTranslations } from "next-intl";
 import type { User } from "@supabase/supabase-js";
 import { useInlineMutation } from "@/hooks/useInlineMutation";
+import { normaliseListingCountryCode } from "@/utils/listingCountry";
 import {
   buildListingDraft,
   submitListingDelete,
@@ -201,7 +202,7 @@ export default function ListingWrite({
     initialListing?.description || ""
   );
   const [countryCode, setCountryCode] = useState<string>(
-    initialListing?.country_code || ""
+    normaliseListingCountryCode(initialListing?.country_code) || ""
   );
   const [coordinates, setCoordinates] = useState(
     initialListing?.coordinates ?? null
@@ -238,7 +239,8 @@ export default function ListingWrite({
             areaName: initialListing.area_name,
             avatar: initialListing.avatar,
             coordinates: initialListing.coordinates,
-            countryCode: initialListing.country_code,
+            countryCode:
+              normaliseListingCountryCode(initialListing.country_code) || "",
             description: initialListing.description,
             isStub: initialListing.is_stub,
             links: initialListing.links,

--- a/src/components/ListingWrite/listingWriteController.ts
+++ b/src/components/ListingWrite/listingWriteController.ts
@@ -21,6 +21,7 @@ import type {
   ListingWriteFieldErrors,
   ListingWriteProfile,
 } from "@/types/listing";
+import { normaliseListingCountryCode } from "@/utils/listingCountry";
 
 export type ListingWriteFormValues = {
   acceptedItems: string[];
@@ -153,7 +154,7 @@ export function buildListingDraft({
     description: values.description,
     location: `POINT(${values.coordinates.longitude} ${values.coordinates.latitude})`,
     area_name: values.areaName,
-    country_code: values.countryCode,
+    country_code: normaliseListingCountryCode(values.countryCode),
     accepted_items: values.acceptedItems.filter((item) => item.trim() !== ""),
     rejected_items: values.rejectedItems.filter((item) => item.trim() !== ""),
     photos: initialListing ? values.photos : values.pendingPhotos,

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -29,7 +29,10 @@ import InputHint from "@/components/InputHint";
 
 import { styled } from "next-yak";
 import { useTranslations } from "next-intl";
-import { LISTING_COUNTRY_PLACEHOLDER } from "@/utils/listingCountry";
+import {
+  LISTING_COUNTRY_PLACEHOLDER,
+  normaliseListingCountryCode,
+} from "@/utils/listingCountry";
 
 const InputHintComponent = InputHint as any;
 
@@ -190,7 +193,7 @@ export default function LocationSelect({
   const [searchStatusMessage, setSearchStatusMessage] = useState("");
 
   useEffect(() => {
-    if (autoDetectCountry && !countryCode) {
+    if (autoDetectCountry && !normaliseListingCountryCode(countryCode)) {
       if (!mapTilerApiKey) {
         return;
       }
@@ -202,7 +205,11 @@ export default function LocationSelect({
           const response = await geolocation.info();
 
           // Only update state if component is still mounted and user hasn't changed the value
-          if (isMounted && !countryCode && response?.country_code) {
+          if (
+            isMounted &&
+            !normaliseListingCountryCode(countryCode) &&
+            response?.country_code
+          ) {
             setCountryCode(response.country_code);
           }
         } catch (error) {
@@ -328,7 +335,7 @@ export default function LocationSelect({
           ariaInvalid={error ? "true" : undefined}
           ariaLabel={t("Listings.form.location")}
           clearLabel={t("Map.searchClear")}
-          countryCode={countryCode}
+          countryCode={normaliseListingCountryCode(countryCode)}
           error={error}
           errorMessage={t("Map.searchError")}
           inputTestId="listing-location-search-input"

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -203,14 +203,17 @@ export default function LocationSelect({
       const initializeLocation = async () => {
         try {
           const response = await geolocation.info();
+          const detectedCountryCode = normaliseListingCountryCode(
+            response?.country_code
+          );
 
           // Only update state if component is still mounted and user hasn't changed the value
           if (
             isMounted &&
             !normaliseListingCountryCode(countryCode) &&
-            response?.country_code
+            detectedCountryCode
           ) {
-            setCountryCode(response.country_code);
+            setCountryCode(detectedCountryCode);
           }
         } catch (error) {
           console.warn("Could not detect country from IP:", error);
@@ -230,7 +233,7 @@ export default function LocationSelect({
   const handleCountryChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       onLocationInteract?.();
-      setCountryCode(e.target.value);
+      setCountryCode(normaliseListingCountryCode(e.target.value) || "");
       setMapShown(false);
       inputRef.current?.focus();
     },
@@ -315,7 +318,10 @@ export default function LocationSelect({
         {/* TODO: Accessibility: label currently covers both select and geocoding control but not yet via htmlFor. Fix or make a separate visually hidden one for the geocoding control */}
         <Select
           id="country"
-          value={countryCode ? countryCode : LISTING_COUNTRY_PLACEHOLDER}
+          value={
+            normaliseListingCountryCode(countryCode) ||
+            LISTING_COUNTRY_PLACEHOLDER
+          }
           onChange={handleCountryChange}
         >
           <option disabled={true} value={LISTING_COUNTRY_PLACEHOLDER}>

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -310,7 +310,6 @@ export default function LocationSelect({
           id="country"
           value={countryCode ? countryCode : LISTING_COUNTRY_PLACEHOLDER}
           onChange={handleCountryChange}
-          required={true}
         >
           <option disabled={true} value={LISTING_COUNTRY_PLACEHOLDER}>
             {t("Listings.form.selectCountry")}

--- a/src/components/LocationSelect/LocationSelect.tsx
+++ b/src/components/LocationSelect/LocationSelect.tsx
@@ -29,6 +29,7 @@ import InputHint from "@/components/InputHint";
 
 import { styled } from "next-yak";
 import { useTranslations } from "next-intl";
+import { LISTING_COUNTRY_PLACEHOLDER } from "@/utils/listingCountry";
 
 const InputHintComponent = InputHint as any;
 
@@ -307,11 +308,11 @@ export default function LocationSelect({
         {/* TODO: Accessibility: label currently covers both select and geocoding control but not yet via htmlFor. Fix or make a separate visually hidden one for the geocoding control */}
         <Select
           id="country"
-          value={countryCode ? countryCode : "initial"}
+          value={countryCode ? countryCode : LISTING_COUNTRY_PLACEHOLDER}
           onChange={handleCountryChange}
           required={true}
         >
-          <option disabled={true} value="initial">
+          <option disabled={true} value={LISTING_COUNTRY_PLACEHOLDER}>
             {t("Listings.form.selectCountry")}
           </option>
           {countries.map((country) => (

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -27,7 +27,7 @@ export type ListingDraftInput = {
   description: string;
   location: string;
   area_name: string;
-  country_code: string;
+  country_code: string | null;
   accepted_items: string[];
   rejected_items: string[];
   photos: string[];

--- a/src/utils/listingCountry.test.ts
+++ b/src/utils/listingCountry.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LISTING_COUNTRY_PLACEHOLDER,
+  normaliseListingCountryCode,
+} from "./listingCountry.ts";
+
+test("normaliseListingCountryCode returns null for empty and placeholder values", () => {
+  assert.equal(normaliseListingCountryCode(undefined), null);
+  assert.equal(normaliseListingCountryCode(null), null);
+  assert.equal(normaliseListingCountryCode(""), null);
+  assert.equal(normaliseListingCountryCode("   "), null);
+  assert.equal(normaliseListingCountryCode(LISTING_COUNTRY_PLACEHOLDER), null);
+});
+
+test("normaliseListingCountryCode returns trimmed country codes", () => {
+  assert.equal(normaliseListingCountryCode("GB"), "GB");
+  assert.equal(normaliseListingCountryCode(" au "), "au");
+});

--- a/src/utils/listingCountry.test.ts
+++ b/src/utils/listingCountry.test.ts
@@ -12,9 +12,10 @@ test("normaliseListingCountryCode returns null for empty and placeholder values"
   assert.equal(normaliseListingCountryCode(""), null);
   assert.equal(normaliseListingCountryCode("   "), null);
   assert.equal(normaliseListingCountryCode(LISTING_COUNTRY_PLACEHOLDER), null);
+  assert.equal(normaliseListingCountryCode("INITIAL"), null);
 });
 
-test("normaliseListingCountryCode returns trimmed country codes", () => {
+test("normaliseListingCountryCode returns trimmed uppercase country codes", () => {
   assert.equal(normaliseListingCountryCode("GB"), "GB");
-  assert.equal(normaliseListingCountryCode(" au "), "au");
+  assert.equal(normaliseListingCountryCode(" au "), "AU");
 });

--- a/src/utils/listingCountry.ts
+++ b/src/utils/listingCountry.ts
@@ -6,9 +6,12 @@ export function normaliseListingCountryCode(
 ): string | null {
   const trimmed = countryCode?.trim() ?? "";
 
-  if (!trimmed || trimmed === LISTING_COUNTRY_PLACEHOLDER) {
+  if (
+    !trimmed ||
+    trimmed.toLowerCase() === LISTING_COUNTRY_PLACEHOLDER.toLowerCase()
+  ) {
     return null;
   }
 
-  return trimmed;
+  return trimmed.toUpperCase();
 }

--- a/src/utils/listingCountry.ts
+++ b/src/utils/listingCountry.ts
@@ -1,0 +1,14 @@
+/** Placeholder select value; never persist this as a country code. */
+export const LISTING_COUNTRY_PLACEHOLDER = "initial";
+
+export function normaliseListingCountryCode(
+  countryCode: string | null | undefined
+): string | null {
+  const trimmed = countryCode?.trim() ?? "";
+
+  if (!trimmed || trimmed === LISTING_COUNTRY_PLACEHOLDER) {
+    return null;
+  }
+
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

- Stop persisting the country `<select>` placeholder sentinel (`initial`) as a real `country_code`.
- Normalise empty/placeholder values to `null` when building the listing draft and on server insert/update.
- Keeps the existing nullable `text` column as-is (no schema change).

## Test plan

- [x] Run `npm run format` on changed files
- [x] Run `npm run check`
- [ ] Create a listing without a detected country and confirm `country_code` is stored as `null`, not `initial`
- [ ] Edit an existing listing and confirm a real ISO code still saves normally

## Notes

- One production row already had `country_code = 'initial'`; that can be fixed manually (e.g. to `GB`).
- Follow-up: address/area-name UX for residential listings is separate from this fix.