### PR TITLE
improve homepage content and promotion controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ npm run dev
 - We’re slowly moving towards TypeScript for type safety
 - Heavy commenting is encouraged to make the codebase accessible to others
 - Code formatting is handled by Prettier. Please ensure your code is formatted according to `.prettierrc` before submitting a pull request
+- The homepage newsletter section is controlled by `siteConfig.showNewsletterOnHomepage` in `src/config/site.ts`. Turn it on when there is a recent issue to promote and off when the latest issue is no longer timely.
 
 ### Languages and Localised Content
 

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -27,7 +27,7 @@ test("homepage renders static content before deferred chat demo hydrates", async
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(
     page.getByRole("heading", {
-      name: "Find a home for your food scraps, wherever you are",
+      name: "Find a home for your food scraps",
     })
   ).toBeVisible();
 

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -173,6 +173,7 @@ test("homepage emits summary FAQPage JSON-LD", async ({ page }) => {
       "Can I compost food scraps if I don’t have a garden or compost bin?",
       "Can businesses use Peels to donate food scraps?",
       "I’m not comfortable sharing my address. Can I still participate?",
+      "How can I promote Peels to my community?",
     ])
   );
   expect(questions).not.toContain("Who maintains Peels?");

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -117,12 +117,10 @@ test("homepage exposes canonical social metadata and one primary H1", async ({
 }) => {
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
-  await expect(page).toHaveTitle(
-    "Peels: Find a home for your food scraps, wherever you are"
-  );
+  await expect(page).toHaveTitle("Peels: Find a home for your food scraps");
   await expectSharedSocialMetadata(page, "/");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText([
-    "Find a home for your food scraps, wherever you are",
+    "Find a home for your food scraps",
   ]);
 
   const emptyLinks = await page.locator("a").evaluateAll((links) =>

--- a/e2e/share-support.spec.ts
+++ b/e2e/share-support.spec.ts
@@ -25,7 +25,7 @@ test("share page presents the sharing resources download", async ({ page }) => {
     page.getByRole("heading", { name: "Inside the ZIP" })
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { level: 2, name: "Copy examples" })
+    page.getByRole("heading", { level: 2, name: "Copywriting examples" })
   ).toBeVisible();
   await expect(page.getByText("Shortest", { exact: true })).toBeVisible();
   await expect(

--- a/messages/de.json
+++ b/messages/de.json
@@ -124,7 +124,7 @@
     "forgotPasswordSuccess": "Prüfe deinen Posteingang (und Spam) für einen Link zum Zurücksetzen des Passworts, sofern diese E-Mail-Adresse mit einem Peels-Konto verknüpft ist."
   },
   "Index": {
-    "title": "Finde ein Zuhause für deine Küchenabfälle, wo auch immer du bist",
+    "title": "Finde ein Zuhause für deine Küchenabfälle",
     "subtitle": "Peels verbindet die Menschen mit Lebensmittelkratzern mit denen, die komponieren. Es ist ein kostenloses und nicht-kommerzielles Gemeinschaftsprojekt.",
     "metaDescription": "Peels verbindet Menschen mit Lebensmittelresten mit denjenigen, die kompostieren. Es ist ein kostenloses, nicht-kommerzielles Gemeinschaftsprojekt.",
     "metaKeywords": "Lebensmittelabfall, Essensreste, Kompost, Kompost in meiner Nähe, Kompost-Abgabestelle, Abgabe von Lebensmittelresten",
@@ -227,7 +227,7 @@
       }
     },
     "copyExamples": {
-      "title": "Textbeispiele",
+      "title": "Beispiele für Werbetexte",
       "subtitle": "Du kannst diese Optionen gern an deine Bedürfnisse anpassen. Sie sind einfach als Ausgangspunkte in verschiedenen Längen gedacht.",
       "listLabel": "Textbeispiele zum Teilen von Peels",
       "items": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -124,7 +124,7 @@
     "forgotPasswordSuccess": "Check your inbox (and spam) for a password reset link, assuming that email address is linked to a Peels account."
   },
   "Index": {
-    "title": "Find a home for your food scraps, wherever you are",
+    "title": "Find a home for your food scraps",
     "subtitle": "Peels connects folks with food scraps to those who compost. It’s a free, non-commercial, community project.",
     "metaDescription": "Peels connects folks with food scraps to those who compost. It’s a free, non-commercial, community project.",
     "metaKeywords": "food waste, food scraps, share waste, sharewaste, makesoil, compost near me, compost drop-off, food scrap drop-off",
@@ -227,7 +227,7 @@
       }
     },
     "copyExamples": {
-      "title": "Copy examples",
+      "title": "Copywriting examples",
       "subtitle": "Please feel free to adapt any of these options to fit your needs. They’re provided simply as starting points, at various lengths.",
       "listLabel": "Copywriting examples for sharing Peels",
       "items": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -124,7 +124,7 @@
     "forgotPasswordSuccess": "Revisa tu bandeja de entrada (y spam) para ver el enlace de restablecimiento de contraseña, suponiendo que ese correo esté vinculado a una cuenta de Peels."
   },
   "Index": {
-    "title": "Encuentra un hogar para tus restos de comida, estés donde estés",
+    "title": "Encuentra un hogar para tus restos de comida",
     "subtitle": "Peels conecta a personas con restos de comida con quienes hacen compost. Es un proyecto comunitario, gratuito y sin fines de lucro.",
     "metaDescription": "Peels conecta a personas con restos de comida con quienes hacen compost. Es un proyecto comunitario, gratuito y sin fines de lucro.",
     "metaKeywords": "residuos orgánicos, restos de comida, desperdicio alimentario, compostaje, compost cerca de mí, punto de compostaje, entrega de restos de comida",
@@ -227,7 +227,7 @@
       }
     },
     "copyExamples": {
-      "title": "Ejemplos de texto",
+      "title": "Ejemplos de redacción",
       "subtitle": "Puedes adaptar cualquiera de estas opciones a tus necesidades. Son simplemente puntos de partida, con distintas extensiones.",
       "listLabel": "Ejemplos de texto para compartir Peels",
       "items": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -124,7 +124,7 @@
     "forgotPasswordSuccess": "Vérifiez votre boîte de réception (et vos spams) pour trouver un lien de réinitialisation du mot de passe, si cette adresse e-mail est bien liée à un compte Peels."
   },
   "Index": {
-    "title": "Trouvez une destination pour vos restes alimentaires, où que vous soyez",
+    "title": "Trouvez une destination pour vos restes alimentaires",
     "subtitle": "Peels met en relation des personnes qui ont des restes alimentaires avec celles qui compostent. C’est un projet communautaire gratuit et non commercial.",
     "metaDescription": "Peels met en relation des personnes qui ont des restes alimentaires avec celles qui compostent. C’est un projet communautaire gratuit et non commercial.",
     "metaKeywords": "gaspillage alimentaire, restes alimentaires, compost, compost près de chez moi, point de dépôt compost, dépôt de restes alimentaires",
@@ -227,7 +227,7 @@
       }
     },
     "copyExamples": {
-      "title": "Exemples de texte",
+      "title": "Exemples de rédaction",
       "subtitle": "N’hésitez pas à adapter ces propositions à vos besoins. Elles sont simplement fournies comme points de départ, en plusieurs longueurs.",
       "listLabel": "Exemples de texte pour faire connaître Peels",
       "items": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -124,7 +124,7 @@
     "forgotPasswordSuccess": "Verifique a sua caixa de entrada (e o spam) para encontrar o link de redefinição de senha, caso esse e-mail esteja ligado a uma conta do Peels."
   },
   "Index": {
-    "title": "Encontre um destino para os seus restos de comida, esteja onde estiver",
+    "title": "Encontre um destino para os seus restos de comida",
     "subtitle": "O Peels liga pessoas com restos de comida a quem faz compostagem. É um projeto comunitário, gratuito e sem fins comerciais.",
     "metaDescription": "O Peels liga pessoas com restos de comida a quem faz compostagem. É um projeto comunitário, gratuito e sem fins comerciais.",
     "metaKeywords": "desperdício de alimentos, restos de comida, compostagem, compostagem perto de mim, ponto de entrega para compostagem, entrega de restos de comida",
@@ -227,7 +227,7 @@
       }
     },
     "copyExamples": {
-      "title": "Exemplos de texto",
+      "title": "Exemplos de redação",
       "subtitle": "Fique à vontade para adaptar qualquer uma destas opções às suas necessidades. Elas são apenas pontos de partida, em diferentes tamanhos.",
       "listLabel": "Exemplos de texto para divulgar o Peels",
       "items": {

--- a/src/app/(core)/(static)/(index)/page.tsx
+++ b/src/app/(core)/(static)/(index)/page.tsx
@@ -123,20 +123,22 @@ export default function Index() {
         </FooterBlock>
       </StaticPageSection>
 
-      <StaticPageSection padding="lg" id="newsletter-section">
-        <HeaderBlock>
-          <h2>{t("newsletter.title")}</h2>
-          <p>{t("newsletter.subtitle")}</p>
-        </HeaderBlock>
-        <NewsletterIssuesList showPastIssues={false} />
-        <FooterBlock>
-          <p>
-            {t.rich("newsletter.footer", {
-              page: (chunks) => <Link href="/newsletter">{chunks}</Link>,
-            })}
-          </p>
-        </FooterBlock>
-      </StaticPageSection>
+      {siteConfig.showNewsletterOnHomepage && (
+        <StaticPageSection padding="lg" id="newsletter-section">
+          <HeaderBlock>
+            <h2>{t("newsletter.title")}</h2>
+            <p>{t("newsletter.subtitle")}</p>
+          </HeaderBlock>
+          <NewsletterIssuesList showPastIssues={false} />
+          <FooterBlock>
+            <p>
+              {t.rich("newsletter.footer", {
+                page: (chunks) => <Link href="/newsletter">{chunks}</Link>,
+              })}
+            </p>
+          </FooterBlock>
+        </StaticPageSection>
+      )}
 
       <StaticPageSection padding="lg" id="faq-section">
         <PeelsFaqJsonLd variant="summary" />

--- a/src/app/(core)/(static)/(index)/page.tsx
+++ b/src/app/(core)/(static)/(index)/page.tsx
@@ -177,7 +177,8 @@ const Intro = styled.div`
   gap: 1.5rem;
 
   & > h1 {
-    max-width: 24ch;
+    max-width: 18ch;
+    text-wrap: balance;
     font-size: 2.75rem;
     letter-spacing: -0.03em;
     line-height: 1.05;

--- a/src/components/PeelsFaq/PeelsFaq.tsx
+++ b/src/components/PeelsFaq/PeelsFaq.tsx
@@ -15,6 +15,7 @@ async function PeelsFaq({ variant = "full" }: PeelsFaqProps) {
   const showAboutFaq = variant !== "community";
   const showExtendedAboutFaq = variant === "about" || variant === "full";
   const showCommunityFaq = variant === "community" || variant === "full";
+  const showPromotionFaq = variant === "summary" || showCommunityFaq;
 
   return (
     <FaqContainer>
@@ -120,20 +121,26 @@ async function PeelsFaq({ variant = "full" }: PeelsFaqProps) {
               ),
             })}
           </FaqDetails>
-          <FaqDetails>
-            <summary>{t("promotion.question")}</summary>
-            {t.rich("promotion.answer", {
-              p: (chunks) => <p>{chunks}</p>,
-              share: (chunks) => (
-                <StrongLink href={siteConfig.links.share}>{chunks}</StrongLink>
-              ),
-              email: (chunks) => (
-                <EncodedEmailLink address={siteConfig.encodedEmail.team}>
-                  {chunks}
-                </EncodedEmailLink>
-              ),
-            })}
-          </FaqDetails>
+        </>
+      ) : null}
+      {showPromotionFaq ? (
+        <FaqDetails>
+          <summary>{t("promotion.question")}</summary>
+          {t.rich("promotion.answer", {
+            p: (chunks) => <p>{chunks}</p>,
+            share: (chunks) => (
+              <StrongLink href={siteConfig.links.share}>{chunks}</StrongLink>
+            ),
+            email: (chunks) => (
+              <EncodedEmailLink address={siteConfig.encodedEmail.team}>
+                {chunks}
+              </EncodedEmailLink>
+            ),
+          })}
+        </FaqDetails>
+      ) : null}
+      {showCommunityFaq ? (
+        <>
           <FaqDetails>
             <summary>{t("government.question")}</summary>
             {t.rich("government.answer", {

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -3,6 +3,7 @@ export const siteConfig = {
   description: "Find a home for your food scraps, wherever you are.",
   url: "https://www.peels.org",
   repoUrl: "https://github.com/peels-org/peels",
+  showNewsletterOnHomepage: false,
   links: {
     about: "/",
     newsletter: "/newsletter",

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
   name: "Peels",
-  description: "Find a home for your food scraps, wherever you are.",
+  description: "Find a home for your food scraps.",
   url: "https://www.peels.org",
   repoUrl: "https://github.com/peels-org/peels",
   showNewsletterOnHomepage: false,

--- a/src/utils/faqJsonLd.ts
+++ b/src/utils/faqJsonLd.ts
@@ -39,6 +39,7 @@ const summaryFaqSources = [
   { namespace: "Support.peelsFaq", key: "noGarden" },
   { namespace: "Support.peelsFaq", key: "businesses" },
   { namespace: "Support.peelsFaq", key: "mapPrivacy" },
+  { namespace: "Support.peelsFaq", key: "promotion" },
 ] satisfies FaqMessageSource[];
 
 const aboutFaqSources = [


### PR DESCRIPTION
Thank you for your contribution to Peels! Before submitting, please:

- [x] Run `npm run format` on your changes
- [x] Run `npm run build` without errors or warnings
- [x] Run `npm run check` when the change touches app logic, messages, or tests

## Summary

- Keep the homepage timely by adding a documented flag for newsletter promotion and turning the section off for now.
- Tighten the homepage tagline and presentation across all supported locales, and rename the sharing-page heading to “Copywriting examples”.
- Make community promotion easier to discover by adding the existing promotion FAQ to the homepage summary and its FAQ structured data.

## Test plan

- [x] `npm run check`
- [x] `npm run build`

## Notes

`siteConfig.showNewsletterOnHomepage` is currently `false`. Set it to `true` when a recent newsletter issue should be promoted on the homepage.
