### PR TITLE
improve expired auth link recovery

### DIFF
--- a/docs/auth-session-architecture.md
+++ b/docs/auth-session-architecture.md
@@ -25,7 +25,7 @@ The hosted Send Email Auth Hook builds an app-owned URL containing `token_hash`,
 3. The page renders action-specific copy and a Continue form. The supported actions are sign-up confirmation, invitation acceptance, magic-link sign-in, password recovery, and email change.
 4. Only the form's explicit POST server action calls `supabase.auth.verifyOtp()`.
 5. A successful verification writes the Supabase session cookies, applies the requested locale, adds the email-change success state when relevant, and redirects to the normalised next path.
-6. Invalid, malformed, expired, or already-consumed tokens redirect to sign-in with the existing invalid-link message and safe `redirect_to` value.
+6. Invalid, malformed, expired, or already-consumed recovery tokens redirect to `/forgot-password` with a contextual error so the user can immediately request another link. Other auth types redirect to sign-in with the existing invalid-link message and safe `redirect_to` value.
 
 Form fields are untrusted input. The POST action must repeat auth-type validation and redirect-path normalisation rather than relying on the preceding GET. Keep this behaviour shared through `src/utils/authRedirects.ts`, and keep invalid-link redirect construction shared by the confirmation page and action.
 

--- a/docs/auth-session-architecture.md
+++ b/docs/auth-session-architecture.md
@@ -25,7 +25,14 @@ The hosted Send Email Auth Hook builds an app-owned URL containing `token_hash`,
 3. The page renders action-specific copy and a Continue form. The supported actions are sign-up confirmation, invitation acceptance, magic-link sign-in, password recovery, and email change.
 4. Only the form's explicit POST server action calls `supabase.auth.verifyOtp()`.
 5. A successful verification writes the Supabase session cookies, applies the requested locale, adds the email-change success state when relevant, and redirects to the normalised next path.
-6. Invalid, malformed, expired, or already-consumed recovery tokens redirect to `/forgot-password` with a contextual error so the user can immediately request another link. Other auth types redirect to sign-in with the existing invalid-link message and safe `redirect_to` value.
+6. Invalid, malformed, expired, or already-consumed tokens lead to an action-specific recovery path:
+   - Password recovery opens `/forgot-password`, where the user can request another reset link.
+   - Sign-up confirmation opens `/auth/retry`, where the user can resend the confirmation with `supabase.auth.resend()`.
+   - Magic-link sign-in opens `/auth/retry`, where the user can request another link with `supabase.auth.signInWithOtp()` and `shouldCreateUser: false`.
+   - Invitation acceptance explains that only the inviter can issue a replacement and offers ordinary sign-in for an existing account.
+   - Email change sends signed-in users back to account settings to restart the change. Signed-out users are asked to sign in first and then return there.
+
+The retry actions preserve the normalised next path and locale in the new email's redirect URL. They accept an email address instead of carrying it from the failed link, both because custom email URLs do not currently expose the recipient address and because query parameters are untrusted. Invitation links cannot be self-regenerated: doing so would require privileged knowledge of the inviter and intended role or account state.
 
 Form fields are untrusted input. The POST action must repeat auth-type validation and redirect-path normalisation rather than relying on the preceding GET. Keep this behaviour shared through `src/utils/authRedirects.ts`, and keep invalid-link redirect construction shared by the confirmation page and action.
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -158,6 +158,76 @@ test("malformed confirmation links show the invalid-link error", async ({
   await expect(page.locator('input[name="email"]')).toBeVisible();
 });
 
+test("other malformed auth links show their recovery action", async ({
+  page,
+}) => {
+  await page.goto("/auth/confirm?type=signup&next=/profile&locale=en");
+  await expect(page).toHaveURL(/\/auth\/retry\?.*type=signup/);
+  await expect(
+    page.getByRole("heading", { name: "Request a new confirmation link" })
+  ).toBeVisible();
+  await expect(page.locator('input[name="email"]')).toBeVisible();
+
+  await page.goto("/auth/confirm?type=magiclink&next=/map&locale=en");
+  await expect(page).toHaveURL(/\/auth\/retry\?.*type=magiclink/);
+  await expect(
+    page.getByRole("heading", { name: "Request a new sign-in link" })
+  ).toBeVisible();
+  await expect(page.locator('input[name="email"]')).toBeVisible();
+
+  await page.goto("/auth/confirm?type=invite&next=/profile&locale=en");
+  await expect(page).toHaveURL(/\/auth\/retry\?.*type=invite/);
+  await expect(
+    page.getByRole("heading", { name: "Invitation expired" })
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+
+  await page.goto("/auth/confirm?type=email_change&next=/profile&locale=en");
+  await expect(page).toHaveURL(/\/auth\/retry\?.*type=email_change/);
+  await expect(
+    page.getByRole("heading", { name: "Confirm your email again" })
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+});
+
+test("an expired magic link can be replaced", async ({ page }) => {
+  await page.goto("/auth/retry?type=magiclink&next=/map&locale=en");
+  await page.locator('input[name="email"]').fill(HOST_EMAIL);
+  await page.getByTestId("auth-retry-submit").click();
+
+  await expect(page).toHaveURL(/\/auth\/retry\?.*success=/);
+  await expect(page.locator('aside[role="status"]')).toContainText(
+    "Email sent. Check your inbox for the new link."
+  );
+});
+
+test("an expired sign-up confirmation can be replaced", async ({ page }) => {
+  const email = `auth-retry-${Date.now()}@peels.local`;
+  const admin = createAdminClient();
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password: SEEDED_PASSWORD,
+    email_confirm: false,
+  });
+  expect(error).toBeNull();
+  const userId = data.user?.id;
+  expect(userId).toBeTruthy();
+  if (!userId) throw new Error("Supabase did not create the test user");
+
+  try {
+    await page.goto("/auth/retry?type=signup&next=/profile&locale=en");
+    await page.locator('input[name="email"]').fill(email);
+    await page.getByTestId("auth-retry-submit").click();
+
+    await expect(page).toHaveURL(/\/auth\/retry\?.*success=/);
+    await expect(page.locator('aside[role="status"]')).toContainText(
+      "Email sent. Check your inbox for the new link."
+    );
+  } finally {
+    await admin.auth.admin.deleteUser(userId);
+  }
+});
+
 test("sign-in normalises unsafe redirect_to values", async ({ page }) => {
   await signIn(page, {
     email: HOST_EMAIL,

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -190,6 +190,23 @@ test("other malformed auth links show their recovery action", async ({
   await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
 });
 
+test("signed-in email-change failures return to account settings", async ({
+  page,
+}) => {
+  await signIn(page, { email: HOST_EMAIL });
+  await page.goto("/auth/confirm?type=email_change&next=/profile&locale=en");
+
+  await expect(page).toHaveURL(/\/auth\/retry\?.*type=email_change/);
+  const accountSettingsLink = page.getByRole("link", {
+    name: "Go to account settings",
+  });
+  await expect(accountSettingsLink).toBeVisible();
+  await expect(accountSettingsLink).toHaveAttribute(
+    "href",
+    /\/profile\?error=/
+  );
+});
+
 test("an expired magic link can be replaced", async ({ page }) => {
   await page.goto("/auth/retry?type=magiclink&next=/map&locale=en");
   await page.locator('input[name="email"]').fill(HOST_EMAIL);

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -139,10 +139,11 @@ test("consumed recovery tokens show the invalid-link error", async ({
   );
   await page.getByTestId("auth-confirm-submit").click();
 
-  await expect(page).toHaveURL(/\/sign-in\?.*error=/);
-  await expect(page.getByTestId("sign-in-form")).toContainText(
-    /invalid or has expired/i
+  await expect(page).toHaveURL(/\/forgot-password\?.*error=/);
+  await expect(page.locator('aside[role="alert"]')).toContainText(
+    "This password reset link is invalid or has expired. Request a new one below."
   );
+  await expect(page.locator('input[name="email"]')).toBeVisible();
 });
 
 test("malformed confirmation links show the invalid-link error", async ({
@@ -150,10 +151,11 @@ test("malformed confirmation links show the invalid-link error", async ({
 }) => {
   await page.goto("/auth/confirm?type=recovery&next=/profile/reset-password");
 
-  await expect(page).toHaveURL(/\/sign-in\?.*error=/);
-  await expect(page.getByTestId("sign-in-form")).toContainText(
-    /invalid or has expired/i
+  await expect(page).toHaveURL(/\/forgot-password\?.*error=/);
+  await expect(page.locator('aside[role="alert"]')).toContainText(
+    "This password reset link is invalid or has expired. Request a new one below."
   );
+  await expect(page.locator('input[name="email"]')).toBeVisible();
 });
 
 test("sign-in normalises unsafe redirect_to values", async ({ page }) => {

--- a/messages/de.json
+++ b/messages/de.json
@@ -77,7 +77,11 @@
   },
   "Errors": {
     "authLinkInvalid": "Dieser Anmeldelink ist ungültig oder abgelaufen. Fordere bitte einen neuen an.",
+    "emailChangeLinkInvalid": "Dieser Link zur E-Mail-Änderung ist ungültig oder abgelaufen. Starte die Änderung in deinen Kontoeinstellungen erneut.",
+    "inviteLinkInvalid": "Dieser Einladungslink ist ungültig oder abgelaufen. Bitte die Person, die dich eingeladen hat, eine neue Einladung zu senden.",
+    "magicLinkInvalid": "Dieser Anmeldelink ist ungültig oder abgelaufen. Fordere unten einen neuen an.",
     "passwordResetLinkInvalid": "Dieser Link zum Zurücksetzen des Passworts ist ungültig oder abgelaufen. Fordere unten einen neuen an.",
+    "signupLinkInvalid": "Dieser Bestätigungslink ist ungültig oder abgelaufen. Fordere unten einen neuen an.",
     "alreadyYourEmail": "Das ist bereits deine E-Mail-Adresse.",
     "emptyListingName": "{type, select, business {Der Name des Unternehmens darf nicht leer sein.} community {Der Name der Community darf nicht leer sein.} other {Der Name des Eintrags darf nicht leer sein.}}",
     "emptyName": "Der Name darf nicht leer sein.",
@@ -317,6 +321,26 @@
         "body": "Drücke „Weiter“, um die Erstellung deines Kontos abzuschließen."
       },
       "pendingAction": "Weiter..."
+    },
+    "retry": {
+      "emailChange": {
+        "title": "E-Mail erneut bestätigen",
+        "body": "Starte die E-Mail-Änderung in deinen Kontoeinstellungen erneut.",
+        "action": "Zu den Kontoeinstellungen"
+      },
+      "invite": {
+        "title": "Einladung abgelaufen",
+        "body": "Bitte die Person, die dich eingeladen hat, eine neue Einladung zu senden."
+      },
+      "magiclink": {
+        "title": "Neuen Anmeldelink anfordern",
+        "body": "Gib deine E-Mail-Adresse ein und wir senden dir einen neuen Link."
+      },
+      "signup": {
+        "title": "Neuen Bestätigungslink anfordern",
+        "body": "Gib die E-Mail-Adresse ein, mit der du dich registriert hast, und wir senden dir einen neuen Link."
+      },
+      "emailSent": "E-Mail gesendet. Prüfe deinen Posteingang auf den neuen Link."
     },
     "complete": {
       "title": "Du wirst angemeldet...",

--- a/messages/de.json
+++ b/messages/de.json
@@ -76,6 +76,8 @@
     "working": "Wird verarbeitet..."
   },
   "Errors": {
+    "authLinkInvalid": "Dieser Anmeldelink ist ungültig oder abgelaufen. Fordere bitte einen neuen an.",
+    "passwordResetLinkInvalid": "Dieser Link zum Zurücksetzen des Passworts ist ungültig oder abgelaufen. Fordere unten einen neuen an.",
     "alreadyYourEmail": "Das ist bereits deine E-Mail-Adresse.",
     "emptyListingName": "{type, select, business {Der Name des Unternehmens darf nicht leer sein.} community {Der Name der Community darf nicht leer sein.} other {Der Name des Eintrags darf nicht leer sein.}}",
     "emptyName": "Der Name darf nicht leer sein.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -76,6 +76,8 @@
     "working": "Working..."
   },
   "Errors": {
+    "authLinkInvalid": "Hmm, that sign-in link is invalid or has expired. Please request a new one.",
+    "passwordResetLinkInvalid": "This password reset link is invalid or has expired. Request a new one below.",
     "alreadyYourEmail": "This is already your email address.",
     "emptyListingName": "{type, select, business {You can't have an empty business name.} community {You can't have an empty community name.} other {You can't have an empty listing name.}}",
     "emptyName": "You can’t have an empty name.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -77,7 +77,11 @@
   },
   "Errors": {
     "authLinkInvalid": "Hmm, that sign-in link is invalid or has expired. Please request a new one.",
+    "emailChangeLinkInvalid": "This email-change link is invalid or has expired. Restart the change from your account settings.",
+    "inviteLinkInvalid": "This invitation link is invalid or has expired. Ask the person who invited you to send a new one.",
+    "magicLinkInvalid": "This sign-in link is invalid or has expired. Request a new one below.",
     "passwordResetLinkInvalid": "This password reset link is invalid or has expired. Request a new one below.",
+    "signupLinkInvalid": "This confirmation link is invalid or has expired. Request a new one below.",
     "alreadyYourEmail": "This is already your email address.",
     "emptyListingName": "{type, select, business {You can't have an empty business name.} community {You can't have an empty community name.} other {You can't have an empty listing name.}}",
     "emptyName": "You can’t have an empty name.",
@@ -317,6 +321,26 @@
         "body": "Press ‘Continue’ to finish creating your account."
       },
       "pendingAction": "Continuing..."
+    },
+    "retry": {
+      "emailChange": {
+        "title": "Confirm your email again",
+        "body": "Restart the email change from your account settings.",
+        "action": "Go to account settings"
+      },
+      "invite": {
+        "title": "Invitation expired",
+        "body": "Ask the person who invited you to send a new invitation."
+      },
+      "magiclink": {
+        "title": "Request a new sign-in link",
+        "body": "Enter your email and we’ll send you a new link."
+      },
+      "signup": {
+        "title": "Request a new confirmation link",
+        "body": "Enter the email you signed up with and we’ll send you a new link."
+      },
+      "emailSent": "Email sent. Check your inbox for the new link."
     },
     "complete": {
       "title": "Signing you in...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -77,7 +77,11 @@
   },
   "Errors": {
     "authLinkInvalid": "Este enlace de inicio de sesión no es válido o ha caducado. Solicita uno nuevo.",
+    "emailChangeLinkInvalid": "Este enlace para cambiar el correo no es válido o ha caducado. Reinicia el cambio desde la configuración de tu cuenta.",
+    "inviteLinkInvalid": "Este enlace de invitación no es válido o ha caducado. Pide a la persona que te invitó que envíe uno nuevo.",
+    "magicLinkInvalid": "Este enlace de inicio de sesión no es válido o ha caducado. Solicita uno nuevo abajo.",
     "passwordResetLinkInvalid": "Este enlace para restablecer la contraseña no es válido o ha caducado. Solicita uno nuevo abajo.",
+    "signupLinkInvalid": "Este enlace de confirmación no es válido o ha caducado. Solicita uno nuevo abajo.",
     "alreadyYourEmail": "Esta ya es tu dirección de correo electrónico.",
     "emptyListingName": "{type, select, business {No puedes dejar vacío el nombre del negocio.} community {No puedes dejar vacío el nombre de la comunidad.} other {No puedes dejar vacío el nombre del anuncio.}}",
     "emptyName": "No puedes dejar el nombre vacío.",
@@ -317,6 +321,26 @@
         "body": "Pulsa «Continuar» para terminar de crear tu cuenta."
       },
       "pendingAction": "Continuando..."
+    },
+    "retry": {
+      "emailChange": {
+        "title": "Confirma tu correo de nuevo",
+        "body": "Reinicia el cambio de correo desde la configuración de tu cuenta.",
+        "action": "Ir a la configuración de la cuenta"
+      },
+      "invite": {
+        "title": "La invitación ha caducado",
+        "body": "Pide a la persona que te invitó que envíe una nueva invitación."
+      },
+      "magiclink": {
+        "title": "Solicita un nuevo enlace de inicio de sesión",
+        "body": "Introduce tu correo y te enviaremos un enlace nuevo."
+      },
+      "signup": {
+        "title": "Solicita un nuevo enlace de confirmación",
+        "body": "Introduce el correo con el que te registraste y te enviaremos un enlace nuevo."
+      },
+      "emailSent": "Correo enviado. Revisa tu bandeja de entrada para encontrar el nuevo enlace."
     },
     "complete": {
       "title": "Iniciando sesión...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -76,6 +76,8 @@
     "working": "Procesando..."
   },
   "Errors": {
+    "authLinkInvalid": "Este enlace de inicio de sesión no es válido o ha caducado. Solicita uno nuevo.",
+    "passwordResetLinkInvalid": "Este enlace para restablecer la contraseña no es válido o ha caducado. Solicita uno nuevo abajo.",
     "alreadyYourEmail": "Esta ya es tu dirección de correo electrónico.",
     "emptyListingName": "{type, select, business {No puedes dejar vacío el nombre del negocio.} community {No puedes dejar vacío el nombre de la comunidad.} other {No puedes dejar vacío el nombre del anuncio.}}",
     "emptyName": "No puedes dejar el nombre vacío.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -76,6 +76,8 @@
     "working": "Traitement..."
   },
   "Errors": {
+    "authLinkInvalid": "Ce lien de connexion est invalide ou a expiré. Veuillez en demander un nouveau.",
+    "passwordResetLinkInvalid": "Ce lien de réinitialisation du mot de passe est invalide ou a expiré. Demandez-en un nouveau ci-dessous.",
     "alreadyYourEmail": "C’est déjà votre adresse e-mail.",
     "emptyListingName": "{type, select, business {Le nom du commerce ne peut pas être vide.} community {Le nom de la communauté ne peut pas être vide.} other {Le nom de l’annonce ne peut pas être vide.}}",
     "emptyName": "Le nom ne peut pas être vide.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -77,7 +77,11 @@
   },
   "Errors": {
     "authLinkInvalid": "Ce lien de connexion est invalide ou a expiré. Veuillez en demander un nouveau.",
+    "emailChangeLinkInvalid": "Ce lien de changement d’adresse e-mail est invalide ou a expiré. Recommencez depuis les paramètres de votre compte.",
+    "inviteLinkInvalid": "Ce lien d’invitation est invalide ou a expiré. Demandez à la personne qui vous a invité d’en envoyer un nouveau.",
+    "magicLinkInvalid": "Ce lien de connexion est invalide ou a expiré. Demandez-en un nouveau ci-dessous.",
     "passwordResetLinkInvalid": "Ce lien de réinitialisation du mot de passe est invalide ou a expiré. Demandez-en un nouveau ci-dessous.",
+    "signupLinkInvalid": "Ce lien de confirmation est invalide ou a expiré. Demandez-en un nouveau ci-dessous.",
     "alreadyYourEmail": "C’est déjà votre adresse e-mail.",
     "emptyListingName": "{type, select, business {Le nom du commerce ne peut pas être vide.} community {Le nom de la communauté ne peut pas être vide.} other {Le nom de l’annonce ne peut pas être vide.}}",
     "emptyName": "Le nom ne peut pas être vide.",
@@ -317,6 +321,26 @@
         "body": "Appuyez sur « Continuer » pour terminer la création de votre compte."
       },
       "pendingAction": "Continuation..."
+    },
+    "retry": {
+      "emailChange": {
+        "title": "Confirmez à nouveau votre adresse e-mail",
+        "body": "Recommencez le changement d’adresse e-mail depuis les paramètres de votre compte.",
+        "action": "Accéder aux paramètres du compte"
+      },
+      "invite": {
+        "title": "Invitation expirée",
+        "body": "Demandez à la personne qui vous a invité d’envoyer une nouvelle invitation."
+      },
+      "magiclink": {
+        "title": "Demandez un nouveau lien de connexion",
+        "body": "Saisissez votre adresse e-mail et nous vous enverrons un nouveau lien."
+      },
+      "signup": {
+        "title": "Demandez un nouveau lien de confirmation",
+        "body": "Saisissez l’adresse e-mail utilisée lors de votre inscription et nous vous enverrons un nouveau lien."
+      },
+      "emailSent": "E-mail envoyé. Consultez votre boîte de réception pour trouver le nouveau lien."
     },
     "complete": {
       "title": "Connexion en cours...",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -76,6 +76,8 @@
     "working": "Processando..."
   },
   "Errors": {
+    "authLinkInvalid": "Este link de acesso é inválido ou expirou. Solicite um novo.",
+    "passwordResetLinkInvalid": "Este link de redefinição de senha é inválido ou expirou. Solicite um novo abaixo.",
     "alreadyYourEmail": "Este já é o seu endereço de e-mail.",
     "emptyListingName": "{type, select, business {O nome do negócio não pode ficar vazio.} community {O nome da comunidade não pode ficar vazio.} other {O nome do anúncio não pode ficar vazio.}}",
     "emptyName": "O nome não pode ficar vazio.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -77,7 +77,11 @@
   },
   "Errors": {
     "authLinkInvalid": "Este link de acesso é inválido ou expirou. Solicite um novo.",
+    "emailChangeLinkInvalid": "Este link para alterar o e-mail é inválido ou expirou. Reinicie a alteração nas configurações da sua conta.",
+    "inviteLinkInvalid": "Este link de convite é inválido ou expirou. Peça à pessoa que convidou você para enviar um novo.",
+    "magicLinkInvalid": "Este link de acesso é inválido ou expirou. Solicite um novo abaixo.",
     "passwordResetLinkInvalid": "Este link de redefinição de senha é inválido ou expirou. Solicite um novo abaixo.",
+    "signupLinkInvalid": "Este link de confirmação é inválido ou expirou. Solicite um novo abaixo.",
     "alreadyYourEmail": "Este já é o seu endereço de e-mail.",
     "emptyListingName": "{type, select, business {O nome do negócio não pode ficar vazio.} community {O nome da comunidade não pode ficar vazio.} other {O nome do anúncio não pode ficar vazio.}}",
     "emptyName": "O nome não pode ficar vazio.",
@@ -317,6 +321,26 @@
         "body": "Pressione “Continuar” para terminar de criar a sua conta."
       },
       "pendingAction": "Continuando..."
+    },
+    "retry": {
+      "emailChange": {
+        "title": "Confirme seu e-mail novamente",
+        "body": "Reinicie a alteração de e-mail nas configurações da sua conta.",
+        "action": "Ir para as configurações da conta"
+      },
+      "invite": {
+        "title": "O convite expirou",
+        "body": "Peça à pessoa que convidou você para enviar um novo convite."
+      },
+      "magiclink": {
+        "title": "Solicite um novo link de acesso",
+        "body": "Digite seu e-mail e enviaremos um novo link."
+      },
+      "signup": {
+        "title": "Solicite um novo link de confirmação",
+        "body": "Digite o e-mail usado no cadastro e enviaremos um novo link."
+      },
+      "emailSent": "E-mail enviado. Verifique sua caixa de entrada para encontrar o novo link."
     },
     "complete": {
       "title": "Entrando...",

--- a/src/app/(forms)/auth/confirm/actions.ts
+++ b/src/app/(forms)/auth/confirm/actions.ts
@@ -10,6 +10,7 @@ import {
 } from "@/utils/authRedirects";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { getInvalidLinkRedirectPath } from "./redirects";
 
 const isAuthDebugEnabled = process.env.NEXT_PUBLIC_AUTH_DEBUG === "true";
@@ -19,8 +20,16 @@ const debugAuth = (event: string, data?: Record<string, unknown>) => {
   console.log("[auth-confirm]", event, data ?? {});
 };
 
-const redirectToSignIn = (nextPath: string): never => {
-  redirect(getInvalidLinkRedirectPath(nextPath));
+const redirectFromInvalidLink = async (
+  authType: string | null,
+  nextPath: string
+): Promise<never> => {
+  const t = await getTranslations("Errors");
+  const errorMessage =
+    authType === "recovery"
+      ? t("passwordResetLinkInvalid")
+      : t("authLinkInvalid");
+  redirect(getInvalidLinkRedirectPath({ authType, errorMessage, nextPath }));
 };
 
 export async function confirmEmailAuthAction(formData: FormData) {
@@ -41,7 +50,7 @@ export async function confirmEmailAuthAction(formData: FormData) {
       authType,
       nextPath,
     });
-    return redirectToSignIn(nextPath);
+    return redirectFromInvalidLink(authType, nextPath);
   }
 
   const verifiedAuthType = authType;
@@ -61,7 +70,7 @@ export async function confirmEmailAuthAction(formData: FormData) {
       authType,
       nextPath,
     });
-    return redirectToSignIn(nextPath);
+    return redirectFromInvalidLink(authType, nextPath);
   }
 
   const resolvedNextPath =

--- a/src/app/(forms)/auth/confirm/actions.ts
+++ b/src/app/(forms)/auth/confirm/actions.ts
@@ -22,14 +22,28 @@ const debugAuth = (event: string, data?: Record<string, unknown>) => {
 
 const redirectFromInvalidLink = async (
   authType: string | null,
-  nextPath: string
+  nextPath: string,
+  locale?: string | null
 ): Promise<never> => {
   const t = await getTranslations("Errors");
+  const errorMessageByType: Record<string, string> = {
+    recovery: t("passwordResetLinkInvalid"),
+    signup: t("signupLinkInvalid"),
+    email: t("magicLinkInvalid"),
+    magiclink: t("magicLinkInvalid"),
+    invite: t("inviteLinkInvalid"),
+    email_change: t("emailChangeLinkInvalid"),
+  };
   const errorMessage =
-    authType === "recovery"
-      ? t("passwordResetLinkInvalid")
-      : t("authLinkInvalid");
-  redirect(getInvalidLinkRedirectPath({ authType, errorMessage, nextPath }));
+    (authType && errorMessageByType[authType]) ?? t("authLinkInvalid");
+  redirect(
+    getInvalidLinkRedirectPath({
+      authType,
+      errorMessage,
+      locale,
+      nextPath,
+    })
+  );
 };
 
 export async function confirmEmailAuthAction(formData: FormData) {
@@ -50,7 +64,7 @@ export async function confirmEmailAuthAction(formData: FormData) {
       authType,
       nextPath,
     });
-    return redirectFromInvalidLink(authType, nextPath);
+    return redirectFromInvalidLink(authType, nextPath, locale);
   }
 
   const verifiedAuthType = authType;
@@ -70,7 +84,7 @@ export async function confirmEmailAuthAction(formData: FormData) {
       authType,
       nextPath,
     });
-    return redirectFromInvalidLink(authType, nextPath);
+    return redirectFromInvalidLink(authType, nextPath, locale);
   }
 
   const resolvedNextPath =

--- a/src/app/(forms)/auth/confirm/page.tsx
+++ b/src/app/(forms)/auth/confirm/page.tsx
@@ -40,15 +40,19 @@ export default async function ConfirmEmailAuthPage({
     requestedNextPath,
     getDefaultNextPathByType(authType)
   );
+  const t = await getTranslations();
 
   if (!tokenHash || !isSupportedEmailAuthType(authType)) {
-    redirect(getInvalidLinkRedirectPath(nextPath));
+    const errorMessage =
+      authType === "recovery"
+        ? t("Errors.passwordResetLinkInvalid")
+        : t("Errors.authLinkInvalid");
+    redirect(getInvalidLinkRedirectPath({ authType, errorMessage, nextPath }));
   }
 
   const locale = getLocaleFromSearchParams(params);
   const email = firstValue(params.email);
   const confirmationCopy = confirmationCopyByType[authType];
-  const t = await getTranslations();
 
   return (
     <>

--- a/src/app/(forms)/auth/confirm/page.tsx
+++ b/src/app/(forms)/auth/confirm/page.tsx
@@ -41,16 +41,29 @@ export default async function ConfirmEmailAuthPage({
     getDefaultNextPathByType(authType)
   );
   const t = await getTranslations();
+  const locale = getLocaleFromSearchParams(params);
 
   if (!tokenHash || !isSupportedEmailAuthType(authType)) {
+    const errorMessageByType: Record<string, string> = {
+      recovery: t("Errors.passwordResetLinkInvalid"),
+      signup: t("Errors.signupLinkInvalid"),
+      email: t("Errors.magicLinkInvalid"),
+      magiclink: t("Errors.magicLinkInvalid"),
+      invite: t("Errors.inviteLinkInvalid"),
+      email_change: t("Errors.emailChangeLinkInvalid"),
+    };
     const errorMessage =
-      authType === "recovery"
-        ? t("Errors.passwordResetLinkInvalid")
-        : t("Errors.authLinkInvalid");
-    redirect(getInvalidLinkRedirectPath({ authType, errorMessage, nextPath }));
+      (authType && errorMessageByType[authType]) ?? t("Errors.authLinkInvalid");
+    redirect(
+      getInvalidLinkRedirectPath({
+        authType,
+        errorMessage,
+        locale,
+        nextPath,
+      })
+    );
   }
 
-  const locale = getLocaleFromSearchParams(params);
   const email = firstValue(params.email);
   const confirmationCopy = confirmationCopyByType[authType];
 

--- a/src/app/(forms)/auth/confirm/redirects.test.ts
+++ b/src/app/(forms)/auth/confirm/redirects.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getInvalidLinkRedirectPath } from "./redirects.ts";
+
+describe("getInvalidLinkRedirectPath", () => {
+  const retryCases = [
+    ["signup", "signup"],
+    ["email", "magiclink"],
+    ["magiclink", "magiclink"],
+    ["invite", "invite"],
+    ["email_change", "email_change"],
+  ] as const;
+
+  for (const [authType, retryType] of retryCases) {
+    it(`routes ${authType} failures to the ${retryType} retry flow`, () => {
+      const path = getInvalidLinkRedirectPath({
+        authType,
+        errorMessage: "Link expired",
+        locale: "es",
+        nextPath: "/profile?tab=account",
+      });
+      const url = new URL(path, "https://www.peels.org");
+
+      assert.equal(url.pathname, "/auth/retry");
+      assert.equal(url.searchParams.get("type"), retryType);
+      assert.equal(url.searchParams.get("error"), "Link expired");
+      assert.equal(url.searchParams.get("locale"), "es");
+      assert.equal(url.searchParams.get("next"), "/profile?tab=account");
+    });
+  }
+
+  it("keeps password recovery on the forgot-password form", () => {
+    assert.equal(
+      getInvalidLinkRedirectPath({
+        authType: "recovery",
+        errorMessage: "Link expired",
+        nextPath: "/profile/reset-password",
+      }),
+      "/forgot-password?error=Link+expired"
+    );
+  });
+
+  it("uses sign-in as the fallback for unsupported types", () => {
+    assert.equal(
+      getInvalidLinkRedirectPath({
+        authType: "unknown",
+        errorMessage: "Link expired",
+        nextPath: "/map",
+      }),
+      "/sign-in?error=Link+expired&redirect_to=%2Fmap"
+    );
+  });
+});

--- a/src/app/(forms)/auth/confirm/redirects.ts
+++ b/src/app/(forms)/auth/confirm/redirects.ts
@@ -1,10 +1,12 @@
 export function getInvalidLinkRedirectPath({
   authType,
   errorMessage,
+  locale,
   nextPath,
 }: {
   authType: string | null;
   errorMessage: string;
+  locale?: string | null;
   nextPath: string;
 }) {
   const searchParams = new URLSearchParams({
@@ -13,6 +15,20 @@ export function getInvalidLinkRedirectPath({
 
   if (authType === "recovery") {
     return `/forgot-password?${searchParams}`;
+  }
+
+  if (
+    authType === "signup" ||
+    authType === "email" ||
+    authType === "magiclink" ||
+    authType === "invite" ||
+    authType === "email_change"
+  ) {
+    const retryType = authType === "email" ? "magiclink" : authType;
+    searchParams.set("type", retryType);
+    searchParams.set("next", nextPath);
+    if (locale) searchParams.set("locale", locale);
+    return `/auth/retry?${searchParams}`;
   }
 
   searchParams.set("redirect_to", nextPath);

--- a/src/app/(forms)/auth/confirm/redirects.ts
+++ b/src/app/(forms)/auth/confirm/redirects.ts
@@ -1,10 +1,20 @@
-const invalidLinkMessage =
-  "Hmm, that sign-in link is invalid or has expired. Please request a new one.";
-
-export function getInvalidLinkRedirectPath(nextPath: string) {
+export function getInvalidLinkRedirectPath({
+  authType,
+  errorMessage,
+  nextPath,
+}: {
+  authType: string | null;
+  errorMessage: string;
+  nextPath: string;
+}) {
   const searchParams = new URLSearchParams({
-    error: invalidLinkMessage,
-    redirect_to: nextPath,
+    error: errorMessage,
   });
+
+  if (authType === "recovery") {
+    return `/forgot-password?${searchParams}`;
+  }
+
+  searchParams.set("redirect_to", nextPath);
   return `/sign-in?${searchParams}`;
 }

--- a/src/app/(forms)/auth/retry/actions.ts
+++ b/src/app/(forms)/auth/retry/actions.ts
@@ -1,0 +1,117 @@
+"use server";
+
+import { getUserLocale } from "@/i18n/services/locale";
+import { normaliseNextPath, resolveAuthLocale } from "@/utils/authRedirects";
+import { createClient } from "@/utils/supabase/server";
+import { getBaseUrl } from "@/utils/url";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+const getRetryPath = ({
+  error,
+  locale,
+  nextPath,
+  success,
+  type,
+}: {
+  error?: string;
+  locale: string;
+  nextPath: string;
+  success?: string;
+  type: "magiclink" | "signup";
+}) => {
+  const searchParams = new URLSearchParams({
+    locale,
+    next: nextPath,
+    type,
+  });
+  if (error) searchParams.set("error", error);
+  if (success) searchParams.set("success", success);
+  return `/auth/retry?${searchParams}`;
+};
+
+const getEmailRedirectTo = ({
+  locale,
+  nextPath,
+  origin,
+}: {
+  locale: string;
+  nextPath: string;
+  origin: string;
+}) => {
+  const searchParams = new URLSearchParams({
+    locale,
+    next: nextPath,
+  });
+  return `${origin}/auth/complete?${searchParams}`;
+};
+
+export async function retryEmailAuthAction(formData: FormData) {
+  const t = await getTranslations();
+  const email = formData.get("email")?.toString().trim();
+  const requestedType = formData.get("type")?.toString();
+  const type =
+    requestedType === "signup" || requestedType === "magiclink"
+      ? requestedType
+      : null;
+  const nextPath = normaliseNextPath(
+    formData.get("next")?.toString(),
+    "/profile"
+  );
+  const locale = resolveAuthLocale(
+    formData.get("locale")?.toString() ?? (await getUserLocale())
+  );
+
+  if (!type) redirect("/sign-in");
+
+  if (!email) {
+    redirect(
+      getRetryPath({
+        error: t("Errors.emailRequired"),
+        locale,
+        nextPath,
+        type,
+      })
+    );
+  }
+
+  const supabase = await createClient();
+  const origin = (await headers()).get("origin") || getBaseUrl();
+  const emailRedirectTo = getEmailRedirectTo({ locale, nextPath, origin });
+  const { error } =
+    type === "signup"
+      ? await supabase.auth.resend({
+          type: "signup",
+          email,
+          options: { emailRedirectTo },
+        })
+      : await supabase.auth.signInWithOtp({
+          email,
+          options: {
+            emailRedirectTo,
+            shouldCreateUser: false,
+          },
+        });
+
+  if (error) {
+    console.error(`Error retrying ${type} auth email:`, error.message);
+    redirect(
+      getRetryPath({
+        error: t("Errors.generic"),
+        locale,
+        nextPath,
+        type,
+      })
+    );
+  }
+
+  redirect(
+    getRetryPath({
+      locale,
+      nextPath,
+      success: t("Auth.retry.emailSent"),
+      type,
+    })
+  );
+}

--- a/src/app/(forms)/auth/retry/page.tsx
+++ b/src/app/(forms)/auth/retry/page.tsx
@@ -10,7 +10,11 @@ import {
   getLocaleFromSearchParams,
   normaliseNextPath,
 } from "@/utils/authRedirects";
-import { createClient } from "@/utils/supabase/server";
+import {
+  authStateHeaderName,
+  authStateSignedIn,
+} from "@/utils/supabase/authState";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { retryEmailAuthAction } from "./actions";
@@ -60,10 +64,8 @@ export default async function RetryEmailAuthPage({
   }
 
   if (type === "email_change") {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    const isSignedIn =
+      (await headers()).get(authStateHeaderName) === authStateSignedIn;
     const profilePath = `/profile?${new URLSearchParams({
       error: error ?? t("Errors.emailChangeLinkInvalid"),
     })}`;
@@ -77,14 +79,16 @@ export default async function RetryEmailAuthPage({
         <Form as="container">
           <Button
             href={
-              user
+              isSignedIn
                 ? profilePath
                 : `/sign-in?${new URLSearchParams({ redirect_to: profilePath })}`
             }
             variant="primary"
             width="full"
           >
-            {user ? t("Auth.retry.emailChange.action") : t("Actions.signIn")}
+            {isSignedIn
+              ? t("Auth.retry.emailChange.action")
+              : t("Actions.signIn")}
           </Button>
         </Form>
       </>

--- a/src/app/(forms)/auth/retry/page.tsx
+++ b/src/app/(forms)/auth/retry/page.tsx
@@ -1,0 +1,127 @@
+import Button from "@/components/Button";
+import Field from "@/components/Field";
+import Form from "@/components/Form";
+import FormHeader from "@/components/FormHeader";
+import FormMessage from "@/components/FormMessage";
+import Input from "@/components/Input";
+import Label from "@/components/Label";
+import SubmitButton from "@/components/SubmitButton";
+import {
+  getLocaleFromSearchParams,
+  normaliseNextPath,
+} from "@/utils/authRedirects";
+import { createClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { retryEmailAuthAction } from "./actions";
+
+type RetryType = "email_change" | "invite" | "magiclink" | "signup";
+type RetrySearchParams = Record<string, string | string[] | undefined>;
+
+const firstValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const isRetryType = (value: string | undefined): value is RetryType =>
+  value === "email_change" ||
+  value === "invite" ||
+  value === "magiclink" ||
+  value === "signup";
+
+export default async function RetryEmailAuthPage({
+  searchParams,
+}: {
+  searchParams: Promise<RetrySearchParams>;
+}) {
+  const params = await searchParams;
+  const requestedType = firstValue(params.type);
+  if (!isRetryType(requestedType)) redirect("/sign-in");
+
+  const type = requestedType;
+  const nextPath = normaliseNextPath(firstValue(params.next), "/profile");
+  const locale = getLocaleFromSearchParams(params);
+  const error = firstValue(params.error);
+  const success = firstValue(params.success);
+  const t = await getTranslations();
+
+  if (type === "invite") {
+    return (
+      <>
+        <FormHeader button="none">
+          <h1>{t("Auth.retry.invite.title")}</h1>
+          <p>{t("Auth.retry.invite.body")}</p>
+        </FormHeader>
+        <Form as="container">
+          <Button href="/sign-in" variant="primary" width="full">
+            {t("Actions.signIn")}
+          </Button>
+        </Form>
+      </>
+    );
+  }
+
+  if (type === "email_change") {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const profilePath = `/profile?${new URLSearchParams({
+      error: error ?? t("Errors.emailChangeLinkInvalid"),
+    })}`;
+
+    return (
+      <>
+        <FormHeader button="none">
+          <h1>{t("Auth.retry.emailChange.title")}</h1>
+          <p>{t("Auth.retry.emailChange.body")}</p>
+        </FormHeader>
+        <Form as="container">
+          <Button
+            href={
+              user
+                ? profilePath
+                : `/sign-in?${new URLSearchParams({ redirect_to: profilePath })}`
+            }
+            variant="primary"
+            width="full"
+          >
+            {user ? t("Auth.retry.emailChange.action") : t("Actions.signIn")}
+          </Button>
+        </Form>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <FormHeader button="none">
+        <h1>{t(`Auth.retry.${type}.title`)}</h1>
+        <p>{t(`Auth.retry.${type}.body`)}</p>
+      </FormHeader>
+      <Form action={retryEmailAuthAction}>
+        <input type="hidden" name="type" value={type} />
+        <input type="hidden" name="next" value={nextPath} />
+        {locale && <input type="hidden" name="locale" value={locale} />}
+        <Field>
+          <Label htmlFor="email">{t("Common.email")}</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@example.com"
+            required
+          />
+        </Field>
+        {(error || success) && (
+          <FormMessage message={success ? { success } : { error }} />
+        )}
+        <SubmitButton
+          pendingText={t("Status.emailing")}
+          width="full"
+          data-testid="auth-retry-submit"
+        >
+          {t("Actions.emailLink")}
+        </SubmitButton>
+      </Form>
+    </>
+  );
+}

--- a/src/components/FormHeader/FormHeader.tsx
+++ b/src/components/FormHeader/FormHeader.tsx
@@ -41,6 +41,7 @@ const Header = styled.header<{ $button?: FormHeaderButton }>`
 
 const Text = styled.div`
   ${sharedSectionTextBlockStyles}
+  gap: 2rem;
   max-width: ${theme.spacing.container.textOpticalWidth};
 
   & h1 {


### PR DESCRIPTION
Thank you for your contribution to Peels! Before submitting, please:

- [x] Run `npm run format` on your changes
- [ ] Run `npm run build` without errors or warnings
- [x] Run `npm run check` when the change touches app logic, messages, or tests

## Summary

- Give form-page headings and supporting copy the same established spacing as the surrounding reset-password states.
- Send invalid or expired recovery links to the password-reset request form with contextual guidance.
- Add action-specific recovery for sign-up confirmation, magic-link sign-in, invitations, and email changes instead of falling back to a generic sign-in error.
- Preserve safe next paths and locales in replacement emails, and document the complete retry architecture.

## Test plan

- [x] `npm run check` (58 unit tests)
- [x] `npm run typecheck`
- [x] `PLAYWRIGHT_PORT=3017 npm run test:e2e:prod -- e2e/auth.spec.ts` (production build and 12 tests passed before adding resend submissions)
- [x] `PLAYWRIGHT_PORT=3022 npm run test:e2e:prod -- e2e/auth.spec.ts` (production build and 15 tests passed, including real replacement emails and signed-in email-change recovery)
- [x] Confirm Mailpit receives both replacement email types and preserves the safe next path and locale.
- [x] Visually inspect the sign-up retry screen at 1280×900 and invitation recovery at 390×844.
- [ ] On the preview, open previously consumed links for each available auth action and confirm the matching recovery state.

## Notes

Invitation links cannot be self-regenerated safely, so that state asks the recipient to contact the inviter. Email-change failures return to account settings, asking signed-out users to authenticate first.

The production build succeeds with the existing Node `module.register()` deprecation warnings. No Supabase dashboard or email-template changes are required.
